### PR TITLE
Reset in memory attributes on clearAllData

### DIFF
--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -187,7 +187,7 @@ public typealias TargetingParams = [String: String]
         if loading == .Ready {
             loading = .Loading
             if didAuthIdChange(newAuthId: (authId)) {
-                resetConsentData()
+                clearAllData()
                 UserDefaults.standard.setValue(authId, forKey: GDPRConsentViewController.GDPR_AUTH_ID_KEY)
             }
             sourcePoint.getMessage(native: native, consentUUID: gdprUUID, euconsent: euconsent, authId: authId) { [weak self] messageResponse, error in
@@ -234,12 +234,6 @@ public typealias TargetingParams = [String: String]
         return newAuthId != UserDefaults.standard.string(forKey: GDPRConsentViewController.GDPR_AUTH_ID_KEY)
     }
 
-    private func resetConsentData() {
-        self.userConsents = GDPRUserConsent.empty()
-        self.gdprUUID = ""
-        clearAllData()
-    }
-
     /// Loads the PrivacyManager (that popup with the toggles) in a WebView
     /// If the user changes her consents we call `ConsentDelegate.onConsentReady`
     public func loadPrivacyManager() {
@@ -269,6 +263,8 @@ public typealias TargetingParams = [String: String]
 
     /// Clears all consent data from the UserDefaults. Use this method if you want to **completely** wipe the user's consent data from the device.
     public func clearAllData() {
+        userConsents = GDPRUserConsent.empty()
+        gdprUUID = ""
         clearInternalData()
         clearIABConsentData()
     }

--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -314,6 +314,11 @@ public typealias TargetingParams = [String: String]
         categories: [String],
         legIntCategories: [String],
         completionHandler: @escaping (GDPRUserConsent) -> Void) {
+        if gdprUUID.isEmpty {
+            consentDelegate?.onError?(error: PostingConsentWithoutConsentUUID())
+            return
+        }
+
         customConsent(
             uuid: gdprUUID,
             vendors: vendors,
@@ -352,6 +357,10 @@ extension GDPRConsentViewController: GDPRConsentDelegate {
         if action.type == .AcceptAll ||
             action.type == .RejectAll ||
             action.type == .SaveAndExit {
+            if gdprUUID.isEmpty {
+                consentDelegate?.onError?(error: PostingConsentWithoutConsentUUID())
+                return
+            }
             sourcePoint.postAction(action: action, consentUUID: gdprUUID) { [weak self] response, error in
                 if let actionResponse = response {
                     self?.userConsents = actionResponse.userConsent

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -107,3 +107,8 @@ import Foundation
     public var failureReason: String? { return message }
     override public var description: String { return message }
 }
+
+@objcMembers public class PostingConsentWithoutConsentUUID: GDPRConsentViewControllerError {
+    public var failureReason: String? { return "Tried to post consent but the stored consentUUID is empty or nil. Make sure to call .loadMessage or .loadPrivacyManager first." }
+    override public var description: String { return "\(failureReason!)\n" }
+}

--- a/ConsentViewController/Classes/GDPRUserConsent.swift
+++ b/ConsentViewController/Classes/GDPRUserConsent.swift
@@ -50,6 +50,18 @@ import Foundation
         self.tcfData = tcfData
     }
 
+    public override func isEqual(_ object: Any?) -> Bool {
+        if let other = object as? GDPRUserConsent {
+            return other.acceptedCategories.elementsEqual(acceptedVendors) &&
+                other.acceptedVendors.elementsEqual(acceptedVendors) &&
+                other.legitimateInterestCategories.elementsEqual(legitimateInterestCategories) &&
+                other.specialFeatures.elementsEqual(specialFeatures) &&
+                other.euconsent.elementsEqual(euconsent)
+        } else {
+            return false
+        }
+    }
+
     open override var description: String {
         return """
         UserConsents(

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -13,7 +13,6 @@ import Nimble
 @testable import ConsentViewController
 
 public class MockConsentDelegate: GDPRConsentDelegate {
-
     var isConsentUIWillShowCalled = false
     var isConsentUIDidDisappearCalled = false
     var isOnErrorCalled = false
@@ -146,13 +145,17 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
 
         describe("Clears UserDefaults ") {
             beforeEach {
+                UserDefaults.standard.set("consent string", forKey: GDPRConsentViewController.EU_CONSENT_KEY)
+                UserDefaults.standard.set("gdpr uuid", forKey: GDPRConsentViewController.GDPR_UUID_KEY)
                 consentViewController = self.getGDPRConsentViewController()
             }
 
             it("Clears all IAB related data from the UserDefaults") {
                 consentViewController.clearIABConsentData()
-                let gdprUUIDKey = UserDefaults.standard.string(forKey: GDPRConsentViewController.GDPR_UUID_KEY)
-                expect(gdprUUIDKey).to(beNil(), description: "Upon successful call to clearIABConsentData GDPR_UUID_KEY gets cleared")
+                let iabData = UserDefaults.standard.dictionaryRepresentation().filter {
+                    $0.key.starts(with: "IABTCF_")
+                }
+                expect(iabData).to(beEmpty())
             }
 
             it("Clears meta data used by the SDK") {
@@ -165,6 +168,13 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
                 consentViewController.clearAllData()
                 let metaKey = UserDefaults.standard.string(forKey: GDPRConsentViewController.META_KEY)
                 expect(metaKey).to(beNil(), description: "Upon successful call to clearAllData META_KEY gets cleared")
+            }
+
+            it("Clears its consent related in-memory attributes") {
+                consentViewController.clearAllData()
+                expect(consentViewController.euconsent).to(beEmpty())
+                expect(consentViewController.gdprUUID).to(beEmpty())
+                expect(consentViewController.userConsents).to(equal(GDPRUserConsent.empty()))
             }
         }
 


### PR DESCRIPTION
When calling `clearAllData` we should not only clear the data from the `UserDefaults` but the in memory attributes as well. 