### PR TITLE
Moved  the API calls on secondary thread to keep main thread independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.2.4 (April 20, 2019)
+* Moved  the API calls on secondary thread to keep main thread independent and free for UI opertaion.
 ## 2.2.3 (April 09, 2019)
 * fix an issue that'd crash the client app if subclassing `ConsentViewController`
 

--- a/ConsentViewController.podspec
+++ b/ConsentViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ConsentViewController'
-  s.version          = '2.2.3'
+  s.version          = '2.2.4'
   s.summary          = 'SourcePoint\'s ConsentViewController to handle privacy consents.'
   s.homepage         = 'https://www.sourcepoint.com'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
                 stagingCampaign: false
             )
 
-            consentViewController.messageTimeoutInSeconds = TimeInterval(5)
+            consentViewController.messageTimeoutInSeconds = TimeInterval(20)
 
             consentViewController.onMessageReady = { controller in
                 parentView.addSubview(controller.view)
@@ -50,13 +50,6 @@ class ViewController: UIViewController {
                         try cvc.getIABPurposeConsents([3])
                     )
                     print("Custom vendor consents")
-                    for consent in try cvc.getCustomVendorConsents() {
-                        print("Custom Vendor Consent id: \(consent.id), name: \(consent.name)")
-                    }
-                    print("Custom purpose consents")
-                    for consent in try cvc.getCustomPurposeConsents() {
-                        print("Custom Purpose Consent id: \(consent.id), name: \(consent.name)")
-                    }
                 }
                 catch { print(error) }
                 cvc.view.removeFromSuperview()


### PR DESCRIPTION
Moved the API calls on secondary thread to keep main thread independent and free for UI operation.
below API's I have moved to secondary thread.
1. getSiteId
2. getGdprStatus
3. getCustomConsents