### PR TITLE
Refactor example app to have a clear button

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,6 +20,6 @@ jobs:
       - name: CocoaPod Install
         run: cd Example && pod install
       - name: iOS build
-        run: xcodebuild build-for-testing -scheme ConsentViewController_ExampleTests -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.3'
-      - name: testing -> iPhone 11 (iOS 13.3)
-        run: xcodebuild test-without-building -scheme ConsentViewController_ExampleTests -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.3'
+        run: xcodebuild build-for-testing -scheme ConsentViewController_ExampleTests -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.4.1'
+      - name: testing -> iPhone 11 (iOS 13.4.1)
+        run: xcodebuild test-without-building -scheme ConsentViewController_ExampleTests -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.4.1'

--- a/ConsentViewController/Classes/GDPRAction.swift
+++ b/ConsentViewController/Classes/GDPRAction.swift
@@ -15,6 +15,18 @@ import Foundation
     case ShowPrivacyManager = 12
     case RejectAll = 13
     case Dismiss = 15
+
+    public var description: String {
+        switch self {
+        case .AcceptAll: return "AcceptAll"
+        case .RejectAll: return "RejectAll"
+        case .ShowPrivacyManager: return "ShowPrivacyManager"
+        case .SaveAndExit: return "SaveAndExit"
+        case .Dismiss: return "Dismiss"
+        case .PMCancel: return "PMCancel"
+        default: return "Unknown"
+        }
+    }
 }
 
 /// Action consists of `GDPRActionType` and an id. Those come from each action the user can take in the ConsentUI

--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -11,10 +11,11 @@ import UIKit
 public typealias TargetingParams = [String: String]
 
 @objcMembers open class GDPRConsentViewController: UIViewController {
-    static let META_KEY = "sp_gdpr_meta"
-    static let EU_CONSENT_KEY = "sp_gdpr_euconsent"
-    static let GDPR_UUID_KEY = "sp_gdpr_consentUUID"
-    static let GDPR_AUTH_ID_KEY = "sp_gdpr_authId"
+    static public let SP_GDPR_KEY_PREFIX = "sp_gdpr_"
+    static let META_KEY = "\(SP_GDPR_KEY_PREFIX)meta"
+    static let EU_CONSENT_KEY = "\(SP_GDPR_KEY_PREFIX)euconsent"
+    static let GDPR_UUID_KEY = "\(SP_GDPR_KEY_PREFIX)consentUUID"
+    static let GDPR_AUTH_ID_KEY = "\(SP_GDPR_KEY_PREFIX)authId"
     static public let IAB_KEY_PREFIX = "IABTCF_"
     static let IAB_CMP_SDK_ID_KEY = "IABTCF_CmpSdkID"
     static let IAB_CMP_SDK_ID = 6

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		8231B14522BA5A6B00D2669B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8231B14322BA5A6B00D2669B /* Main.storyboard */; };
 		8231B14722BA5A6C00D2669B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8231B14622BA5A6C00D2669B /* Assets.xcassets */; };
 		8231B14A22BA5A6C00D2669B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8231B14822BA5A6C00D2669B /* LaunchScreen.storyboard */; };
+		824BC0342463F6B0006D3C18 /* GDPRActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */; };
 		82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */; };
 		8277C33C22BBD22C00F1607F /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277C33B22BBD22C00F1607F /* HomeViewController.swift */; };
 		82D8FEDF23DC753400F28D74 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D8FEDE23DC753400F28D74 /* AppDelegate.swift */; };
@@ -188,6 +189,7 @@
 		8231B14922BA5A6C00D2669B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8231B14B22BA5A6C00D2669B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8231B15122BBC39900D2669B /* ConsentViewController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ConsentViewController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRActionSpec.swift; sourceTree = "<group>"; };
 		82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPGDPRArbitraryJsonSpec.swift; sourceTree = "<group>"; };
 		8277C33B22BBD22C00F1607F /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		82D8FEDC23DC753400F28D74 /* NativeMessageExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NativeMessageExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -728,6 +730,7 @@
 				82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */,
 				82FC4D3E23983231002F08E5 /* Info.plist */,
 				6D554C2124310BF800B15583 /* SourcePointClientSpec.swift */,
+				824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */,
 			);
 			path = ConsentViewController_ExampleTests;
 			sourceTree = "<group>";
@@ -1357,6 +1360,7 @@
 				6D605DF22423523700BB3E5F /* GDPRConsentViewControllerSpec.swift in Sources */,
 				6D554C2224310BF800B15583 /* SourcePointClientSpec.swift in Sources */,
 				6DB2B2222424C52A008F9226 /* ConnectivityManagerSpec.swift in Sources */,
+				824BC0342463F6B0006D3C18 /* GDPRActionSpec.swift in Sources */,
 				6DB561EE24269470008501AC /* GDPRMessageSpec.swift in Sources */,
 				6DC1CD412427E7330028F03F /* GDPRNativeMessageViewControllerSpec.swift in Sources */,
 				6D605DF42423523700BB3E5F /* GDPRMessageViewControllerSpec.swift in Sources */,

--- a/Example/ConsentViewController/Base.lproj/Main.storyboard
+++ b/Example/ConsentViewController/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
-    <device id="retina5_5" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+    <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,7 +11,7 @@
         <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModule="ConsentViewController_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModule="SPGDPRExampleApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
@@ -25,11 +23,22 @@
                                     <action selector="onPrivacySettingsTap:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="5A0-eX-g3u"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Jg-eO-F1M">
+                                <rect key="frame" x="158" y="686" width="98" height="30"/>
+                                <state key="normal" title="Clear Consent">
+                                    <color key="titleColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="onClearConsentTap:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="z83-uH-nwW"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Cf6-CW-8f5" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="Hbv-hd-FU9"/>
                             <constraint firstItem="Cf6-CW-8f5" firstAttribute="centerX" secondItem="nYM-pK-Vec" secondAttribute="centerX" id="gaZ-fa-jov"/>
+                            <constraint firstItem="0Jg-eO-F1M" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="mdy-4X-3Kh"/>
+                            <constraint firstItem="nYM-pK-Vec" firstAttribute="bottom" secondItem="0Jg-eO-F1M" secondAttribute="bottom" constant="20" id="sgi-zI-fxX"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="nYM-pK-Vec"/>
                     </view>

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -19,6 +19,17 @@ class ViewController: UIViewController {
         consentDelegate: self
     )}()
 
+    @IBAction func onClearConsentTap(_ sender: Any) {
+        let spStoredData = UserDefaults.standard.dictionaryRepresentation().filter {
+            $0.key.starts(with: GDPRConsentViewController.SP_GDPR_KEY_PREFIX) ||
+            $0.key.starts(with: GDPRConsentViewController.IAB_KEY_PREFIX)
+        }
+        spStoredData.isEmpty ?
+            print("There's no consent data stored") :
+            print("Deleting following consent data: ", spStoredData)
+        consentViewController.clearAllData()
+    }
+
     @IBAction func onPrivacySettingsTap(_ sender: Any) {
         consentViewController.loadPrivacyManager()
     }
@@ -30,6 +41,10 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: GDPRConsentDelegate {
+    func onAction(_ action: GDPRAction) {
+        print("User took the action: \(action.type.description)")
+    }
+
     func gdprConsentUIWillShow() {
         present(consentViewController, animated: true, completion: nil)
     }
@@ -43,7 +58,6 @@ extension ViewController: GDPRConsentDelegate {
         userConsent.acceptedVendors.forEach { vendorId in print("Vendor: \(vendorId)") }
         userConsent.acceptedCategories.forEach { purposeId in print("Purpose: \(purposeId)") }
 
-        // IAB Related Data
         print(UserDefaults.standard.dictionaryWithValues(forKeys: userConsent.tcfData.dictionaryValue?.keys.sorted() ?? []))
     }
 

--- a/Example/ConsentViewController_ExampleTests/GDPRActionSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRActionSpec.swift
@@ -1,0 +1,102 @@
+//
+//  GDPRActionSpec.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 07.05.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+// swiftlint:disable function_body_length
+
+import Foundation
+import Quick
+import Nimble
+@testable import ConsentViewController
+
+class GDPRActionSpec: QuickSpec {
+    override func spec() {
+        describe("GDPRAction") {
+            describe("init") {
+                it("initialises type, id and payload") {
+                    let payload = "".data(using: .utf8)!
+                    let type = GDPRActionType.AcceptAll
+                    let id = "something"
+                    let action = GDPRAction(type: .AcceptAll, id: "something", payload: payload)
+
+                    expect(action.type).to(equal(type))
+                    expect(action.id).to(equal(id))
+                    expect(action.payload).to(equal(payload))
+                }
+            }
+
+            describe("convenience init") {
+                it("initialises the data attribute with {}") {
+                    let action = GDPRAction(type: .AcceptAll, id: nil)
+                    expect(action.payload).to(equal("{}".data(using: .utf8)!))
+                }
+            }
+        }
+
+        describe("GDPRActionType") {
+            describe("SaveAndExit") {
+                it("has the raw value of 1") {
+                    expect(GDPRActionType.SaveAndExit.rawValue).to(equal(1))
+                }
+
+                it("has its description as 'SaveAndExit'") {
+                    expect(GDPRActionType.SaveAndExit.description).to(equal("SaveAndExit"))
+                }
+            }
+
+            describe("PMCancel") {
+                it("has the raw value of 2") {
+                    expect(GDPRActionType.PMCancel.rawValue).to(equal(2))
+                }
+
+                it("has its description as 'PMCancel'") {
+                    expect(GDPRActionType.PMCancel.description).to(equal("PMCancel"))
+                }
+            }
+
+            describe("AcceptAll") {
+                it("has the raw value of 11") {
+                    expect(GDPRActionType.AcceptAll.rawValue).to(equal(11))
+                }
+
+                it("has its description as 'AcceptAll'") {
+                    expect(GDPRActionType.AcceptAll.description).to(equal("AcceptAll"))
+                }
+            }
+
+            describe("ShowPrivacyManager") {
+                it("has the raw value of 12") {
+                    expect(GDPRActionType.ShowPrivacyManager.rawValue).to(equal(12))
+                }
+
+                it("has its description as 'ShowPrivacyManager'") {
+                    expect(GDPRActionType.ShowPrivacyManager.description).to(equal("ShowPrivacyManager"))
+                }
+            }
+
+            describe("RejectAll") {
+                it("has the raw value of 13") {
+                    expect(GDPRActionType.RejectAll.rawValue).to(equal(13))
+                }
+
+                it("has its description as 'RejectAll'") {
+                    expect(GDPRActionType.RejectAll.description).to(equal("RejectAll"))
+                }
+            }
+
+            describe("Dismiss") {
+                it("has the raw value of 15") {
+                    expect(GDPRActionType.Dismiss.rawValue).to(equal(15))
+                }
+
+                it("has its description as 'Dismiss'") {
+                    expect(GDPRActionType.Dismiss.description).to(equal("Dismiss"))
+                }
+            }
+        }
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
@@ -42,7 +42,7 @@ class MessageWebViewControllerSpec: QuickSpec, GDPRConsentDelegate, WKNavigation
             }
         }
 
-        fdescribe("Test GDPRConsentDelegate methods") {
+        describe("Test GDPRConsentDelegate methods") {
             beforeEach {
                 messageWebViewController = self.getMessageWebViewController()
                 messageWebViewController.consentDelegate = mockConsentDelegate


### PR DESCRIPTION
There are 3 main parts to this PR:
1. add a clear consent button to the example app
2. add a `description` attribute to `GDPRActionType` for better printing
3. add specs for `GDPRActionType` and `GDPRAction`