### PR TITLE
SP-3524 implement customConsent API

### DIFF
--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -279,6 +279,51 @@ public typealias TargetingParams = [String: String]
             UserDefaults.standard.setValuesForKeys(iabDataDictionary)
         }
     }
+
+    // swiftlint:disable:next function_parameter_count
+    private func customConsent(
+        uuid: String,
+        vendors: [String],
+        categories: [String],
+        legIntCategories: [String],
+        euconsent: String,
+        tcfData: SPGDPRArbitraryJson,
+        completionHandler: @escaping (GDPRUserConsent) -> Void) {
+        sourcePoint.customConsent(toConsentUUID: uuid, vendors: vendors, categories: categories, legIntCategories: legIntCategories) { [weak self] (response, error) in
+            guard let response = response, error == nil else {
+                self?.consentDelegate?.onError?(error: error)
+                return
+            }
+
+            completionHandler(GDPRUserConsent(
+                acceptedVendors: response.vendors,
+                acceptedCategories: response.categories,
+                legitimateInterestCategories: response.legIntCategories,
+                specialFeatures: response.specialFeatures,
+                euconsent: euconsent,
+                tcfData: tcfData)
+            )
+        }
+    }
+
+    /// Add the vendors/categories/legitimateInterestCategories ids to the consent profile of the current user.
+    /// In order words, programatically consent a user to the above
+    /// If an error occurs, the `GDPRConsentDelegate.onError` is called
+    public func customConsentTo(
+        vendors: [String],
+        categories: [String],
+        legIntCategories: [String],
+        completionHandler: @escaping (GDPRUserConsent) -> Void) {
+        customConsent(
+            uuid: gdprUUID,
+            vendors: vendors,
+            categories: categories,
+            legIntCategories: legIntCategories,
+            euconsent: self.euconsent,
+            tcfData: self.tcfData,
+            completionHandler: completionHandler
+        )
+    }
 }
 
 extension GDPRConsentViewController: GDPRConsentDelegate {

--- a/ConsentViewController/Classes/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient.swift
@@ -113,7 +113,7 @@ class SourcePointClient {
     static let GET_MESSAGE_CONTENTS_URL = URL(string: "native-message?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
     static let GET_MESSAGE_URL_URL = URL(string: "message-url?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
     static let CONSENT_URL = URL(string: "consent?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
-    static let CUSTOM_CONSENT_URL = URL(string: "https://fake-wrapper-api.herokuapp.com/tcfv2/v1/gdpr/custom-consent?inApp=true")!
+    static let CUSTOM_CONSENT_URL = URL(string: "custom-consent?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
 
     private var client: HttpClient
     private lazy var json: JSON = { return JSON() }()

--- a/ConsentViewController/Classes/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient.swift
@@ -10,7 +10,6 @@ import Foundation
 typealias CompletionHandler = (Data?, GDPRConsentViewControllerError?) -> Void
 
 protocol HttpClient {
-
     func get(url: URL?, completionHandler: @escaping CompletionHandler)
     func post(url: URL?, body: Data?, completionHandler: @escaping CompletionHandler)
 }
@@ -114,6 +113,7 @@ class SourcePointClient {
     static let GET_MESSAGE_CONTENTS_URL = URL(string: "native-message?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
     static let GET_MESSAGE_URL_URL = URL(string: "message-url?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
     static let CONSENT_URL = URL(string: "consent?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
+    static let CUSTOM_CONSENT_URL = URL(string: "https://fake-wrapper-api.herokuapp.com/tcfv2/v1/gdpr/custom-consent?inApp=true")!
 
     private var client: HttpClient
     private lazy var json: JSON = { return JSON() }()
@@ -266,6 +266,36 @@ class SourcePointClient {
             } catch {
                 completionHandler(nil, APIParsingError(url.absoluteString, error))
             }
+        }
+    }
+
+    func customConsent(
+        toConsentUUID consentUUID: String,
+        vendors: [String],
+        categories: [String],
+        legIntCategories: [String],
+        completionHandler: @escaping (CustomConsentResponse?, APIParsingError?) -> Void) {
+        guard let body = try? JSONSerialization.data(withJSONObject: [
+            "consentUUID": consentUUID,
+            "propertyId": propertyId,
+            "vendors": vendors,
+            "categories": categories,
+            "legIntCategories": legIntCategories
+        ]) else {
+            completionHandler(nil, APIParsingError("encoding custom consent", nil))
+            return
+        }
+
+        client.post(url: SourcePointClient.CUSTOM_CONSENT_URL, body: body) { [weak self] data, error in
+            guard
+                let data = data,
+                let consentsResponse = try? (self?.json.decode(CustomConsentResponse.self, from: data)),
+                error == nil
+            else {
+                completionHandler(nil, APIParsingError(SourcePointClient.CUSTOM_CONSENT_URL.absoluteString, error))
+                return
+            }
+            completionHandler(consentsResponse, nil)
         }
     }
 }

--- a/ConsentViewController/Classes/SourcePointRequestsResponses.swift
+++ b/ConsentViewController/Classes/SourcePointRequestsResponses.swift
@@ -56,3 +56,7 @@ typealias PMConsents = SPGDPRArbitraryJson
 struct GDPRPMConsents: Codable {
     let acceptedVendors, acceptedCategories: [String]
 }
+
+struct CustomConsentResponse: Codable, Equatable {
+    let vendors, categories, legIntCategories, specialFeatures: [String]
+}

--- a/Example/ConsentViewController/Base.lproj/Main.storyboard
+++ b/Example/ConsentViewController/Base.lproj/Main.storyboard
@@ -32,20 +32,61 @@
                                     <action selector="onClearConsentTap:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="z83-uH-nwW"/>
                                 </connections>
                             </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="oRm-6q-XKe">
+                                <rect key="frame" x="20" y="20" width="374" height="220"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eG1-YT-GoF">
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="33.666666666666664"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Custom Vendor X: " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lc7-fD-UxR" userLabel="Custom Vendor X:">
+                                                <rect key="frame" x="0.0" y="0.0" width="361.33333333333331" height="33.666666666666664"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8zi-ja-23M" userLabel="Custom Vendor X:">
+                                                <rect key="frame" x="361.33333333333331" y="0.0" width="12.666666666666686" height="33.666666666666664"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cK6-8K-y3h">
+                                        <rect key="frame" x="0.0" y="33.666666666666671" width="374" height="186.33333333333331"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="phN-fo-I2o">
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="186.33333333333334"/>
+                                                <state key="normal" title="Accept Vendor X"/>
+                                                <connections>
+                                                    <action selector="onAcceptVendorXTap:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="0A2-pq-2fs"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="oRm-6q-XKe" firstAttribute="top" secondItem="nYM-pK-Vec" secondAttribute="top" constant="20" id="G4X-UX-YYO"/>
                             <constraint firstItem="Cf6-CW-8f5" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="Hbv-hd-FU9"/>
+                            <constraint firstItem="nYM-pK-Vec" firstAttribute="trailing" secondItem="oRm-6q-XKe" secondAttribute="trailing" constant="20" id="Tgw-rY-tFq"/>
                             <constraint firstItem="Cf6-CW-8f5" firstAttribute="centerX" secondItem="nYM-pK-Vec" secondAttribute="centerX" id="gaZ-fa-jov"/>
+                            <constraint firstItem="Cf6-CW-8f5" firstAttribute="top" secondItem="oRm-6q-XKe" secondAttribute="bottom" constant="113" id="j74-aJ-pPs"/>
+                            <constraint firstItem="oRm-6q-XKe" firstAttribute="leading" secondItem="nYM-pK-Vec" secondAttribute="leading" constant="20" id="la4-sS-uM0"/>
                             <constraint firstItem="0Jg-eO-F1M" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="mdy-4X-3Kh"/>
                             <constraint firstItem="nYM-pK-Vec" firstAttribute="bottom" secondItem="0Jg-eO-F1M" secondAttribute="bottom" constant="20" id="sgi-zI-fxX"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="nYM-pK-Vec"/>
                     </view>
+                    <connections>
+                        <outlet property="vendorXStatusLabel" destination="8zi-ja-23M" id="AUh-7t-01b"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="105" y="62.5"/>
+            <point key="canvasLocation" x="104.34782608695653" y="61.956521739130437"/>
         </scene>
     </scenes>
 </document>

--- a/Example/ConsentViewController_ExampleTests/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClientSpec.swift
@@ -6,14 +6,16 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-// swiftlint:disable force_try
+// swiftlint:disable force_try function_body_length force_cast
 
 import Quick
 import Nimble
 @testable import ConsentViewController
 
 public class MockHttp: HttpClient {
-    var getCalledWith: URL?
+    var getWasCalledWithUrl: URL?
+    var postWasCalledWithUrl: URL?
+    var postWasCalledWithBody: Data?
     var success: Data?
     var error: Error?
 
@@ -25,38 +27,32 @@ public class MockHttp: HttpClient {
         self.error = error
     }
 
-    public func get(url: URL?, completionHandler: @escaping CompletionHandler) {
-        getCalledWith = url?.absoluteURL
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2), execute: {
-            completionHandler(self.success!, nil)
-        })
-    }
+    public func get(url: URL?, completionHandler: @escaping CompletionHandler) {}
 
-    func request(_ urlRequest: URLRequest, _ completionHandler: @escaping CompletionHandler) {
-        getCalledWith = urlRequest.url?.absoluteURL
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2), execute: {
-            completionHandler(self.success!, nil)
-        })
-    }
+    func request(_ urlRequest: URLRequest, _ completionHandler: @escaping CompletionHandler) {}
 
     public func post(url: URL?, body: Data?, completionHandler: @escaping CompletionHandler) {
-        getCalledWith = url?.absoluteURL
-        var urlRequest = URLRequest(url: getCalledWith!)
+        postWasCalledWithUrl = url?.absoluteURL
+        postWasCalledWithBody = body
+        var urlRequest = URLRequest(url: postWasCalledWithUrl!)
         urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.httpMethod = "POST"
         urlRequest.httpBody = body
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2), execute: {
-            completionHandler(self.success!, nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1), execute: {
+            self.success != nil ?
+                completionHandler(self.success!, nil) :
+                completionHandler(nil, APIParsingError(url!.absoluteString, self.error))
         })
     }
 }
 
 class SourcePointClientSpec: QuickSpec {
+    static let propertyId = 123
 
     func getClient(_ client: MockHttp) -> SourcePointClient {
         return SourcePointClient(
             accountId: 123,
-            propertyId: 123,
+            propertyId: SourcePointClientSpec.propertyId,
             propertyName: try! GDPRPropertyName("tcfv2.mobile.demo"),
             pmId: "123",
             campaignEnv: .Public,
@@ -65,12 +61,21 @@ class SourcePointClientSpec: QuickSpec {
     }
 
     override func spec() {
+        Nimble.AsyncDefaults.Timeout = 2
+
         var client: SourcePointClient!
         var httpClient: MockHttp?
         var mockedResponse: Data?
 
-        describe("Test SourcePointClient Methods") {
+        describe("statics") {
+            it("CUSTOM_CONSENT_URL") {
+                expect(SourcePointClient.CUSTOM_CONSENT_URL.absoluteURL).to(equal(
+                    URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/custom-consent?inApp=true")!.absoluteURL
+                ))
+            }
+        }
 
+        describe("Test SourcePointClient Methods") {
             beforeEach {
                 mockedResponse = "{\"url\": \"https://notice.sp-prod.net/?message_id=59706\"}".data(using: .utf8)
                 httpClient = MockHttp(success: mockedResponse)
@@ -85,7 +90,7 @@ class SourcePointClientSpec: QuickSpec {
                         euconsent: "COwkbAyOwkbAyAGABBENAeCAAAAAAAAAAAAAAAAAAAAA",
                         authId: "test",
                         completionHandler: { _, _  in})
-                    expect(httpClient?.getCalledWith).to(equal(URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/message-url?inApp=true")))
+                    expect(httpClient?.postWasCalledWithUrl).to(equal(URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/message-url?inApp=true")))
                 }
 
                 it("calls get on the http client with the right url") {
@@ -95,7 +100,7 @@ class SourcePointClientSpec: QuickSpec {
                         euconsent: "COwkbAyOwkbAyAGABBENAeCAAAAAAAAAAAAAAAAAAAAA",
                         authId: nil,
                         completionHandler: { _, _  in })
-                    expect(httpClient?.getCalledWith).to(equal(URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/message-url?inApp=true")))
+                    expect(httpClient?.postWasCalledWithUrl).to(equal(URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/message-url?inApp=true")))
                 }
             }
 
@@ -103,7 +108,7 @@ class SourcePointClientSpec: QuickSpec {
                 it("calls post on the http client with the right url") {
                     let acceptAllAction = GDPRAction(type: .AcceptAll, id: "1234")
                     client.postAction(action: acceptAllAction, consentUUID: "744BC49E-7327-4255-9794-FB07AA43E1DF", completionHandler: { _, _  in})
-                    expect(httpClient?.getCalledWith).to(equal(URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/consent?inApp=true")))
+                    expect(httpClient?.postWasCalledWithUrl).to(equal(URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/consent?inApp=true")))
                 }
             }
 
@@ -114,6 +119,75 @@ class SourcePointClientSpec: QuickSpec {
                     let encodeTargetingParam = "{\"native\":\"false\"}".data(using: .utf8)
                     let encodedString = String(data: encodeTargetingParam!, encoding: .utf8)
                     expect(targetingParamString).to(equal(encodedString))
+                }
+            }
+
+            describe("customConsent") {
+                it("makes a POST to SourcePointClient.CUSTOM_CONSENT_URL") {
+                    let http = MockHttp(success: "".data(using: .utf8)!)
+                    self.getClient(http).customConsent(toConsentUUID: "", vendors: [], categories: [], legIntCategories: []) { _, _ in }
+                    expect(http.postWasCalledWithUrl).to(equal(SourcePointClient.CUSTOM_CONSENT_URL))
+                }
+
+                it("makes a POST with the correct body") {
+                    var parsedRequest: [String: Any]?
+                    let http = MockHttp(success: "".data(using: .utf8)!)
+                    self.getClient(http).customConsent(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: []) { _, _ in }
+                    parsedRequest = try! JSONSerialization.jsonObject(with: http.postWasCalledWithBody!) as! [String: Any]
+
+                    expect((parsedRequest?["consentUUID"] as! String)).to(equal("uuid"))
+                    expect((parsedRequest?["vendors"] as! [String])).to(equal([]))
+                    expect((parsedRequest?["categories"] as! [String])).to(equal([]))
+                    expect((parsedRequest?["legIntCategories"] as! [String])).to(equal([]))
+                    expect((parsedRequest?["propertyId"] as! Int)).to(equal(SourcePointClientSpec.propertyId))
+                }
+
+                context("on success") {
+                    beforeEach {
+                        client = self.getClient(MockHttp(success: """
+                        {
+                            "vendors": [],
+                            "categories": [],
+                            "legIntCategories": [],
+                            "specialFeatures": []
+                        }
+                        """.data(using: .utf8)!))
+                    }
+
+                    it("calls the completion handler with a CustomConsentResponse") {
+                        var consentsResponse: CustomConsentResponse?
+                        client.customConsent(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: []) { response, _ in
+                            consentsResponse = response
+                        }
+                        expect(consentsResponse).toEventually(equal(CustomConsentResponse(
+                            vendors: [],
+                            categories: [],
+                            legIntCategories: [],
+                            specialFeatures: []
+                        )))
+                    }
+
+                    it("calls completion handler with nil as error") {
+                        var error: GDPRConsentViewControllerError? = .none
+                        client.customConsent(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: []) { _, e in
+                            error = e
+                        }
+                        expect(error).toEventually(beNil())
+                    }
+                }
+
+                context("on failure") {
+                    beforeEach {
+                        client = self.getClient(MockHttp(error: nil))
+                    }
+
+                    it("calls the completion handler with an GDPRConsentViewControllerError") {
+                        var error: GDPRConsentViewControllerError?
+                        client.customConsent(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: []) { _, e in
+                            error = e
+                        }
+                        expect(error).toEventually(beAKindOf(GDPRConsentViewControllerError.self))
+                    }
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClientSpec.swift
@@ -126,7 +126,7 @@ class SourcePointClientSpec: QuickSpec {
                 it("makes a POST to SourcePointClient.CUSTOM_CONSENT_URL") {
                     let http = MockHttp(success: "".data(using: .utf8)!)
                     self.getClient(http).customConsent(toConsentUUID: "", vendors: [], categories: [], legIntCategories: []) { _, _ in }
-                    expect(http.postWasCalledWithUrl).to(equal(SourcePointClient.CUSTOM_CONSENT_URL))
+                    expect(http.postWasCalledWithUrl).to(equal(SourcePointClient.CUSTOM_CONSENT_URL.absoluteURL))
                 }
 
                 it("makes a POST with the correct body") {


### PR DESCRIPTION
It's now possible to add vendors, categories and legitimateInterestCategories consents to a given consentUUID. In other words, programatically consent an user to a list of vendors/cat/legIntCat.

* Updated SourcePointClient to use the new `custom-consent` endpoint
* Updated GDPRConsentViewController to expose `customConsentTo` method
* Updated the Example app to show off the new feature