### PR TITLE
SP-3679 capture error events on JSReceiver

### DIFF
--- a/ConsentViewController/Assets/GDPRJSReceiver.js
+++ b/ConsentViewController/Assets/GDPRJSReceiver.js
@@ -60,15 +60,29 @@
     return event.fromPM || event.settings.vendorList
   }
 
+    function isError(event) {
+        return event.stackTrace !== undefined
+    }
+
+    function handleError(event) {
+        window.SDK.onError({
+            code: event.code,
+            title: event.title,
+            stackTrace: event.stackTrace
+        })
+    }
+
   var handleMessageOrPMEvent = function (SDK) {
     return function (event) {
       try {
-        handleMessageEvent(SDK)({
-          name: event.name,
-          fromPM: isFromPM(event),
-          actionType: event.actionType,
-          payload: event.payload || event.actions || {}
-        });
+          isError(event) ?
+            handleError(event) :
+            handleMessageEvent(SDK)({
+              name: event.name,
+              fromPM: isFromPM(event),
+              actionType: event.actionType,
+              payload: event.payload || event.actions || {}
+            });
       } catch (error) {
         SDK.onError(error);
       }

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -76,7 +76,19 @@ import Foundation
 }
 
 @objcMembers public class WebViewError: GDPRConsentViewControllerError {
-    public var failureReason: String? { return "Something went wrong in the webview" }
+    let spCode: Int?
+    let title, stackTrace: String?
+
+    init(code: Int? = nil, title: String? = nil, stackTrace: String? = nil) {
+        self.spCode = code
+        self.title = title
+        self.stackTrace = stackTrace
+        super.init()
+    }
+
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    public var failureReason: String? { return "Something went wrong in the webview (code: \(spCode ?? 0), title: \(title ?? ""), stackTrace: \(stackTrace ?? "")" }
     override public var description: String { return "\(failureReason!)" }
 }
 

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -53,12 +53,12 @@ import Foundation
 
 @objcMembers public class UnableToLoadJSReceiver: GDPRConsentViewControllerError {
     public var failureReason: String? { return "Unable to load the JSReceiver.js resource." }
-    override public var description: String { return "\(failureReason!)\n" }
+    override public var description: String { return "\(failureReason!)" }
 }
 
 @objcMembers public class NoInternetConnection: GDPRConsentViewControllerError {
     public var failureReason: String? { return "The device is not connected to the internet." }
-    override public var description: String { return "\(failureReason!)\n" }
+    override public var description: String { return "\(failureReason!)" }
 }
 
 @objcMembers public class MessageEventParsingError: GDPRConsentViewControllerError {
@@ -72,12 +72,12 @@ import Foundation
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     public var failureReason: String? { return "Could not parse message coming from the WebView \(message)" }
-    override public var description: String { return "\(failureReason!)\n" }
+    override public var description: String { return "\(failureReason!)" }
 }
 
 @objcMembers public class WebViewError: GDPRConsentViewControllerError {
     public var failureReason: String? { return "Something went wrong in the webview" }
-    override public var description: String { return "\(failureReason!)\n" }
+    override public var description: String { return "\(failureReason!)" }
 }
 
 @objcMembers public class URLParsingError: GDPRConsentViewControllerError {
@@ -91,7 +91,7 @@ import Foundation
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     public var failureReason: String? { return "Could not parse URL: \(urlString)" }
-    override public var description: String { return "\(failureReason!)\n" }
+    override public var description: String { return "\(failureReason!)" }
 }
 
 @objcMembers public class InvalidArgumentError: GDPRConsentViewControllerError {
@@ -110,7 +110,7 @@ import Foundation
 
 @objcMembers public class PostingConsentWithoutConsentUUID: GDPRConsentViewControllerError {
     public var failureReason: String? { return "Tried to post consent but the stored consentUUID is empty or nil. Make sure to call .loadMessage or .loadPrivacyManager first." }
-    override public var description: String { return "\(failureReason!)\n" }
+    override public var description: String { return "\(failureReason!)" }
 }
 
 @objcMembers public class MessageTimeout: GDPRConsentViewControllerError {

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -88,7 +88,7 @@ import Foundation
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    public var failureReason: String? { return "Something went wrong in the webview (code: \(spCode ?? 0), title: \(title ?? ""), stackTrace: \(stackTrace ?? "")" }
+    public var failureReason: String? { return "Something went wrong in the webview (code: \(spCode ?? 0), title: \(title ?? ""), stackTrace: \(stackTrace ?? ""))" }
     override public var description: String { return "\(failureReason!)" }
 }
 

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -224,7 +224,13 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
             }
             onAction(GDPRAction(type: actionType, id: getChoiceId(payload), payload: payloadData))
         case "onError":
-            onError(error: WebViewError())
+            let payload = body["body"] as? [String: Any] ?? [:]
+            let error = payload["error"] as? [String: Any] ?? [:]
+            onError(error: WebViewError(
+                code: error["code"] as? Int,
+                title: error["title"] as? String,
+                stackTrace: error["stackTrace"] as? String
+            ))
         default:
             print(message.body)
         }

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
@@ -40,7 +40,7 @@ class GDPRConsentViewControllerErrorSpec: QuickSpec {
 
             it("Test WebViewError method") {
                 let errorObject = WebViewError()
-                expect(errorObject.failureReason).to(equal("Something went wrong in the webview"))
+                expect(errorObject.failureReason).to(equal("Something went wrong in the webview (code: 0, title: , stackTrace: )"))
             }
 
             it("Test URLParsingError method") {


### PR DESCRIPTION
We're still not getting [specific error messages](https://sourcepoint.atlassian.net/browse/SP-3809?focusedCommentId=44334) but that's beyond our scope.

With this PR we make use of @MarkGeeRomano recent work, related to dispatching an error event when something goes bad.