### PR TITLE
SP-3526 add GPDRVendorGrants to GDPRUserConsent

### DIFF
--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -117,6 +117,7 @@ public typealias TargetingParams = [String: String]
             acceptedCategories: [],
             legitimateInterestCategories: [],
             specialFeatures: [],
+            vendorGrants: VendorGrants(),
             euconsent: UserDefaults.standard.string(forKey: GDPRConsentViewController.EU_CONSENT_KEY) ?? "",
             tcfData: tcfData ?? SPGDPRArbitraryJson()
         )
@@ -230,7 +231,6 @@ public typealias TargetingParams = [String: String]
     /// Will first check if there's a message to show according to the scenario, for the `authId` provided.
     /// If there is, we'll load the message in a WebView and call `ConsentDelegate.onConsentUIWillShow`
     /// Otherwise, we short circuit to `ConsentDelegate.onConsentReady`
-    ///
     /// - Parameter authId: any arbitrary token that uniquely identifies an user in your system.
     public func loadMessage(forAuthId authId: String?) {
         loadGDPRMessage(native: false, authId: authId)
@@ -303,6 +303,7 @@ public typealias TargetingParams = [String: String]
                 acceptedCategories: response.categories,
                 legitimateInterestCategories: response.legIntCategories,
                 specialFeatures: response.specialFeatures,
+                vendorGrants: VendorGrants(),
                 euconsent: euconsent,
                 tcfData: tcfData)
             )

--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -117,7 +117,7 @@ public typealias TargetingParams = [String: String]
             acceptedCategories: [],
             legitimateInterestCategories: [],
             specialFeatures: [],
-            vendorGrants: VendorGrants(),
+            vendorGrants: GDPRVendorGrants(),
             euconsent: UserDefaults.standard.string(forKey: GDPRConsentViewController.EU_CONSENT_KEY) ?? "",
             tcfData: tcfData ?? SPGDPRArbitraryJson()
         )
@@ -303,7 +303,7 @@ public typealias TargetingParams = [String: String]
                 acceptedCategories: response.categories,
                 legitimateInterestCategories: response.legIntCategories,
                 specialFeatures: response.specialFeatures,
-                vendorGrants: VendorGrants(),
+                vendorGrants: GDPRVendorGrants(),
                 euconsent: euconsent,
                 tcfData: tcfData)
             )

--- a/ConsentViewController/Classes/GDPRUserConsent.swift
+++ b/ConsentViewController/Classes/GDPRUserConsent.swift
@@ -7,12 +7,18 @@
 
 import Foundation
 
-public typealias VendorGrants = [String: VendorGrant]
-public typealias PurposeGrants = [String: Bool]
+/// A dictionary in which the keys represent the Vendor Id
+public typealias GDPRVendorGrants = [GDPRVendorId: GDPRVendorGrant]
+public typealias GDPRVendorId = String
 
-@objcMembers public class VendorGrant: NSObject, Codable {
+/// A dictionary in which the keys represent the Purpose Id and the values indicate if that purpose is granted (`true`) or not (`false`)
+public typealias GDPRPurposeGrants = [GDPRPurposeId: Bool]
+public typealias GDPRPurposeId = String
+
+@objcMembers public class GDPRVendorGrant: NSObject, Codable {
+    /// if all purposes are granted, the vendorGrant will be set to `true`
     public let vendorGrant: Bool
-    public let purposeGrants: PurposeGrants
+    public let purposeGrants: GDPRPurposeGrants
 
     public override var description: String {
         return "vendorGrant: \(vendorGrant), purposeGrants: \(purposeGrants)"
@@ -29,7 +35,7 @@ public typealias PurposeGrants = [String: Bool]
             acceptedCategories: [],
             legitimateInterestCategories: [],
             specialFeatures: [],
-            vendorGrants: VendorGrants(),
+            vendorGrants: GDPRVendorGrants(),
             euconsent: "",
             tcfData: SPGDPRArbitraryJson())
     }
@@ -42,7 +48,7 @@ public typealias PurposeGrants = [String: Bool]
         legitimateInterestCategories,
         specialFeatures: [String]
 
-    public let vendorGrants: VendorGrants
+    public let vendorGrants: GDPRVendorGrants
 
     /// The iAB consent string.
     public let euconsent: String
@@ -55,7 +61,7 @@ public typealias PurposeGrants = [String: Bool]
         acceptedCategories: [String],
         legitimateInterestCategories: [String],
         specialFeatures: [String],
-        vendorGrants: VendorGrants,
+        vendorGrants: GDPRVendorGrants,
         euconsent: String,
         tcfData: SPGDPRArbitraryJson) {
         self.acceptedVendors = acceptedVendors

--- a/ConsentViewController/Classes/GDPRUserConsent.swift
+++ b/ConsentViewController/Classes/GDPRUserConsent.swift
@@ -11,8 +11,12 @@ public typealias VendorGrants = [String: VendorGrant]
 public typealias PurposeGrants = [String: Bool]
 
 @objcMembers public class VendorGrant: NSObject, Codable {
-    let vendorGrant: Bool
-    let purposeGrants: PurposeGrants
+    public let vendorGrant: Bool
+    public let purposeGrants: PurposeGrants
+
+    public override var description: String {
+        return "vendorGrant: \(vendorGrant), purposeGrants: \(purposeGrants)"
+    }
 }
 
 /**

--- a/ConsentViewController/Classes/GDPRUserConsent.swift
+++ b/ConsentViewController/Classes/GDPRUserConsent.swift
@@ -11,17 +11,18 @@ import Foundation
 public typealias GDPRVendorGrants = [GDPRVendorId: GDPRVendorGrant]
 public typealias GDPRVendorId = String
 
-/// A dictionary in which the keys represent the Purpose Id and the values indicate if that purpose is granted (`true`) or not (`false`)
+/// A dictionary in which the keys represent the Purpose Id and the values indicate if that purpose is granted (`true`) or not (`false`) on a legal basis.
 public typealias GDPRPurposeGrants = [GDPRPurposeId: Bool]
 public typealias GDPRPurposeId = String
 
+/// Encapuslates data about a particular vendor being "granted" based on its purposes
 @objcMembers public class GDPRVendorGrant: NSObject, Codable {
     /// if all purposes are granted, the vendorGrant will be set to `true`
     public let vendorGrant: Bool
     public let purposeGrants: GDPRPurposeGrants
 
     public override var description: String {
-        return "vendorGrant: \(vendorGrant), purposeGrants: \(purposeGrants)"
+        return "VendorGrant(vendorGrant: \(vendorGrant), purposeGrants: \(purposeGrants))"
     }
 }
 

--- a/ConsentViewController/Classes/GDPRUserConsent.swift
+++ b/ConsentViewController/Classes/GDPRUserConsent.swift
@@ -98,8 +98,9 @@ public typealias GDPRPurposeId = String
     }
 
     enum CodingKeys: String, CodingKey {
-        case acceptedVendors, acceptedCategories, euconsent, specialFeatures, vendorGrants
+        case acceptedVendors, acceptedCategories, euconsent, specialFeatures
         case legitimateInterestCategories = "legIntCategories"
         case tcfData = "TCData"
+        case vendorGrants = "grants"
     }
 }

--- a/ConsentViewController/Classes/GDPRUserConsent.swift
+++ b/ConsentViewController/Classes/GDPRUserConsent.swift
@@ -7,6 +7,14 @@
 
 import Foundation
 
+public typealias VendorGrants = [String: VendorGrant]
+public typealias PurposeGrants = [String: Bool]
+
+@objcMembers public class VendorGrant: NSObject, Codable {
+    let vendorGrant: Bool
+    let purposeGrants: PurposeGrants
+}
+
 /**
     GDPRUserConsent encapsulates all consent data from a user.
  */
@@ -17,6 +25,7 @@ import Foundation
             acceptedCategories: [],
             legitimateInterestCategories: [],
             specialFeatures: [],
+            vendorGrants: VendorGrants(),
             euconsent: "",
             tcfData: SPGDPRArbitraryJson())
     }
@@ -29,6 +38,8 @@ import Foundation
         legitimateInterestCategories,
         specialFeatures: [String]
 
+    public let vendorGrants: VendorGrants
+
     /// The iAB consent string.
     public let euconsent: String
 
@@ -40,12 +51,14 @@ import Foundation
         acceptedCategories: [String],
         legitimateInterestCategories: [String],
         specialFeatures: [String],
+        vendorGrants: VendorGrants,
         euconsent: String,
         tcfData: SPGDPRArbitraryJson) {
         self.acceptedVendors = acceptedVendors
         self.acceptedCategories = acceptedCategories
         self.legitimateInterestCategories = legitimateInterestCategories
         self.specialFeatures = specialFeatures
+        self.vendorGrants = vendorGrants
         self.euconsent = euconsent
         self.tcfData = tcfData
     }
@@ -75,7 +88,7 @@ import Foundation
     }
 
     enum CodingKeys: String, CodingKey {
-        case acceptedVendors, acceptedCategories, euconsent, specialFeatures
+        case acceptedVendors, acceptedCategories, euconsent, specialFeatures, vendorGrants
         case legitimateInterestCategories = "legIntCategories"
         case tcfData = "TCData"
     }

--- a/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
@@ -50,10 +50,10 @@ class SimpleClient: HttpClient {
     let logCalls: Bool = false
 
     func logRequest(_ type: String, _ request: URLRequest, _ body: Data?) {
-        if logCalls {
-            logger.debug("\(type) \(String(describing: request.httpMethod)) \(String(describing: request.url))")
-            if let body = body {
-                logger.debug(String(describing: String(data: body, encoding: .utf8)))
+        if logCalls, let method = request.httpMethod, let url = request.url {
+            logger.debug("\(type) \(method) \(url)")
+            if let body = body, let bodyString = String(data: body, encoding: .utf8) {
+                logger.debug(bodyString)
             }
         }
     }

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -25,7 +25,7 @@ A Http client for SourcePoint's endpoints
  - Important: it should only be used the SDK as its public API is still in constant development and is probably going to change.
  */
 class SourcePointClient {
-    static let WRAPPER_API = URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/")!
+    static let WRAPPER_API = URL(string: "https://fake-wrapper-api.herokuapp.com/tcfv2/v1/gdpr/")!
     static let GET_MESSAGE_CONTENTS_URL = URL(string: "native-message?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
     static let GET_MESSAGE_URL_URL = URL(string: "message-url?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
     static let CONSENT_URL = URL(string: "consent?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -25,7 +25,7 @@ A Http client for SourcePoint's endpoints
  - Important: it should only be used the SDK as its public API is still in constant development and is probably going to change.
  */
 class SourcePointClient {
-    static let WRAPPER_API = URL(string: "https://fake-wrapper-api.herokuapp.com/tcfv2/v1/gdpr/")!
+    static let WRAPPER_API = URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/")!
     static let GET_MESSAGE_CONTENTS_URL = URL(string: "native-message?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
     static let GET_MESSAGE_URL_URL = URL(string: "message-url?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
     static let CONSENT_URL = URL(string: "consent?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		8231B14722BA5A6C00D2669B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8231B14622BA5A6C00D2669B /* Assets.xcassets */; };
 		8231B14A22BA5A6C00D2669B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8231B14822BA5A6C00D2669B /* LaunchScreen.storyboard */; };
 		8248A497247D17AA00A7D9AD /* SimpleClientSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8248A496247D17AA00A7D9AD /* SimpleClientSpec.swift */; };
+		8248A499247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8248A498247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift */; };
 		824BC0342463F6B0006D3C18 /* GDPRActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */; };
 		82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */; };
 		8277C33C22BBD22C00F1607F /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277C33B22BBD22C00F1607F /* HomeViewController.swift */; };
@@ -191,6 +192,7 @@
 		8231B14B22BA5A6C00D2669B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8231B15122BBC39900D2669B /* ConsentViewController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ConsentViewController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8248A496247D17AA00A7D9AD /* SimpleClientSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleClientSpec.swift; sourceTree = "<group>"; };
+		8248A498247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRUserConsentsSpec.swift; sourceTree = "<group>"; };
 		824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRActionSpec.swift; sourceTree = "<group>"; };
 		82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPGDPRArbitraryJsonSpec.swift; sourceTree = "<group>"; };
 		8277C33B22BBD22C00F1607F /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -734,6 +736,7 @@
 				6D554C2124310BF800B15583 /* SourcePointClientSpec.swift */,
 				824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */,
 				8248A496247D17AA00A7D9AD /* SimpleClientSpec.swift */,
+				8248A498247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift */,
 			);
 			path = ConsentViewController_ExampleTests;
 			sourceTree = "<group>";
@@ -1368,6 +1371,7 @@
 				6DB561EE24269470008501AC /* GDPRMessageSpec.swift in Sources */,
 				6DC1CD412427E7330028F03F /* GDPRNativeMessageViewControllerSpec.swift in Sources */,
 				6D605DF42423523700BB3E5F /* GDPRMessageViewControllerSpec.swift in Sources */,
+				8248A499247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift in Sources */,
 				82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/ConsentViewController.xcodeproj/xcshareddata/xcschemes/ConsentViewController_ExampleTests.xcscheme
+++ b/Example/ConsentViewController.xcodeproj/xcshareddata/xcschemes/ConsentViewController_ExampleTests.xcscheme
@@ -10,7 +10,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "374151914BA6B7C6A7C04A46512F48FA"
+            BuildableName = "ConsentViewController.framework"
+            BlueprintName = "ConsentViewController"
+            ReferencedContainer = "container:Pods/Pods.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -81,6 +81,7 @@ extension ViewController: GDPRConsentDelegate {
         vendorXAccepted = userConsent.acceptedVendors.contains(ViewController.vendorXId)
         userConsent.acceptedVendors.forEach { vendorId in print("Vendor: \(vendorId)") }
         userConsent.acceptedCategories.forEach { purposeId in print("Purpose: \(purposeId)") }
+        print(userConsent.vendorGrants)
 
         print(UserDefaults.standard.dictionaryWithValues(forKeys: userConsent.tcfData.dictionaryValue?.keys.sorted() ?? []))
         

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -81,7 +81,7 @@ extension ViewController: GDPRConsentDelegate {
         vendorXAccepted = userConsent.acceptedVendors.contains(ViewController.vendorXId)
         userConsent.acceptedVendors.forEach { vendorId in print("Vendor: \(vendorId)") }
         userConsent.acceptedCategories.forEach { purposeId in print("Purpose: \(purposeId)") }
-        print(userConsent.vendorGrants)
+        print("VendorGrants(\(userConsent.vendorGrants))")
 
         print(UserDefaults.standard.dictionaryWithValues(forKeys: userConsent.tcfData.dictionaryValue?.keys.sorted() ?? []))
         

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -88,6 +88,7 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
             acceptedCategories: [],
             legitimateInterestCategories: [],
             specialFeatures: [],
+            vendorGrants: VendorGrants(),
             euconsent: "",
             tcfData: SPGDPRArbitraryJson()
         )
@@ -104,6 +105,7 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
                 acceptedCategories: [],
                 legitimateInterestCategories: [],
                 specialFeatures: [],
+                vendorGrants: VendorGrants(),
                 euconsent: "",
                 tcfData: SPGDPRArbitraryJson()
             )
@@ -237,6 +239,7 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
                         acceptedCategories: [],
                         legitimateInterestCategories: [],
                         specialFeatures: [],
+                        vendorGrants: VendorGrants(),
                         euconsent: "my_consent_string",
                         tcfData: try! SPGDPRArbitraryJson(["IABTCF_bar": "bar"])
                     )

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -88,7 +88,7 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
             acceptedCategories: [],
             legitimateInterestCategories: [],
             specialFeatures: [],
-            vendorGrants: VendorGrants(),
+            vendorGrants: GDPRVendorGrants(),
             euconsent: "",
             tcfData: SPGDPRArbitraryJson()
         )
@@ -105,7 +105,7 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
                 acceptedCategories: [],
                 legitimateInterestCategories: [],
                 specialFeatures: [],
-                vendorGrants: VendorGrants(),
+                vendorGrants: GDPRVendorGrants(),
                 euconsent: "",
                 tcfData: SPGDPRArbitraryJson()
             )
@@ -239,7 +239,7 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
                         acceptedCategories: [],
                         legitimateInterestCategories: [],
                         specialFeatures: [],
-                        vendorGrants: VendorGrants(),
+                        vendorGrants: GDPRVendorGrants(),
                         euconsent: "my_consent_string",
                         tcfData: try! SPGDPRArbitraryJson(["IABTCF_bar": "bar"])
                     )

--- a/Example/ConsentViewController_ExampleTests/GDPRUserConsentsSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRUserConsentsSpec.swift
@@ -1,0 +1,44 @@
+//
+//  GDPRUserConsents.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 27.05.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import ConsentViewController
+
+class GDPRUserConsentsSpec: QuickSpec {
+    override func spec() {
+        describe("static empty()") {
+            it("contain empty defaults for all its fields") {
+                let consents = GDPRUserConsent.empty()
+                expect(consents.acceptedCategories).to(beEmpty())
+                expect(consents.acceptedVendors).to(beEmpty())
+                expect(consents.legitimateInterestCategories).to(beEmpty())
+                expect(consents.specialFeatures).to(beEmpty())
+                expect(consents.euconsent).to(beEmpty())
+                expect(consents.tcfData.dictionaryValue).to(beEmpty())
+                expect(consents.vendorGrants).to(beEmpty())
+            }
+        }
+
+        it("is Codable") {
+            expect(GDPRUserConsent.empty()).to(beAKindOf(Codable.self))
+        }
+
+        describe("CodingKeys") {
+            it("legIntCategories is mapped to legitimateInterestCategories") {
+                expect(GDPRUserConsent.CodingKeys.legitimateInterestCategories.rawValue)
+                    .to(equal("legIntCategories"))
+            }
+
+            it("TCData is mapped to tcfData") {
+                expect(GDPRUserConsent.CodingKeys.tcfData.rawValue).to(equal("TCData"))
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR expands the `GDPRUserConsent` with the `VendorGrants` field. 

The `VendorGrants` field is a dictionary in the shape of:
```js
{
  vendorId: {
    vendorGrant: Bool,
    purposeGrants: {
      purposeId: Bool,
      // more purposes here
    }
  }
  // more vendors here
}
```

All vendors in the vendor list will be present in the `vendorGrants` object. The `vendorGrant` property on each vendor will indicate if that vendor has all the purposes granted (consented in the legal basis), thus, the vendor is consented too. 