### PR TITLE
Load WebView separately

### DIFF
--- a/ConsentViewController/Classes/ConsentViewController.swift
+++ b/ConsentViewController/Classes/ConsentViewController.swift
@@ -449,23 +449,21 @@ import Reachability
     private func handleMessage(withName name: String, andBody body: [String:Any?]) {
         switch name {
         case "onReceiveMessageData": // when the message is first loaded
-            onReceiveMessage(willShow: body["willShowMessage"] as! Int == 1)
+            guard let willShow = body["willShowMessage"] as? Int else { fallthrough }
+            onReceiveMessage(willShow: willShow == 1)
         case "onMessageChoiceSelect": // when a choice is selected
-            onMessageChoiceSelect(choiceType: body["choiceType"] as! Int)
+            guard let choiceType = body["choiceType"] as? Int else { fallthrough }
+            onMessageChoiceSelect(choiceType: choiceType)
         case "interactionComplete": // when interaction with message is complete
             guard
                 let euconsent = body["euconsent"] as? String,
                 let consentUUID = body["consentUUID"] as? String
-            else {
-                print("Could not get EUConsent and ConsentUUID")
-                done()
-                return
-            }
+            else { fallthrough }
             onInteractionComplete(euconsent: euconsent, consentUUID: consentUUID)
         case "onErrorOccurred":
             onErrorOccurred(errorType: body["errorType"] as? String ?? "")
         default:
-            print("userContentController was called but the message body: \(name) is unknown.")
+            print("Couldn't parse message in userContentController. Called with name: \(name) and body: \(body)")
             done()
         }
     }

--- a/ConsentViewController/Classes/ConsentViewController.swift
+++ b/ConsentViewController/Classes/ConsentViewController.swift
@@ -272,6 +272,7 @@ import Reachability
             try setSubjectToGDPR()
             guard Reachability()!.connection != .none else {
                 onErrorOccurred?(NoInternetConnection())
+                messageStatus = .notStarted
                 return
             }
             webView.load(URLRequest(url: messageUrl))

--- a/ConsentViewController/Classes/ConsentViewController.swift
+++ b/ConsentViewController/Classes/ConsentViewController.swift
@@ -441,8 +441,8 @@ import Reachability
         done()
     }
 
-    private func onErrorOccurred(errorType: String) {
-        onErrorOccurred?(WebViewErrors[errorType] ?? PrivacyManagerUnknownError())
+    private func onErrorOccurred(_ error: ConsentViewControllerError) {
+        onErrorOccurred?(error)
         done()
     }
 
@@ -461,10 +461,9 @@ import Reachability
             else { fallthrough }
             onInteractionComplete(euconsent: euconsent, consentUUID: consentUUID)
         case "onErrorOccurred":
-            onErrorOccurred(errorType: body["errorType"] as? String ?? "")
+            onErrorOccurred(WebViewErrors[body["errorType"] as? String ?? ""] ?? PrivacyManagerUnknownError())
         default:
-            print("Couldn't parse message in userContentController. Called with name: \(name) and body: \(body)")
-            done()
+            onErrorOccurred(PrivacyManagerUnknownMessageResponse(name: name, body: body))
         }
     }
 
@@ -474,7 +473,10 @@ import Reachability
             let messageBody = message.body as? [String: Any],
             let name = messageBody["name"] as? String,
             let body = messageBody["body"] as? [String: Any?]
-        else { return }
+        else {
+            onErrorOccurred(PrivacyManagerUnknownMessageResponse(name: "", body: ["":""]))
+            return
+        }
         handleMessage(withName: name, andBody: body)
     }
 

--- a/ConsentViewController/Classes/ConsentViewController.swift
+++ b/ConsentViewController/Classes/ConsentViewController.swift
@@ -269,7 +269,7 @@ import Reachability
             let messageUrl = try sourcePoint.getMessageUrl(forTargetingParams:  targetingParams, debugLevel: debugLevel.rawValue)
             print ("url: \((messageUrl.absoluteString))")
             UserDefaults.standard.setValue(true, forKey: "IABConsent_CMPPresent")
-            setSubjectToGDPR()
+            try setSubjectToGDPR()
             guard Reachability()!.connection != .none else {
                 onErrorOccurred?(NoInternetConnection())
                 return
@@ -289,15 +289,10 @@ import Reachability
         loadMessage()
     }
 
-    private func setSubjectToGDPR() {
+    private func setSubjectToGDPR() throws {
         if(UserDefaults.standard.string(forKey: ConsentViewController.IAB_CONSENT_SUBJECT_TO_GDPR) != nil) { return }
-
-        do {
-            let gdprStatus = try sourcePoint.getGdprStatus()
-            UserDefaults.standard.setValue(String(gdprStatus), forKey: ConsentViewController.IAB_CONSENT_SUBJECT_TO_GDPR)
-        } catch {
-            print(error)
-        }
+        let gdprStatus = try sourcePoint.getGdprStatus()
+        UserDefaults.standard.setValue(String(gdprStatus), forKey: ConsentViewController.IAB_CONSENT_SUBJECT_TO_GDPR)
     }
 
     /**

--- a/ConsentViewController/Classes/ConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/ConsentViewControllerError.swift
@@ -16,7 +16,7 @@ public struct UnableToParseConsentStringError: ConsentViewControllerError {
     public var errorDescription: String? { get { return "Could not parse the raw string \(euConsent) into a ConsentString" } }
 
     init(euConsent: String) { self.euConsent = euConsent }
-    public var description: String { get {return "\(failureReason!)\n\(errorDescription!)" } }
+    public var description: String { get { return "\(failureReason!)\n\(errorDescription!)" } }
 }
 
 public struct InvalidMessageURLError: ConsentViewControllerError {
@@ -27,12 +27,11 @@ public struct InvalidMessageURLError: ConsentViewControllerError {
     public var helpAnchor: String? { get { return "Please make sure the query params are URL encodable." } }
 
     init(urlString: String) { self.urlString = urlString }
-    public var description: String { get {return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
+    public var description: String { get { return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
 }
 
 public struct InvalidURLError: ConsentViewControllerError {
-    private let urlName: String
-    private let urlString: String
+    private let urlName: String, urlString: String
 
     public var failureReason: String? { get { return "Failed to parse \(urlName)." } }
     public var errorDescription: String? { get { return "Could not convert \(urlString) into URL." } }
@@ -42,12 +41,11 @@ public struct InvalidURLError: ConsentViewControllerError {
         self.urlName = urlName
         self.urlString = urlString
     }
-    public var description: String { get {return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
+    public var description: String { get { return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
 }
 
 public struct SiteIDNotFound: ConsentViewControllerError {
-    private let accountId: String
-    private let siteName: String
+    private let accountId: String, siteName: String
 
     public var failureReason: String? { get { return "Could not find site ID)." } }
     public var errorDescription: String? { get { return "Could not find a site with name \(siteName) for the account id \(accountId)" } }
@@ -57,7 +55,7 @@ public struct SiteIDNotFound: ConsentViewControllerError {
         self.accountId = accountId
         self.siteName = siteName
     }
-    public var description: String { get {return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
+    public var description: String { get { return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
 }
 
 public struct GdprStatusNotFound: ConsentViewControllerError {
@@ -67,13 +65,13 @@ public struct GdprStatusNotFound: ConsentViewControllerError {
     public var helpAnchor: String? { get { return "Make sure \(gdprStatusUrl) is correct." } }
 
     init(gdprStatusUrl: URL) { self.gdprStatusUrl = gdprStatusUrl }
-    public var description: String { get {return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
+    public var description: String { get { return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
 }
 
 public struct ConsentsAPIError: ConsentViewControllerError {
     public var failureReason: String? { get { return "Failed to get Custom Consents" } }
     public var errorDescription: String? { get { return "Failed to either get custom consents or parse the endpoint's response" } }
-    public var description: String { get {return "\(failureReason!)\n\(errorDescription!)" } }
+    public var description: String { get { return "\(failureReason!)\n\(errorDescription!)" } }
 }
 
 public let WebViewErrors: [String : ConsentViewControllerError] = [
@@ -85,22 +83,34 @@ public struct PrivacyManagerLoadError: ConsentViewControllerError {
     public var failureReason: String? { get { return "Failed start the Privacy Manager" } }
     public var errorDescription: String? { get { return "Could not load the Privacy Manager due to a javascript error." } }
     public var helpAnchor: String? { get { return "This is most probably happening due to a misconfiguration on the Publisher's portal." } }
-    public var description: String { get {return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
+    public var description: String { get { return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
 }
 
 public struct PrivacyManagerSaveError: ConsentViewControllerError {
     public var failureReason: String? { get { return "Failed to save user consents on Privacy Manager" } }
     public var errorDescription: String? { get { return "Something wrong happened while saving the privacy settings on the Privacy Manager" } }
     public var helpAnchor: String? { get { return "This might have occurred due to faulty internet connection." } }
-    public var description: String { get {return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
+    public var description: String { get { return "\(failureReason!)\n\(errorDescription!)\n\(helpAnchor!)" } }
+}
+
+public struct PrivacyManagerUnknownMessageResponse: ConsentViewControllerError {
+    private let name: String, body: [String:Any?]
+    init(name: String, body: [String:Any?]) {
+        self.name = name
+        self.body = body
+    }
+    public var failureReason: String? { get {
+        return "Couldn't parse message in userContentController. Called with name: \(name) and body: \(body)"
+    }}
+    public var description: String { get { return "\(failureReason!)\n" } }
 }
 
 public struct PrivacyManagerUnknownError: ConsentViewControllerError {
     public var failureReason: String? { get { return "Something bad happened in the javascript world." } }
-    public var description: String { get {return "\(failureReason!)\n" } }
+    public var description: String { get { return "\(failureReason!)\n" } }
 }
 
 public struct NoInternetConnection: ConsentViewControllerError {
     public var failureReason: String? { get { return "The device is not connected to the internet." } }
-    public var description: String { get {return "\(failureReason!)\n" } }
+    public var description: String { get { return "\(failureReason!)\n" } }
 }

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -10,84 +10,63 @@ import ConsentViewController
 class ViewController: UIViewController {
     var consentViewController: ConsentViewController!
 
-    private func buildConsentViewController(showPM: Bool) throws -> ConsentViewController {
-        let consentViewController = try ConsentViewController(
+    private func buildConsentViewController(showPM: Bool, addToView parentView: UIView) {
+        do {
+            let consentViewController = try ConsentViewController(
                 accountId: 22,
                 siteName: "mobile.demo",
                 stagingCampaign: false
             )
-        // optional, set custom targeting parameters supports Strings and Integers
-        consentViewController.setTargetingParam(key: "CMP", value: String(showPM))
 
-        // optional, sets debug level defaults to OFF
-        consentViewController.debugLevel = ConsentViewController.DebugLevel.OFF
-
-        consentViewController.willShowMessage = { cvc in print("the message will show") }
-
-        // optional, callback triggered when message choice is selected when called choice
-        // type will be available as Integer at cvc.choiceType
-        consentViewController.onMessageChoiceSelect = { cvc in
-            print("Choice type selected by user", cvc.choiceType as Any)
-        }
-
-        consentViewController.onErrorOccurred = { error in print(error) }
-
-        // optional, callback triggered when consent data is captured when called
-        // euconsent will be available as String at cLib.euconsent and under
-        // PreferenceManager.getDefaultSharedPreferences(activity).getString(EU_CONSENT_KEY, null);
-        // consentUUID will be available as String at cLib.consentUUID and under
-        // PreferenceManager.getDefaultSharedPreferences(activity).getString(CONSENT_UUID_KEY null);
-        consentViewController.onInteractionComplete = { cvc in
-            do {
-                print(
-                    "\n eu consent prop",
-                    cvc.euconsent as Any,
-                    "\n consent uuid prop",
-                    cvc.consentUUID as Any,
-                    "\n eu consent in storage",
-                    UserDefaults.standard.string(forKey: ConsentViewController.EU_CONSENT_KEY) as Any,
-                    "\n consent uuid in storage",
-                    UserDefaults.standard.string(forKey: ConsentViewController.CONSENT_UUID_KEY) as Any,
-
-                    // Standard IAB values in UserDefaults
-                    "\n IABConsent_ConsentString in storage",
-                    UserDefaults.standard.string(forKey: ConsentViewController.IAB_CONSENT_CONSENT_STRING) as Any,
-                    "\n IABConsent_ParsedPurposeConsents in storage",
-                    UserDefaults.standard.string(forKey: ConsentViewController.IAB_CONSENT_PARSED_PURPOSE_CONSENTS) as Any,
-                    "\n IABConsent_ParsedVendorConsents in storage",
-                    UserDefaults.standard.string(forKey: ConsentViewController.IAB_CONSENT_PARSED_VENDOR_CONSENTS) as Any,
-
-                    // API for getting IAB Purpose Consents
-                    "\n IAB purpose consent for \"Ad selection, delivery, reporting\"",
-                    try cvc.getIABPurposeConsents([3])
-                )
-                print("Custom vendor consents")
-                for consent in try cvc.getCustomVendorConsents() {
-                    print("Custom Vendor Consent id: \(consent.id), name: \(consent.name)")
-                }
-                print("Custom purpose consents")
-                for consent in try cvc.getCustomPurposeConsents() {
-                    print("Custom Purpose Consent id: \(consent.id), name: \(consent.name)")
-                }
+            consentViewController.onMessageReady = { controller in
+                parentView.addSubview(controller.view)
+                controller.view.frame = controller.view.superview!.bounds
             }
-            catch { print(error) }
-        }
 
-        return consentViewController
+            // optional, set custom targeting parameters supports Strings and Integers
+            consentViewController.setTargetingParam(key: "CMP", value: String(showPM))
+
+            consentViewController.onErrorOccurred = { error in print(error) }
+            
+            consentViewController.onInteractionComplete = { cvc in
+                do {
+                    print(
+                        // Standard IAB values in UserDefaults
+                        "\n IABConsent_ConsentString in storage",
+                        UserDefaults.standard.string(forKey: ConsentViewController.IAB_CONSENT_CONSENT_STRING) as Any,
+                        "\n IABConsent_ParsedPurposeConsents in storage",
+                        UserDefaults.standard.string(forKey: ConsentViewController.IAB_CONSENT_PARSED_PURPOSE_CONSENTS) as Any,
+                        "\n IABConsent_ParsedVendorConsents in storage",
+                        UserDefaults.standard.string(forKey: ConsentViewController.IAB_CONSENT_PARSED_VENDOR_CONSENTS) as Any,
+                        // API for getting IAB Purpose Consents
+                        "\n IAB purpose consent for \"Ad selection, delivery, reporting\"",
+                        try cvc.getIABPurposeConsents([3])
+                    )
+                    print("Custom vendor consents")
+                    for consent in try cvc.getCustomVendorConsents() {
+                        print("Custom Vendor Consent id: \(consent.id), name: \(consent.name)")
+                    }
+                    print("Custom purpose consents")
+                    for consent in try cvc.getCustomPurposeConsents() {
+                        print("Custom Purpose Consent id: \(consent.id), name: \(consent.name)")
+                    }
+                }
+                catch { print(error) }
+                cvc.view.removeFromSuperview()
+            }
+
+            consentViewController.loadMessage()
+        } catch { print(error) }
     }
 
     @IBAction func showPrivacyManager(_ sender: Any) {
-        do {
-            try view.addSubview(buildConsentViewController(showPM: true).view)
-        } catch { print(error) }
+        buildConsentViewController(showPM: true, addToView: view)
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        do {
-            try view.addSubview(buildConsentViewController(showPM: false).view)
-        } catch { print(error) }
+        buildConsentViewController(showPM: false, addToView: view)
 
         // IABConsent_CMPPresent must be set immediately after loading the ConsentViewController
         print(

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController {
 
             consentViewController.onMessageReady = { controller in
                 parentView.addSubview(controller.view)
-                controller.view.frame = controller.view.superview!.bounds
+                controller.view.frame = parentView.bounds
             }
 
             // optional, set custom targeting parameters supports Strings and Integers


### PR DESCRIPTION
TL;DR; We now: 
* load the webview in a separate function and call `onMessageReady` when the message is ready to be shown. 
* no longer add/remove the view from the superview. it's up to the parent to decide if/when the view should be added (we recommend using `onMessageReady` to add it and `onInteractionComplete` to remove it)