### PR TITLE
implement shouldCleanConsentOnError flag

### DIFF
--- a/ConsentViewController/Classes/ConsentViewController.swift
+++ b/ConsentViewController/Classes/ConsentViewController.swift
@@ -136,6 +136,9 @@ import Reachability
     private let logger: Logger
 
     private var newPM = false
+    
+    /// will instruct the SDK to clean consent data if an error occurs
+    public var shouldCleanConsentOnError = true
 
     /**
      Initialises the library with `accountId`, `propertyId`,`PMId`,`campaign`, `showPM` and property`.
@@ -493,6 +496,9 @@ import Reachability
     }
 
     private func onErrorOccurred(error: ConsentViewControllerError) {
+        if(shouldCleanConsentOnError) {
+            clearAllConsentData()
+        }
         releaseWebViewHandlers()
         consentDelegate?.onErrorOccurred(error: error)
     }
@@ -556,7 +562,6 @@ import Reachability
             logger.log("onPrivacyManagerAction event is triggered", [])
             return
         case "onErrorOccurred":
-            clearAllConsentData()
             onErrorOccurred(error: WebViewErrors[body["errorType"] as? String ?? ""] ?? PrivacyManagerUnknownError())
         case "onMessageChoiceError":
             onErrorOccurred(error: WebViewErrors[body["error"] as? String ?? ""] ?? PrivacyManagerUnknownError())


### PR DESCRIPTION
* call `clearAllConsentData` from within `ConsentViewController.onErrorOccurred`
* add flag `shouldCleanConsentOnError` to allow for the user to opt-in/out from cleaning the consent data on error.