### PR TITLE
Check for consentUUID before posting consent

### DIFF
--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -314,6 +314,11 @@ public typealias TargetingParams = [String: String]
         categories: [String],
         legIntCategories: [String],
         completionHandler: @escaping (GDPRUserConsent) -> Void) {
+        if gdprUUID.isEmpty {
+            consentDelegate?.onError?(error: PostingConsentWithoutConsentUUID())
+            return
+        }
+
         customConsent(
             uuid: gdprUUID,
             vendors: vendors,
@@ -352,6 +357,10 @@ extension GDPRConsentViewController: GDPRConsentDelegate {
         if action.type == .AcceptAll ||
             action.type == .RejectAll ||
             action.type == .SaveAndExit {
+            if gdprUUID.isEmpty {
+                consentDelegate?.onError?(error: PostingConsentWithoutConsentUUID())
+                return
+            }
             sourcePoint.postAction(action: action, consentUUID: gdprUUID) { [weak self] response, error in
                 if let actionResponse = response {
                     self?.userConsents = actionResponse.userConsent

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -107,3 +107,8 @@ import Foundation
     public var failureReason: String? { return message }
     override public var description: String { return message }
 }
+
+@objcMembers public class PostingConsentWithoutConsentUUID: GDPRConsentViewControllerError {
+    public var failureReason: String? { return "Tried to post consent but the stored consentUUID is empty or nil. Make sure to call .loadMessage or .loadPrivacyManager first." }
+    override public var description: String { return "\(failureReason!)\n" }
+}


### PR DESCRIPTION
There might be a case in which the `consentUUID` (gdprUUID) is empty when calling one of the post consent endpoints. In this case, rather than waiting for the endpoint to return an error we call the `onError` ourselves with an description of what's going on.