### PR TITLE
Fix scrolling on device rotate

### DIFF
--- a/ConsentViewController/Classes/ConsentViewController.swift
+++ b/ConsentViewController/Classes/ConsentViewController.swift
@@ -228,6 +228,8 @@ import Reachability
         if #available(iOS 11.0, *) {
             webView.scrollView.contentInsetAdjustmentBehavior = .never;
         }
+        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        webView.translatesAutoresizingMaskIntoConstraints = true
         webView.uiDelegate = self
         webView.navigationDelegate = self
         webView.isOpaque = false

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -465,6 +465,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -481,6 +482,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.sourcepoint.ConsentViewController-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Example/ConsentViewController/Info.plist
+++ b/Example/ConsentViewController/Info.plist
@@ -31,6 +31,9 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
On iPads, when rotating the device, the WebView would get cropped. Making it impossible for the user to scroll.

With this PR, the `ConsentViewCotntroller.webView` will be able to take the whole screen when rotating the device.