### PR TITLE
SP-3631 always call on consent ready

### DIFF
--- a/ConsentViewController/Classes/GDPRAction.swift
+++ b/ConsentViewController/Classes/GDPRAction.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// User actions. Its integer representation matches with what SourcePoint's endpoints expect.
-@objc public enum GDPRActionType: Int, Codable {
+@objc public enum GDPRActionType: Int, Codable, CaseIterable, CustomStringConvertible {
     case SaveAndExit = 1
     case PMCancel = 2
     case AcceptAll = 11

--- a/ConsentViewController/Classes/GDPRAction.swift
+++ b/ConsentViewController/Classes/GDPRAction.swift
@@ -35,13 +35,9 @@ import Foundation
     public let id: String?
     public let payload: Data
 
-    public init(type: GDPRActionType, id: String?, payload: Data) {
+    public init(type: GDPRActionType, id: String? = nil, payload: Data = "{}".data(using: .utf8)!) {
         self.type = type
         self.id = id
         self.payload = payload
-    }
-
-    convenience public init(type: GDPRActionType, id: String?) {
-        self.init(type: type, id: id, payload: "{}".data(using: .utf8)!)
     }
 }

--- a/ConsentViewController/Classes/GDPRCampaignEnv.swift
+++ b/ConsentViewController/Classes/GDPRCampaignEnv.swift
@@ -31,21 +31,45 @@ import Foundation
     }
 }
 
+/// JSONDecoder and Encoder do not work for single valued elements prior to iOS 11
+/// Example:
+///   try JSONEncoder().encode(GDPRCampaignEnv.Stage) will throw an exception
+///        -> "Top-level GDPRCampaignEnv encoded as number JSON fragment."
+/// As a workaround, for iOS < 11, we encode it to an array [0] or [1]
+/// because that works as expected when encoding/decoding
+/// https://forums.swift.org/t/top-level-t-self-encoded-as-number-json-fragment/11001/3
 extension GDPRCampaignEnv: Codable {
+    static func decodeFromSingleValue(_ decoder: Decoder) throws -> GDPRCampaignEnv? {
+        let container = try decoder.singleValueContainer()
+        return GDPRCampaignEnv(stringValue: try container.decode(String.self))
+    }
+
+    static func decodeFromArray(_ decoder: Decoder) throws -> GDPRCampaignEnv? {
+        var container = try decoder.unkeyedContainer()
+        return GDPRCampaignEnv(stringValue: try container.decode(String.self))
+    }
+
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(stringValue)
+        if #available(iOS 11, *) {
+            var container = encoder.singleValueContainer()
+            try container.encode(stringValue)
+        } else {
+            var container = encoder.unkeyedContainer()
+            try container.encode(stringValue)
+        }
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
         do {
-            let env = GDPRCampaignEnv.string[try container.decode(String.self)]
-            self = env!
+            if #available(iOS 11, *) {
+                self = try GDPRCampaignEnv.decodeFromSingleValue(decoder)!
+            } else {
+                self = try GDPRCampaignEnv.decodeFromArray(decoder)!
+            }
         } catch {
             throw DecodingError.dataCorrupted(DecodingError.Context(
-                codingPath: [],
-                debugDescription: "Unknown GDPRCampaignEnv"
+               codingPath: [],
+               debugDescription: "Unknown GDPRCampaignEnv"
             ))
         }
     }

--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 
 public typealias TargetingParams = [String: String]
 
+// swiftlint:disable type_body_length
+
 @objcMembers open class GDPRConsentViewController: UIViewController, GDPRMessageUIDelegate {
     static public let SP_GDPR_KEY_PREFIX = "sp_gdpr_"
     static let META_KEY = "\(SP_GDPR_KEY_PREFIX)meta"

--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public typealias TargetingParams = [String: String]
 
-@objcMembers open class GDPRConsentViewController: UIViewController {
+@objcMembers open class GDPRConsentViewController: UIViewController, GDPRMessageUIDelegate {
     static public let SP_GDPR_KEY_PREFIX = "sp_gdpr_"
     static let META_KEY = "\(SP_GDPR_KEY_PREFIX)meta"
     static let EU_CONSENT_KEY = "\(SP_GDPR_KEY_PREFIX)euconsent"
@@ -231,7 +231,7 @@ public typealias TargetingParams = [String: String]
        loadGDPRMessage(native: true, authId: authId)
     }
 
-    func loadMessage(fromUrl url: URL) {
+    public func loadMessage(fromUrl url: URL) {
         messageViewController = MessageWebViewController(propertyId: propertyId, pmId: pmId, consentUUID: gdprUUID, timeout: messageTimeoutInSeconds)
         messageViewController?.consentDelegate = self
         messageViewController?.loadMessage(fromUrl: url)

--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -331,10 +331,6 @@ public typealias TargetingParams = [String: String]
     }
 
     public func reportAction(_ action: GDPRAction) {
-        if gdprUUID.isEmpty {
-            consentDelegate?.onError?(error: PostingConsentWithoutConsentUUID())
-            return
-        }
         sourcePoint.postAction(action: action, consentUUID: gdprUUID, meta: localStorage.meta) { [weak self] response, error in
             if let actionResponse = response {
                 self?.localStorage.meta = actionResponse.meta
@@ -371,7 +367,7 @@ extension GDPRConsentViewController: GDPRConsentDelegate {
     public func onAction(_ action: GDPRAction) {
         let type = action.type
         consentDelegate?.onAction?(action)
-        if type == .Dismiss || type == .PMCancel {
+        if type == .Dismiss {
             self.onConsentReady(gdprUUID: gdprUUID, userConsent: userConsents)
         } else if type == .AcceptAll || type == .RejectAll || type == .SaveAndExit {
             reportAction(action)

--- a/ConsentViewController/Classes/GDPRMessageViewController.swift
+++ b/ConsentViewController/Classes/GDPRMessageViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import WebKit
 
 @objc public protocol GDPRMessageUIDelegate {
+    var consentDelegate: GDPRConsentDelegate? { get }
     func loadMessage(fromUrl url: URL)
     func loadPrivacyManager()
 }
@@ -20,7 +21,7 @@ import WebKit
 ///  with any other class that knows how to render a consent message and a privacy manager.
 ///  Eg. a native message view controller
 @objcMembers open class GDPRMessageViewController: UIViewController, GDPRMessageUIDelegate {
-    weak var consentDelegate: GDPRConsentDelegate?
+    weak public var consentDelegate: GDPRConsentDelegate?
     public func loadMessage(fromUrl url: URL) {}
     public func loadPrivacyManager() {}
 }

--- a/ConsentViewController/Classes/GDPRNativeMessageViewController.swift
+++ b/ConsentViewController/Classes/GDPRNativeMessageViewController.swift
@@ -29,9 +29,9 @@ import UIKit
     }
 
     let message: GDPRMessage
-    let consentViewController: GDPRConsentViewController
+    let consentViewController: GDPRMessageUIDelegate
 
-    public init(messageContents: GDPRMessage, consentViewController: GDPRConsentViewController) {
+    public init(messageContents: GDPRMessage, consentViewController: GDPRMessageUIDelegate) {
         message = messageContents
         self.consentViewController = consentViewController
         super.init(nibName: "GDPRNativeMessageViewController", bundle: Bundle.init(for: GDPRNativeMessageViewController.self))

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -51,6 +51,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
     let pmId: String
     let consentUUID: GDPRUUID
 
+    var isSecondLayerMessage = false
     var consentUILoaded = false
     var isPMLoaded = false
     let timeout: TimeInterval
@@ -192,7 +193,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
         // since we store the last non-null choiceId, the lastChoiceId
         // will be either the choiceId of "Show Options" action when coming from the message
         // or null if coming from the PM opened directly
-        lastChoiceId = payload["id"] as? String? ?? lastChoiceId
+        lastChoiceId = (payload["id"] as? String) ?? lastChoiceId
         return lastChoiceId
     }
 

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -116,17 +116,19 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
     }
 
     func showPrivacyManagerFromMessageAction() {
+        isSecondLayerMessage = true
         closeMessage()
         loadPrivacyManager()
     }
 
     func cancelPMAction() {
-        (webview?.canGoBack ?? false) ?
-            goBackAndClosePrivacyManager():
+        isSecondLayerMessage ?
+            goBackAndClosePrivacyManager() :
             closeConsentUIIfOpen()
     }
 
     func goBackAndClosePrivacyManager() {
+        isSecondLayerMessage = false
         webview?.goBack()
         closePrivacyManager()
         onMessageReady()

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -135,13 +135,17 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
     }
 
     func onAction(_ action: GDPRAction) {
-        consentDelegate?.onAction?(action)
         switch action.type {
         case .ShowPrivacyManager:
+            consentDelegate?.onAction?(action)
             showPrivacyManagerFromMessageAction()
         case .PMCancel:
+            consentDelegate?.onAction?(
+                GDPRAction(type: isSecondLayerMessage ? .PMCancel : .Dismiss, id: action.id, payload: action.payload)
+            )
             cancelPMAction()
         default:
+            consentDelegate?.onAction?(action)
             closeConsentUIIfOpen()
         }
     }

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -55,7 +55,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
     var consentUILoaded = false
     var isPMLoaded = false
     let timeout: TimeInterval
-
+    var connectivityManager: Connectivity = ConnectivityManager()
     var lastChoiceId: String?
 
     init(propertyId: Int, pmId: String, consentUUID: GDPRUUID, timeout: TimeInterval) {
@@ -145,8 +145,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
     }
 
     func load(url: URL) {
-        let connectvityManager = ConnectivityManager()
-        if connectvityManager.isConnectedToNetwork() {
+        if connectivityManager.isConnectedToNetwork() {
             webview?.load(URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: timeout))
         } else {
             onError(error: NoInternetConnection())

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -7,11 +7,50 @@
 
 import Foundation
 
+protocol SourcePointProtocol {
+    init(
+        accountId: Int,
+        propertyId: Int,
+        propertyName: GDPRPropertyName,
+        pmId: String,
+        campaignEnv: GDPRCampaignEnv,
+        targetingParams: TargetingParams,
+        timeout: TimeInterval
+    )
+
+    // swiftlint:disable:next function_parameter_count
+    func getMessage(
+        native: Bool,
+        consentUUID: GDPRUUID?,
+        euconsent: String,
+        authId: String?,
+        meta: Meta,
+        completionHandler: @escaping (MessageResponse?, APIParsingError?)
+    -> Void)
+
+    func postAction(
+        action: GDPRAction,
+        consentUUID: GDPRUUID,
+        meta: Meta,
+        completionHandler: @escaping (ActionResponse?, APIParsingError?)
+    -> Void)
+
+    func customConsent(
+        toConsentUUID consentUUID: String,
+        vendors: [String],
+        categories: [String],
+        legIntCategories: [String],
+        completionHandler: @escaping (CustomConsentResponse?, APIParsingError?)
+    -> Void)
+
+    func setRequestTimeout(_ timeout: TimeInterval)
+}
+
 /**
 A Http client for SourcePoint's endpoints
  - Important: it should only be used the SDK as its public API is still in constant development and is probably going to change.
  */
-class SourcePointClient {
+class SourcePointClient: SourcePointProtocol {
     static let WRAPPER_API = URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/")!
     static let GET_MESSAGE_CONTENTS_URL = URL(string: "native-message?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
     static let GET_MESSAGE_URL_URL = URL(string: "message-url?inApp=true", relativeTo: SourcePointClient.WRAPPER_API)!
@@ -47,7 +86,7 @@ class SourcePointClient {
         self.client = client
     }
 
-    convenience init(
+    required convenience init(
         accountId: Int,
         propertyId: Int,
         propertyName: GDPRPropertyName,

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		82D8FEEB23DC753500F28D74 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 82D8FEE923DC753500F28D74 /* LaunchScreen.storyboard */; };
 		82EA4E302491019900DC01C9 /* HttpMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E2F2491019900DC01C9 /* HttpMock.swift */; };
 		82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */; };
+		82EA4E342491324400DC01C9 /* GDPRLocalStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */; };
+		82EA4E362491328A00DC01C9 /* InMemoryStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */; };
 		82EA4FA42488EB7300BA48BF /* GDPRUserDefaultsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82ACF6AB2487E73C006E207A /* GDPRUserDefaultsSpec.swift */; };
 		82EA4FA62489171200BA48BF /* GDPRLocalStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4FA52489171200BA48BF /* GDPRLocalStorageSpec.swift */; };
 /* End PBXBuildFile section */
@@ -212,6 +214,8 @@
 		82D8FEEC23DC753500F28D74 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		82EA4E2F2491019900DC01C9 /* HttpMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HttpMock.swift; path = Helpers/HttpMock.swift; sourceTree = "<group>"; };
 		82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SourcePointClientMock.swift; path = Helpers/SourcePointClientMock.swift; sourceTree = "<group>"; };
+		82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GDPRLocalStorageMock.swift; path = Helpers/GDPRLocalStorageMock.swift; sourceTree = "<group>"; };
+		82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InMemoryStorageMock.swift; path = Helpers/InMemoryStorageMock.swift; sourceTree = "<group>"; };
 		82EA4FA52489171200BA48BF /* GDPRLocalStorageSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRLocalStorageSpec.swift; sourceTree = "<group>"; };
 		82FC4D3A23983231002F08E5 /* ConsentViewController_ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ConsentViewController_ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		82FC4D3E23983231002F08E5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -755,6 +759,8 @@
 			children = (
 				82EA4E2F2491019900DC01C9 /* HttpMock.swift */,
 				82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */,
+				82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */,
+				82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -1403,6 +1409,7 @@
 				8248A497247D17AA00A7D9AD /* SimpleClientSpec.swift in Sources */,
 				6D605DF12423523700BB3E5F /* MessageWebViewControllerSpec.swift in Sources */,
 				82EA4E302491019900DC01C9 /* HttpMock.swift in Sources */,
+				82EA4E342491324400DC01C9 /* GDPRLocalStorageMock.swift in Sources */,
 				6D605DF62423B96C00BB3E5F /* GDPRConsentViewControllerErrorSpec.swift in Sources */,
 				6D605DF22423523700BB3E5F /* GDPRConsentViewControllerSpec.swift in Sources */,
 				82813A6A248A69F000521571 /* GDPRCampaignEnvSpec.swift in Sources */,
@@ -1416,6 +1423,7 @@
 				8248A499247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift in Sources */,
 				82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */,
 				82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */,
+				82EA4E362491328A00DC01C9 /* InMemoryStorageMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		8248A499247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8248A498247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift */; };
 		824BC0342463F6B0006D3C18 /* GDPRActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */; };
 		82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */; };
+		826D31AD2498DE340026A6B9 /* MockConsentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826D31AC2498DE340026A6B9 /* MockConsentDelegate.swift */; };
 		8277C33C22BBD22C00F1607F /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277C33B22BBD22C00F1607F /* HomeViewController.swift */; };
 		82813A6A248A69F000521571 /* GDPRCampaignEnvSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82813A69248A69F000521571 /* GDPRCampaignEnvSpec.swift */; };
 		82D8FEDF23DC753400F28D74 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D8FEDE23DC753400F28D74 /* AppDelegate.swift */; };
@@ -202,6 +203,7 @@
 		8248A498247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRUserConsentsSpec.swift; sourceTree = "<group>"; };
 		824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRActionSpec.swift; sourceTree = "<group>"; };
 		82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPGDPRArbitraryJsonSpec.swift; sourceTree = "<group>"; };
+		826D31AC2498DE340026A6B9 /* MockConsentDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockConsentDelegate.swift; path = Helpers/MockConsentDelegate.swift; sourceTree = "<group>"; };
 		8277C33B22BBD22C00F1607F /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		82813A69248A69F000521571 /* GDPRCampaignEnvSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRCampaignEnvSpec.swift; sourceTree = "<group>"; };
 		82ACF6AB2487E73C006E207A /* GDPRUserDefaultsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRUserDefaultsSpec.swift; sourceTree = "<group>"; };
@@ -761,6 +763,7 @@
 				82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */,
 				82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */,
 				82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */,
+				826D31AC2498DE340026A6B9 /* MockConsentDelegate.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -1420,6 +1423,7 @@
 				6DB561EE24269470008501AC /* GDPRMessageSpec.swift in Sources */,
 				6DC1CD412427E7330028F03F /* GDPRNativeMessageViewControllerSpec.swift in Sources */,
 				6D605DF42423523700BB3E5F /* GDPRMessageViewControllerSpec.swift in Sources */,
+				826D31AD2498DE340026A6B9 /* MockConsentDelegate.swift in Sources */,
 				8248A499247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift in Sources */,
 				82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */,
 				82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */,

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		82D8FEE623DC753400F28D74 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 82D8FEE423DC753400F28D74 /* Main.storyboard */; };
 		82D8FEE823DC753500F28D74 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 82D8FEE723DC753500F28D74 /* Assets.xcassets */; };
 		82D8FEEB23DC753500F28D74 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 82D8FEE923DC753500F28D74 /* LaunchScreen.storyboard */; };
+		82EA4E302491019900DC01C9 /* HttpMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E2F2491019900DC01C9 /* HttpMock.swift */; };
+		82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */; };
 		82EA4FA42488EB7300BA48BF /* GDPRUserDefaultsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82ACF6AB2487E73C006E207A /* GDPRUserDefaultsSpec.swift */; };
 		82EA4FA62489171200BA48BF /* GDPRLocalStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4FA52489171200BA48BF /* GDPRLocalStorageSpec.swift */; };
 /* End PBXBuildFile section */
@@ -208,6 +210,8 @@
 		82D8FEE723DC753500F28D74 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		82D8FEEA23DC753500F28D74 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		82D8FEEC23DC753500F28D74 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		82EA4E2F2491019900DC01C9 /* HttpMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HttpMock.swift; path = Helpers/HttpMock.swift; sourceTree = "<group>"; };
+		82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SourcePointClientMock.swift; path = Helpers/SourcePointClientMock.swift; sourceTree = "<group>"; };
 		82EA4FA52489171200BA48BF /* GDPRLocalStorageSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRLocalStorageSpec.swift; sourceTree = "<group>"; };
 		82FC4D3A23983231002F08E5 /* ConsentViewController_ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ConsentViewController_ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		82FC4D3E23983231002F08E5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -746,9 +750,19 @@
 			path = NativeMessageExample;
 			sourceTree = "<group>";
 		};
+		82EA4E2E249100B800DC01C9 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				82EA4E2F2491019900DC01C9 /* HttpMock.swift */,
+				82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */,
+			);
+			name = Helpers;
+			sourceTree = "<group>";
+		};
 		82FC4D3B23983231002F08E5 /* ConsentViewController_ExampleTests */ = {
 			isa = PBXGroup;
 			children = (
+				82EA4E2E249100B800DC01C9 /* Helpers */,
 				825F4B7F2487B5D100769B6A /* SourcePointClient */,
 				825F4B802487B5DB00769B6A /* LocalStorage */,
 				6D605DEE2423523600BB3E5F /* GDPRConsentViewControllerSpec.swift */,
@@ -1388,6 +1402,7 @@
 				82EA4FA42488EB7300BA48BF /* GDPRUserDefaultsSpec.swift in Sources */,
 				8248A497247D17AA00A7D9AD /* SimpleClientSpec.swift in Sources */,
 				6D605DF12423523700BB3E5F /* MessageWebViewControllerSpec.swift in Sources */,
+				82EA4E302491019900DC01C9 /* HttpMock.swift in Sources */,
 				6D605DF62423B96C00BB3E5F /* GDPRConsentViewControllerErrorSpec.swift in Sources */,
 				6D605DF22423523700BB3E5F /* GDPRConsentViewControllerSpec.swift in Sources */,
 				82813A6A248A69F000521571 /* GDPRCampaignEnvSpec.swift in Sources */,
@@ -1400,6 +1415,7 @@
 				6D605DF42423523700BB3E5F /* GDPRMessageViewControllerSpec.swift in Sources */,
 				8248A499247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift in Sources */,
 				82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */,
+				82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */; };
 		826D31AD2498DE340026A6B9 /* MockConsentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826D31AC2498DE340026A6B9 /* MockConsentDelegate.swift */; };
 		826D31B1249A46C40026A6B9 /* GDPRUIiDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826D31B0249A46C40026A6B9 /* GDPRUIiDelegateMock.swift */; };
+		826D31B3249A71E20026A6B9 /* ConnectivityMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826D31B2249A71E20026A6B9 /* ConnectivityMock.swift */; };
 		8277C33C22BBD22C00F1607F /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277C33B22BBD22C00F1607F /* HomeViewController.swift */; };
 		82813A6A248A69F000521571 /* GDPRCampaignEnvSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82813A69248A69F000521571 /* GDPRCampaignEnvSpec.swift */; };
 		82D8FEDF23DC753400F28D74 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D8FEDE23DC753400F28D74 /* AppDelegate.swift */; };
@@ -206,6 +207,7 @@
 		82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPGDPRArbitraryJsonSpec.swift; sourceTree = "<group>"; };
 		826D31AC2498DE340026A6B9 /* MockConsentDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockConsentDelegate.swift; path = Helpers/MockConsentDelegate.swift; sourceTree = "<group>"; };
 		826D31B0249A46C40026A6B9 /* GDPRUIiDelegateMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GDPRUIiDelegateMock.swift; path = Helpers/GDPRUIiDelegateMock.swift; sourceTree = "<group>"; };
+		826D31B2249A71E20026A6B9 /* ConnectivityMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConnectivityMock.swift; path = Helpers/ConnectivityMock.swift; sourceTree = "<group>"; };
 		8277C33B22BBD22C00F1607F /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		82813A69248A69F000521571 /* GDPRCampaignEnvSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRCampaignEnvSpec.swift; sourceTree = "<group>"; };
 		82ACF6AB2487E73C006E207A /* GDPRUserDefaultsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRUserDefaultsSpec.swift; sourceTree = "<group>"; };
@@ -767,6 +769,7 @@
 				82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */,
 				82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */,
 				826D31AC2498DE340026A6B9 /* MockConsentDelegate.swift */,
+				826D31B2249A71E20026A6B9 /* ConnectivityMock.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -1423,6 +1426,7 @@
 				6DB2B2222424C52A008F9226 /* ConnectivityManagerSpec.swift in Sources */,
 				82EA4FA62489171200BA48BF /* GDPRLocalStorageSpec.swift in Sources */,
 				824BC0342463F6B0006D3C18 /* GDPRActionSpec.swift in Sources */,
+				826D31B3249A71E20026A6B9 /* ConnectivityMock.swift in Sources */,
 				6DB561EE24269470008501AC /* GDPRMessageSpec.swift in Sources */,
 				6DC1CD412427E7330028F03F /* GDPRNativeMessageViewControllerSpec.swift in Sources */,
 				6D605DF42423523700BB3E5F /* GDPRMessageViewControllerSpec.swift in Sources */,

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		824BC0342463F6B0006D3C18 /* GDPRActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */; };
 		82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */; };
 		826D31AD2498DE340026A6B9 /* MockConsentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826D31AC2498DE340026A6B9 /* MockConsentDelegate.swift */; };
+		826D31B1249A46C40026A6B9 /* GDPRUIiDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826D31B0249A46C40026A6B9 /* GDPRUIiDelegateMock.swift */; };
 		8277C33C22BBD22C00F1607F /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277C33B22BBD22C00F1607F /* HomeViewController.swift */; };
 		82813A6A248A69F000521571 /* GDPRCampaignEnvSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82813A69248A69F000521571 /* GDPRCampaignEnvSpec.swift */; };
 		82D8FEDF23DC753400F28D74 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D8FEDE23DC753400F28D74 /* AppDelegate.swift */; };
@@ -204,6 +205,7 @@
 		824BC0332463F6B0006D3C18 /* GDPRActionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRActionSpec.swift; sourceTree = "<group>"; };
 		82665C302444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPGDPRArbitraryJsonSpec.swift; sourceTree = "<group>"; };
 		826D31AC2498DE340026A6B9 /* MockConsentDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockConsentDelegate.swift; path = Helpers/MockConsentDelegate.swift; sourceTree = "<group>"; };
+		826D31B0249A46C40026A6B9 /* GDPRUIiDelegateMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GDPRUIiDelegateMock.swift; path = Helpers/GDPRUIiDelegateMock.swift; sourceTree = "<group>"; };
 		8277C33B22BBD22C00F1607F /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		82813A69248A69F000521571 /* GDPRCampaignEnvSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRCampaignEnvSpec.swift; sourceTree = "<group>"; };
 		82ACF6AB2487E73C006E207A /* GDPRUserDefaultsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRUserDefaultsSpec.swift; sourceTree = "<group>"; };
@@ -759,6 +761,7 @@
 		82EA4E2E249100B800DC01C9 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				826D31B0249A46C40026A6B9 /* GDPRUIiDelegateMock.swift */,
 				82EA4E2F2491019900DC01C9 /* HttpMock.swift */,
 				82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */,
 				82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */,
@@ -1427,6 +1430,7 @@
 				8248A499247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift in Sources */,
 				82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */,
 				82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */,
+				826D31B1249A46C40026A6B9 /* GDPRUIiDelegateMock.swift in Sources */,
 				82EA4E362491328A00DC01C9 /* InMemoryStorageMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/ConsentViewController.xcodeproj/xcshareddata/xcschemes/ConsentViewController_Example.xcscheme
+++ b/Example/ConsentViewController.xcodeproj/xcshareddata/xcschemes/ConsentViewController_Example.xcscheme
@@ -40,7 +40,9 @@
       </CodeCoverageTargets>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "82FC4D3923983231002F08E5"

--- a/Example/ConsentViewController_ExampleTests/GDPRActionSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRActionSpec.swift
@@ -27,12 +27,15 @@ class GDPRActionSpec: QuickSpec {
                     expect(action.id).to(equal(id))
                     expect(action.payload).to(equal(payload))
                 }
-            }
 
-            describe("convenience init") {
-                it("initialises the data attribute with {}") {
-                    let action = GDPRAction(type: .AcceptAll, id: nil)
-                    expect(action.payload).to(equal("{}".data(using: .utf8)!))
+                it("initialises id to nil by default") {
+                    let action = GDPRAction(type: .AcceptAll)
+                    expect(action.id).to(beNil())
+                }
+
+                it("initialises data to data encoded \"{}\" by default") {
+                    let action = GDPRAction(type: .AcceptAll)
+                    expect(action.payload).to(equal("{}".data(using: .utf8)))
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -125,18 +125,6 @@ class GDPRConsentViewControllerSpec: QuickSpec {
             }
 
             fcontext("onAction") {
-                describe("for actions that don't call the post consent API") {
-                    let types: [GDPRActionType] = [.Dismiss, .PMCancel]
-                    types.forEach { type in
-                        describe(type.description) {
-                            it("calls onConsentReady") {
-                                consentViewController.onAction(GDPRAction(type: type))
-                                expect(mockConsentDelegate.isOnConsentReadyCalled).to(beTrue(), description: type.description)
-                            }
-                        }
-                    }
-                }
-
                 describe("for actions that call the post consent API") {
                     let types: [GDPRActionType] = [.AcceptAll, .RejectAll, .SaveAndExit]
 
@@ -186,9 +174,21 @@ class GDPRConsentViewControllerSpec: QuickSpec {
                     }
                 }
 
-                it("does not call onConsentReady for ShowPrivacyManager action type") {
-                    consentViewController.onAction(GDPRAction(type: .ShowPrivacyManager))
-                    expect(mockConsentDelegate.isOnConsentReadyCalled).to(beFalse())
+                let types: [GDPRActionType] = [.ShowPrivacyManager, .PMCancel]
+                types.forEach { type in
+                    describe(type.description) {
+                        it("does not call onConsentReady") {
+                            consentViewController.onAction(GDPRAction(type: type))
+                            expect(mockConsentDelegate.isOnConsentReadyCalled).to(beFalse(), description: type.description)
+                        }
+                    }
+                }
+
+                describe("for an action with Dismiss type") {
+                    it("calls the onConsentReady") {
+                        consentViewController.onAction(GDPRAction(type: .Dismiss))
+                        expect(mockConsentDelegate.isOnConsentReadyCalled).to(beTrue())
+                    }
                 }
             }
 

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -42,22 +42,17 @@ class GDPRConsentViewControllerSpec: QuickSpec {
             userConsents = GDPRUserConsent.empty()
         }
 
-        describe("load Native Message") {
-            it("Load native message with auth ID") {
-                consentViewController.loadNativeMessage(forAuthId: "SPTest")
-                expect(consentViewController.loading).to(equal(.Loading), description: "")
+        describe("loadNativeMessage") {
+            it("calls getMessage on SourcePointClient") {
+                consentViewController.loadNativeMessage(forAuthId: nil)
+                expect(sourcePointClient.getMessageCalled).to(beTruthy())
             }
         }
 
-        describe("load Message in webview") {
-            it("Load message in webview without authId") {
+        describe("loadMessage") {
+            it("calls getMessage on SourcePointClient") {
                 consentViewController.loadMessage()
-                expect(consentViewController.loading).to(equal(.Loading), description: "loadMessage method works as expected")
-            }
-
-            it("Load message in webview with authId") {
-                consentViewController.loadMessage(forAuthId: "SPTestMessage")
-                expect(consentViewController.loading).to(equal(.Loading), description: "loadMessage method with authID works as expected")
+                expect(sourcePointClient.getMessageCalled).to(beTruthy())
             }
         }
 
@@ -124,7 +119,7 @@ class GDPRConsentViewControllerSpec: QuickSpec {
                 }
             }
 
-            fcontext("onAction") {
+            context("onAction") {
                 describe("for actions that call the post consent API") {
                     let types: [GDPRActionType] = [.AcceptAll, .RejectAll, .SaveAndExit]
 

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -12,54 +12,6 @@ import Quick
 import Nimble
 @testable import ConsentViewController
 
-class MockConsentDelegate: GDPRConsentDelegate {
-    var isConsentUIWillShowCalled = false
-    var isConsentUIDidDisappearCalled = false
-    var isOnErrorCalled = false
-    var isOnActionCalled = false
-    var isOnConsentReadyCalled = false
-    var isMessageWillShowCalled = false
-    var isMessageDidDisappearCalled = false
-    var isGdprPMWillShowCalled = false
-    var isGdprPMDidDisappearCalled = false
-
-    public func consentUIWillShow() {
-        isConsentUIWillShowCalled = true
-    }
-
-    public func consentUIDidDisappear() {
-        isConsentUIDidDisappearCalled = true
-    }
-
-    public func onError(error: GDPRConsentViewControllerError?) {
-        isOnErrorCalled = true
-    }
-
-    public func onAction(_ action: GDPRAction) {
-        isOnActionCalled = true
-    }
-
-    public func onConsentReady(gdprUUID: GDPRUUID, userConsent: GDPRUserConsent) {
-        isOnConsentReadyCalled = true
-    }
-
-    public func messageWillShow() {
-        isMessageWillShowCalled = true
-    }
-
-    public func messageDidDisappear() {
-        isMessageDidDisappearCalled = true
-    }
-
-    public func gdprPMWillShow() {
-        isGdprPMWillShowCalled = true
-    }
-
-    public func gdprPMDidDisappear() {
-        isGdprPMDidDisappearCalled = true
-    }
-}
-
 class GDPRConsentViewControllerSpec: QuickSpec {
     func getController(_ delegate: GDPRConsentDelegate = MockConsentDelegate(), _ spClient: SourcePointProtocol = SourcePointClientMock(), _ storage: GDPRLocalStorage = GDPRLocalStorageMock()) -> GDPRConsentViewController {
         return GDPRConsentViewController(accountId: 22,

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -63,28 +63,10 @@ class GDPRConsentViewControllerSpec: QuickSpec {
             }
         }
 
-        describe("Clears UserDefaults") {
-            beforeEach {
-                UserDefaults.standard.set("consent string", forKey: GDPRConsentViewController.EU_CONSENT_KEY)
-                UserDefaults.standard.set("gdpr uuid", forKey: GDPRConsentViewController.GDPR_UUID_KEY)
-            }
-
-            it("Clears all IAB related data from the UserDefaults") {
-                consentViewController.clearIABConsentData()
-                expect(consentViewController.localStorage.tcfData).to(beEmpty())
-            }
-
-            it("Clears all consent data from the UserDefaults") {
+        describe("clearAllData") {
+            it("calls clear on its localStorage") {
                 consentViewController.clearAllData()
-                let metaKey = UserDefaults.standard.string(forKey: GDPRConsentViewController.META_KEY)
-                expect(metaKey).to(equal("{}"))
-            }
-
-            it("Clears its consent related in-memory attributes") {
-                consentViewController.clearAllData()
-                expect(consentViewController.euconsent).to(beEmpty())
-                expect(consentViewController.gdprUUID).to(beEmpty())
-                expect(consentViewController.userConsents).to(equal(GDPRUserConsent.empty()))
+                expect(localStorage.clearWasCalled).to(beTrue())
             }
         }
 

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -6,17 +6,16 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-// swiftlint:disable force_try function_body_length
+// swiftlint:disable force_try function_body_length line_length
 
 import Quick
 import Nimble
 @testable import ConsentViewController
 
-public class MockConsentDelegate: GDPRConsentDelegate {
+class MockConsentDelegate: GDPRConsentDelegate {
     var isConsentUIWillShowCalled = false
     var isConsentUIDidDisappearCalled = false
     var isOnErrorCalled = false
-    var isReportActionCalled = false
     var isOnActionCalled = false
     var isOnConsentReadyCalled = false
     var isMessageWillShowCalled = false
@@ -34,10 +33,6 @@ public class MockConsentDelegate: GDPRConsentDelegate {
 
     public func onError(error: GDPRConsentViewControllerError?) {
         isOnErrorCalled = true
-    }
-
-    public func reportAction(_ action: GDPRAction) {
-        isReportActionCalled = true
     }
 
     public func onAction(_ action: GDPRAction) {
@@ -63,53 +58,36 @@ public class MockConsentDelegate: GDPRConsentDelegate {
     public func gdprPMDidDisappear() {
         isGdprPMDidDisappearCalled = true
     }
-
 }
 
-class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
-    func getGDPRConsentViewController() -> GDPRConsentViewController {
+class GDPRConsentViewControllerSpec: QuickSpec {
+    func getController(_ delegate: GDPRConsentDelegate = MockConsentDelegate(), _ spClient: SourcePointProtocol = SourcePointClientMock(), _ storage: GDPRLocalStorage = GDPRLocalStorageMock()) -> GDPRConsentViewController {
         return GDPRConsentViewController(accountId: 22,
                                          propertyId: 7094,
                                          propertyName: try! GDPRPropertyName("tcfv2.mobile.demo"),
                                          PMId: "100699",
                                          campaignEnv: .Public,
-                                         consentDelegate: self)
+                                         targetingParams: [:],
+                                         consentDelegate: delegate,
+                                         sourcePointClient: spClient,
+                                         localStorage: storage)
     }
 
     override func spec() {
-        var consentViewController = self.getGDPRConsentViewController()
+        var sourcePointClient = SourcePointClientMock()
+        var localStorage = GDPRLocalStorageMock()
         var mockConsentDelegate = MockConsentDelegate()
-        var acceptAllAction = GDPRAction(type: .AcceptAll, id: "1234")
-        var dismissAction = GDPRAction(type: .Dismiss, id: "1234")
-        var gdprUUID = UUID().uuidString
+        var consentViewController = self.getController(mockConsentDelegate, sourcePointClient, localStorage)
         var messageViewController = GDPRMessageViewController()
-        var userConsents = GDPRUserConsent(
-            acceptedVendors: [],
-            acceptedCategories: [],
-            legitimateInterestCategories: [],
-            specialFeatures: [],
-            vendorGrants: GDPRVendorGrants(),
-            euconsent: "",
-            tcfData: SPGDPRArbitraryJson()
-        )
+        var userConsents = GDPRUserConsent.empty()
 
         beforeEach {
-            consentViewController = self.getGDPRConsentViewController()
-            consentViewController.localStorage.clear()
+            sourcePointClient = SourcePointClientMock()
+            localStorage = GDPRLocalStorageMock()
             mockConsentDelegate = MockConsentDelegate()
-            acceptAllAction = GDPRAction(type: .AcceptAll, id: "1234")
-            dismissAction = GDPRAction(type: .Dismiss, id: "1234")
-            gdprUUID = UUID().uuidString
+            consentViewController = self.getController(mockConsentDelegate, sourcePointClient, localStorage)
             messageViewController = GDPRMessageViewController()
-            userConsents = GDPRUserConsent(
-                acceptedVendors: [],
-                acceptedCategories: [],
-                legitimateInterestCategories: [],
-                specialFeatures: [],
-                vendorGrants: GDPRVendorGrants(),
-                euconsent: "",
-                tcfData: SPGDPRArbitraryJson()
-            )
+            userConsents = GDPRUserConsent.empty()
         }
 
         describe("load Native Message") {
@@ -120,10 +98,6 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
         }
 
         describe("load Message in webview") {
-            beforeEach {
-                consentViewController = self.getGDPRConsentViewController()
-            }
-
             it("Load message in webview without authId") {
                 consentViewController.loadMessage()
                 expect(consentViewController.loading).to(equal(.Loading), description: "loadMessage method works as expected")
@@ -136,10 +110,6 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
         }
 
         describe("load Privacy Manager") {
-            beforeEach {
-                consentViewController = self.getGDPRConsentViewController()
-            }
-
             it("Load privacy manager in webview") {
                 consentViewController.loadPrivacyManager()
                 expect(consentViewController.loading).to(equal(.Loading), description: "loadPrivacyManager method works as expected")
@@ -150,15 +120,11 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
             beforeEach {
                 UserDefaults.standard.set("consent string", forKey: GDPRConsentViewController.EU_CONSENT_KEY)
                 UserDefaults.standard.set("gdpr uuid", forKey: GDPRConsentViewController.GDPR_UUID_KEY)
-                consentViewController = self.getGDPRConsentViewController()
             }
 
             it("Clears all IAB related data from the UserDefaults") {
                 consentViewController.clearIABConsentData()
-                let iabData = UserDefaults.standard.dictionaryRepresentation().filter {
-                    $0.key.starts(with: "IABTCF_")
-                }
-                expect(iabData).to(beEmpty())
+                expect(consentViewController.localStorage.tcfData).to(beEmpty())
             }
 
             it("Clears all consent data from the UserDefaults") {
@@ -177,7 +143,6 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
 
         describe("GDPRConsentDelegate") {
             beforeEach {
-                consentViewController = self.getGDPRConsentViewController()
                 consentViewController.consentDelegate = mockConsentDelegate
             }
 
@@ -207,24 +172,71 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
                 }
             }
 
-            context("Test reportAction delegate method") {
-                it("Test GDPRMessageViewController calls reportAction delegate method for accept all action") {
-                    consentViewController.reportAction(acceptAllAction)
-                    expect(mockConsentDelegate.isOnConsentReadyCalled).to(equal(false), description: "reportAction delegate method calls successfully")
+            fcontext("onAction") {
+                describe("for actions that don't call the post consent API") {
+                    let types: [GDPRActionType] = [.Dismiss, .PMCancel]
+                    types.forEach { type in
+                        describe(type.description) {
+                            it("calls onConsentReady") {
+                                consentViewController.onAction(GDPRAction(type: type))
+                                expect(mockConsentDelegate.isOnConsentReadyCalled).to(beTrue(), description: type.description)
+                            }
+                        }
+                    }
                 }
-            }
 
-            context("Test reportAction delegate method") {
-                it("Test GDPRMessageViewController calls reportAction delegate method for dismiss action") {
-                    consentViewController.reportAction(dismissAction)
-                    expect(mockConsentDelegate.isOnConsentReadyCalled).to(equal(true), description: "reportAction delegate method calls successfully")
+                describe("for actions that call the post consent API") {
+                    let types: [GDPRActionType] = [.AcceptAll, .RejectAll, .SaveAndExit]
+
+                    describe("and the local storage contains an consentUUID") {
+                        beforeEach {
+                            consentViewController.localStorage.consentUUID = "test"
+                        }
+                        describe("and the api returns a valid ActionResponse") {
+                            beforeEach {
+                                sourcePointClient.postActionResponse = ActionResponse(uuid: "test", userConsent: GDPRUserConsent.empty(), meta: "")
+                            }
+                            types.forEach { type in
+                                describe(type.description) {
+                                    it("calls onConsentReady") {
+                                        consentViewController.onAction(GDPRAction(type: type))
+                                        expect(mockConsentDelegate.isOnConsentReadyCalled).toEventually(beTrue(), description: type.description)
+                                    }
+                                }
+                            }
+                        }
+
+                        describe("and the api returns an error") {
+                            beforeEach {
+                                sourcePointClient.postActionResponse = nil
+                                sourcePointClient.error = APIParsingError("test", nil)
+                            }
+                            types.forEach { type in
+                                describe(type.description) {
+                                    it("calls onConsentReady") {
+                                        consentViewController.onAction(GDPRAction(type: type))
+                                        expect(mockConsentDelegate.isOnConsentReadyCalled).toEventually(beFalse(), description: type.description)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    describe("and the local storage doesn't contain an consentUUID") {
+                        types.forEach { type in
+                            describe(type.description) {
+                                it("calls onConsentReady") {
+                                    consentViewController.onAction(GDPRAction(type: type))
+                                    expect(mockConsentDelegate.isOnConsentReadyCalled).toEventually(beFalse(), description: type.description)
+                                }
+                            }
+                        }
+                    }
                 }
-            }
 
-            context("Test onAction delegate method") {
-                it("Test GDPRMessageViewController calls onAction delegate method") {
-                    consentViewController.onAction(acceptAllAction)
-                    expect(mockConsentDelegate.isOnActionCalled).to(equal(true), description: "onAction delegate method calls successfully")
+                it("does not call onConsentReady for ShowPrivacyManager action type") {
+                    consentViewController.onAction(GDPRAction(type: .ShowPrivacyManager))
+                    expect(mockConsentDelegate.isOnConsentReadyCalled).to(beFalse())
                 }
             }
 
@@ -242,18 +254,18 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
                 }
 
                 it("calls onConsentReady delegate method") {
-                    consentViewController.onConsentReady(gdprUUID: gdprUUID, userConsent: userConsents)
+                    consentViewController.onConsentReady(gdprUUID: "test", userConsent: userConsents)
                     expect(mockConsentDelegate.isOnConsentReadyCalled).to(equal(true), description: "onConsentReady delegate method calls successfully")
                 }
 
                 it("sets the consentUUID in its local storage") {
-                    consentViewController.onConsentReady(gdprUUID: gdprUUID, userConsent: userConsents)
-                    expect(consentViewController.localStorage.consentUUID).to(equal(gdprUUID))
-                    expect(consentViewController.gdprUUID).to(equal(gdprUUID))
+                    consentViewController.onConsentReady(gdprUUID: "test", userConsent: userConsents)
+                    expect(consentViewController.localStorage.consentUUID).to(equal("test"))
+                    expect(consentViewController.gdprUUID).to(equal("test"))
                 }
 
                 it("sets the userConsent in its local storage") {
-                    consentViewController.onConsentReady(gdprUUID: gdprUUID, userConsent: userConsents)
+                    consentViewController.onConsentReady(gdprUUID: "test", userConsent: userConsents)
                     expect(consentViewController.localStorage.userConsents).to(equal(userConsents))
                     expect(consentViewController.userConsents).to(equal(userConsents))
                 }
@@ -296,10 +308,6 @@ class GDPRConsentViewControllerSpec: QuickSpec, GDPRConsentDelegate {
         }
 
         describe("Test Add/Remove MessageViewController") {
-            beforeEach {
-                consentViewController = self.getGDPRConsentViewController()
-            }
-
             it("Test add MessageViewController into viewcontroller stack") {
                 let viewController = UIViewController()
                 consentViewController.add(asChildViewController: viewController)

--- a/Example/ConsentViewController_ExampleTests/GDPRNativeMessageViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRNativeMessageViewControllerSpec.swift
@@ -10,86 +10,76 @@ import Quick
 import Nimble
 @testable import ConsentViewController
 
-// swiftlint:disable force_try function_body_length
+// swiftlint:disable function_body_length
 
-class GDPRNativeMessageViewControllerSpec: QuickSpec, GDPRConsentDelegate {
-
-    func getGDPRConsentViewController() -> GDPRConsentViewController {
-        return GDPRConsentViewController(
-            accountId: 22,
-            propertyId: 7094,
-            propertyName: try! GDPRPropertyName("tcfv2.mobile.demo"),
-            PMId: "100699",
-            campaignEnv: .Public,
-            consentDelegate: self)
-    }
-
+class GDPRNativeMessageViewControllerSpec: QuickSpec {
     override func spec() {
-
-        describe("Test GDPRNativeMessageViewController methods") {
+        describe("GDPRNativeMessageViewController") {
             let customFileds = ["Custom": "Fileds"]
             let attributeStyle = AttributeStyle(fontFamily: "System-Font", fontSize: 14, color: "#00FA9A", backgroundColor: "#944488")
             let messageAttribute = MessageAttribute(text: "Test GDPR Message", style: attributeStyle, customFields: customFileds)
             let messageAction = MessageAction(text: "Test GDPR Message", style: attributeStyle, customFields: customFileds, choiceId: 12, choiceType: GDPRActionType.AcceptAll)
             let gdprMessage = GDPRMessage(title: messageAttribute, body: messageAttribute, actions: [messageAction], customFields: customFileds)
-            var gdprNativeMessageViewController: GDPRNativeMessageViewController?
-            var gdprConsentViewController: GDPRConsentViewController!
-            let mockConsentDelegate = MockConsentDelegate()
+            var mockConsentDelegate = MockConsentDelegate()
+            var gpdrMessageUiDelegate = GDPRUIDelegateMock(mockConsentDelegate)
+            var gdprNativeMessageViewController = GDPRNativeMessageViewController(messageContents: gdprMessage, consentViewController: gpdrMessageUiDelegate)
 
             let titleLabel = UILabel()
             let descriptionTextView = UITextView()
             let acceptButton = UIButton()
 
             beforeEach {
-                gdprConsentViewController = self.getGDPRConsentViewController()
-                gdprConsentViewController.consentDelegate = mockConsentDelegate
-                gdprNativeMessageViewController = GDPRNativeMessageViewController(messageContents: gdprMessage, consentViewController: gdprConsentViewController)
+                mockConsentDelegate = MockConsentDelegate()
+                gpdrMessageUiDelegate = GDPRUIDelegateMock(mockConsentDelegate)
+                gdprNativeMessageViewController = GDPRNativeMessageViewController(messageContents: gdprMessage, consentViewController: gpdrMessageUiDelegate)
             }
 
             it("Test onShowOptionsTap method") {
-                gdprNativeMessageViewController?.onShowOptionsTap(AnyClass.self)
+                gdprNativeMessageViewController.onShowOptionsTap(AnyClass.self)
                 expect(mockConsentDelegate.isOnActionCalled).to(equal(false), description: "onAction delegate method calls successfully")
             }
 
             it("Test onShowOptionsTap method") {
-                gdprNativeMessageViewController?.onRejectTap(AnyClass.self)
+                gdprNativeMessageViewController.onRejectTap(AnyClass.self)
                 expect(mockConsentDelegate.isOnActionCalled).to(equal(false), description: "onAction delegate method calls successfully")
             }
 
             it("Test onShowOptionsTap method") {
-                gdprNativeMessageViewController?.onAcceptTap(AnyClass.self)
+                gdprNativeMessageViewController.onAcceptTap(AnyClass.self)
                 expect(mockConsentDelegate.isOnActionCalled).to(equal(true), description: "onAction delegate method calls successfully")
             }
 
             it("Test loadOrHideActionButton method") {
-                gdprNativeMessageViewController?.loadOrHideActionButton(actionType: GDPRActionType.AcceptAll, button: acceptButton)
+                gdprNativeMessageViewController.loadOrHideActionButton(actionType: GDPRActionType.AcceptAll, button: acceptButton)
                 expect(acceptButton.titleLabel?.text).to(equal("Test GDPR Message"), description: "Expected data is added in label")
             }
 
             it("Test loadTitle method") {
-                gdprNativeMessageViewController?.loadTitle(forAttribute: messageAttribute, label: titleLabel)
+                gdprNativeMessageViewController.loadTitle(forAttribute: messageAttribute, label: titleLabel)
                 expect(titleLabel.text).to(equal("Test GDPR Message"), description: "Expected data is added in label")
             }
 
             it("Test loadBody method") {
-                gdprNativeMessageViewController?.loadBody(forAttribute: messageAttribute, textView: descriptionTextView)
+                gdprNativeMessageViewController.loadBody(forAttribute: messageAttribute, textView: descriptionTextView)
                 expect(descriptionTextView.text).to(equal("Test GDPR Message"), description: "Expected data is added in textview")
             }
 
             context("Test onAction delegate method") {
                 it("Test GDPRMessageViewController calls onAction delegate method") {
-                    gdprNativeMessageViewController?.action(GDPRActionType.AcceptAll)
+                    gdprNativeMessageViewController.action(GDPRActionType.AcceptAll)
                     expect(mockConsentDelegate.isOnActionCalled).to(equal(true), description: "onAction delegate method calls successfully")
                 }
             }
 
-            it("Load privacy manager in webview") {
-                gdprNativeMessageViewController?.showPrivacyManager()
-                expect(gdprConsentViewController.loading).to(equal(.Loading), description: "loadPrivacyManager method works as expected")
+            describe("showPrivacyManager") {
+                it("calls loadPrivacyManager on its gpdrMessageUiDelegate") {
+                    gdprNativeMessageViewController.showPrivacyManager()
+                    expect(gpdrMessageUiDelegate.loadPrivacyManagerCalled).to(beTruthy())
+                }
             }
 
             it("Test hexStringToUIColor method") {
-                let rgbColor = gdprNativeMessageViewController?.hexStringToUIColor(hex: "#757575")
+                let rgbColor = gdprNativeMessageViewController.hexStringToUIColor(hex: "#757575")
                 expect(rgbColor?.cgColor.components).to(equal([0.4588235294117647, 0.4588235294117647, 0.4588235294117647, 1.0]), description: "Hex string converted to UIColor")
             }
         }

--- a/Example/ConsentViewController_ExampleTests/Helpers/ConnectivityMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/ConnectivityMock.swift
@@ -1,0 +1,20 @@
+//
+//  ConnectivityMock.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 17.06.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import ConsentViewController
+
+class ConnectivityMock: Connectivity {
+    let isConnected: Bool
+    init(connected: Bool) {
+        isConnected = connected
+    }
+    func isConnectedToNetwork() -> Bool {
+        return isConnected
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/Helpers/GDPRLocalStorageMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/GDPRLocalStorageMock.swift
@@ -1,0 +1,25 @@
+//
+//  GDPRLocalStorageMock.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 10.06.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import ConsentViewController
+
+class GDPRLocalStorageMock: GDPRLocalStorage {
+    var storage: Storage = InMemoryStorageMock()
+    var consentUUID: GDPRUUID = ""
+    var meta: String = ""
+    var authId: String?
+    var tcfData: [String: Any] = [:]
+    var userConsents: GDPRUserConsent = GDPRUserConsent.empty()
+    func clear() {
+        storage = InMemoryStorageMock()
+    }
+    required init(storage: Storage = InMemoryStorageMock()) {
+        self.storage = storage
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/Helpers/GDPRLocalStorageMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/GDPRLocalStorageMock.swift
@@ -12,13 +12,18 @@ import Foundation
 class GDPRLocalStorageMock: GDPRLocalStorage {
     var storage: Storage = InMemoryStorageMock()
     var consentUUID: GDPRUUID = ""
-    var meta: String = ""
+    var meta: String = "{}"
     var authId: String?
     var tcfData: [String: Any] = [:]
     var userConsents: GDPRUserConsent = GDPRUserConsent.empty()
+
+    var clearWasCalled = false
+
     func clear() {
+        clearWasCalled = true
         storage = InMemoryStorageMock()
     }
+
     required init(storage: Storage = InMemoryStorageMock()) {
         self.storage = storage
     }

--- a/Example/ConsentViewController_ExampleTests/Helpers/GDPRUIiDelegateMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/GDPRUIiDelegateMock.swift
@@ -1,0 +1,30 @@
+//
+//  GDPRMessageUiDelegateMock.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 17.06.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import ConsentViewController
+
+class GDPRUIDelegateMock: GDPRMessageUIDelegate {
+    weak var consentDelegate: GDPRConsentDelegate?
+    var loadMessageCalled = false
+    var loadPrivacyManagerCalled = false
+    var loadMessageCalledWith: URL?
+
+    init(_ consentDelegate: GDPRConsentDelegate) {
+        self.consentDelegate = consentDelegate
+    }
+
+    func loadMessage(fromUrl url: URL) {
+        loadMessageCalled = true
+        loadMessageCalledWith = url
+    }
+
+    func loadPrivacyManager() {
+        loadPrivacyManagerCalled = true
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/Helpers/HttpMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/HttpMock.swift
@@ -1,0 +1,40 @@
+//
+//  HttpMock.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 10.06.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import ConsentViewController
+
+class MockHttp: HttpClient {
+    var getWasCalledWithUrl: URL?
+    var postWasCalledWithUrl: URL?
+    var postWasCalledWithBody: Data?
+    var success: Data?
+    var error: Error?
+
+    init(success: Data?) {
+        self.success = success
+    }
+
+    init(error: Error?) {
+        self.error = error
+    }
+
+    public func get(url: URL?, completionHandler: @escaping CompletionHandler) {}
+
+    func request(_ urlRequest: URLRequest, _ completionHandler: @escaping CompletionHandler) {}
+
+    public func post(url: URL?, body: Data?, completionHandler: @escaping CompletionHandler) {
+        postWasCalledWithUrl = url?.absoluteURL
+        postWasCalledWithBody = body
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1), execute: {
+            self.success != nil ?
+                completionHandler(self.success!, nil) :
+                completionHandler(nil, APIParsingError(url!.absoluteString, self.error))
+        })
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/Helpers/InMemoryStorageMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/InMemoryStorageMock.swift
@@ -1,0 +1,47 @@
+//
+//  InMemoryStorageMock.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 10.06.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import ConsentViewController
+
+/// A class that uses [String: Any] as its storage
+class InMemoryStorageMock: Storage {
+    var storage = [String: Any]()
+
+    func string(forKey defaultName: String) -> String? {
+        return storage[defaultName] as? String
+    }
+
+    func object<T>(ofType type: T.Type, forKey defaultName: String) -> T? where T: Decodable {
+        return storage[defaultName] as? T
+    }
+
+    func set(_ value: Any?, forKey defaultName: String) {
+        storage[defaultName] = value
+    }
+
+    func setObject<T>(_ value: T, forKey defaultName: String) where T: Encodable {
+        storage[defaultName] = value
+    }
+
+    func setValuesForKeys(_ keyedValues: [String: Any]) {
+        keyedValues.forEach { storage[$0.key] = $0.value }
+    }
+
+    func removeObject(forKey defaultName: String) {
+        storage.removeValue(forKey: defaultName)
+    }
+
+    func removeObjects(forKeys keys: [String]) {
+        keys.forEach { storage.removeValue(forKey: $0) }
+    }
+
+    func dictionaryRepresentation() -> [String: Any] {
+        return storage
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/Helpers/MockConsentDelegate.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/MockConsentDelegate.swift
@@ -1,0 +1,58 @@
+//
+//  MockConsentDelegate.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 16.06.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import ConsentViewController
+
+class MockConsentDelegate: GDPRConsentDelegate {
+    var isConsentUIWillShowCalled = false
+    var isConsentUIDidDisappearCalled = false
+    var isOnErrorCalled = false
+    var isOnActionCalled = false
+    var isOnConsentReadyCalled = false
+    var isMessageWillShowCalled = false
+    var isMessageDidDisappearCalled = false
+    var isGdprPMWillShowCalled = false
+    var isGdprPMDidDisappearCalled = false
+
+    public func consentUIWillShow() {
+        isConsentUIWillShowCalled = true
+    }
+
+    public func consentUIDidDisappear() {
+        isConsentUIDidDisappearCalled = true
+    }
+
+    public func onError(error: GDPRConsentViewControllerError?) {
+        isOnErrorCalled = true
+    }
+
+    public func onAction(_ action: GDPRAction) {
+        isOnActionCalled = true
+    }
+
+    public func onConsentReady(gdprUUID: GDPRUUID, userConsent: GDPRUserConsent) {
+        isOnConsentReadyCalled = true
+    }
+
+    public func messageWillShow() {
+        isMessageWillShowCalled = true
+    }
+
+    public func messageDidDisappear() {
+        isMessageDidDisappearCalled = true
+    }
+
+    public func gdprPMWillShow() {
+        isGdprPMWillShowCalled = true
+    }
+
+    public func gdprPMDidDisappear() {
+        isGdprPMDidDisappearCalled = true
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/Helpers/MockConsentDelegate.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/MockConsentDelegate.swift
@@ -20,6 +20,8 @@ class MockConsentDelegate: GDPRConsentDelegate {
     var isGdprPMWillShowCalled = false
     var isGdprPMDidDisappearCalled = false
 
+    var onActionCalledWith: GDPRAction!
+
     public func consentUIWillShow() {
         isConsentUIWillShowCalled = true
     }
@@ -34,6 +36,7 @@ class MockConsentDelegate: GDPRConsentDelegate {
 
     public func onAction(_ action: GDPRAction) {
         isOnActionCalled = true
+        onActionCalledWith = action
     }
 
     public func onConsentReady(gdprUUID: GDPRUUID, userConsent: GDPRUserConsent) {

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -1,0 +1,58 @@
+//
+//  SourcePointClientMock.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 10.06.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import ConsentViewController
+
+// swiftlint:disable force_try function_parameter_count
+
+class SourcePointClientMock: SourcePointProtocol {
+    var customConsentResponse: CustomConsentResponse?
+    var getMessageResponse: MessageResponse?
+    var postActionResponse: ActionResponse?
+    var error: APIParsingError?
+    var postActionCalled = false, getMessageCalled = false, customConsentCalled = false
+
+    convenience init() {
+        self.init(accountId: 0, propertyId: 0, propertyName: try! GDPRPropertyName("test"), pmId: "", campaignEnv: .Stage, targetingParams: [:], timeout: 0.0)
+    }
+
+    required init(accountId: Int,
+                  propertyId: Int,
+                  propertyName: GDPRPropertyName,
+                  pmId: String,
+                  campaignEnv: GDPRCampaignEnv,
+                  targetingParams: TargetingParams,
+                  timeout: TimeInterval) {}
+
+    func getMessage(native: Bool,
+                    consentUUID: GDPRUUID?,
+                    euconsent: String,
+                    authId: String?,
+                    meta: Meta,
+                    completionHandler: @escaping (MessageResponse?, APIParsingError?) -> Void) {
+        getMessageCalled = true
+        completionHandler(getMessageResponse, error)
+    }
+
+    func postAction(action: GDPRAction, consentUUID: GDPRUUID, meta: Meta, completionHandler: @escaping (ActionResponse?, APIParsingError?) -> Void) {
+        postActionCalled = true
+        completionHandler(postActionResponse, error)
+    }
+
+    func customConsent(toConsentUUID consentUUID: String,
+                       vendors: [String],
+                       categories: [String],
+                       legIntCategories: [String],
+                       completionHandler: @escaping (CustomConsentResponse?, APIParsingError?) -> Void) {
+        customConsentCalled = true
+        completionHandler(customConsentResponse, error)
+    }
+
+    func setRequestTimeout(_ timeout: TimeInterval) {}
+}

--- a/Example/ConsentViewController_ExampleTests/LocalStorage/GDPRUserDefaultsSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/LocalStorage/GDPRUserDefaultsSpec.swift
@@ -12,42 +12,6 @@ import Nimble
 
 // swiftlint:disable force_cast function_body_length
 
-class InMemoryStorageMock: Storage {
-    var storage = [String: Any]()
-
-    func string(forKey defaultName: String) -> String? {
-        return storage[defaultName] as? String
-    }
-
-    func object<T>(ofType type: T.Type, forKey defaultName: String) -> T? where T: Decodable {
-        return storage[defaultName] as? T
-    }
-
-    func set(_ value: Any?, forKey defaultName: String) {
-        storage[defaultName] = value
-    }
-
-    func setObject<T>(_ value: T, forKey defaultName: String) where T: Encodable {
-        storage[defaultName] = value
-    }
-
-    func setValuesForKeys(_ keyedValues: [String: Any]) {
-        keyedValues.forEach { storage[$0.key] = $0.value }
-    }
-
-    func removeObject(forKey defaultName: String) {
-        storage.removeValue(forKey: defaultName)
-    }
-
-    func removeObjects(forKeys keys: [String]) {
-        keys.forEach { storage.removeValue(forKey: $0) }
-    }
-
-    func dictionaryRepresentation() -> [String: Any] {
-        return storage
-    }
-}
-
 class GDPRUserDefaultsSpec: QuickSpec {
     func randomUserConsents() -> GDPRUserConsent {
         return GDPRUserConsent(acceptedVendors: [],

--- a/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
@@ -141,17 +141,18 @@ class MessageWebViewControllerSpec: QuickSpec, GDPRConsentDelegate, WKNavigation
             }
         }
 
-        describe("Test getChoiceId methods") {
-            var chioceID: String?
-            beforeEach {
-                messageWebViewController = self.getMessageWebViewController()
+        describe("getChoiceId") {
+            context("when the payload contains an id") {
+                it("returns the id from the payload") {
+                    expect(messageWebViewController.getChoiceId(["id": "foo"])).to(equal("foo"))
+                }
             }
-            it("Test MessageWebViewController calls getChoiceId method") {
-                chioceID = messageWebViewController.getChoiceId(payload as! [String: Any])
-                if chioceID != nil {
-                    expect(chioceID!).to(equal("455262"), description: "Able to get chioceID")
-                } else {
-                    expect(chioceID).to(beNil(), description: "Unable to get chioceID")
+
+            context("when the payload doesn't contain id") {
+                it("returns the lastChoiceId property") {
+                    expect(messageWebViewController.getChoiceId([:])).to(beNil())
+                    messageWebViewController.lastChoiceId = "id"
+                    expect(messageWebViewController.getChoiceId([:])).to(equal("id"))
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
@@ -11,41 +11,62 @@ import Nimble
 import WebKit
 @testable import ConsentViewController
 
-// swiftlint:disable force_cast function_body_length
+// swiftlint:disable function_body_length
+
+class WebViewMock: WKWebView {
+    var loadCalledWith: URLRequest!
+
+    override func load(_ request: URLRequest) -> WKNavigation? {
+        loadCalledWith = request
+        return nil
+    }
+}
 
 class MessageWebViewControllerSpec: QuickSpec, GDPRConsentDelegate, WKNavigationDelegate {
-    func getMessageWebViewController() -> MessageWebViewController {
-        return MessageWebViewController(propertyId: 22, pmId: "100699", consentUUID: UUID().uuidString, timeout: 100)
-    }
-
     override func spec() {
         var messageWebViewController: MessageWebViewController!
-        let mockConsentDelegate = MockConsentDelegate()
-        let showPMAction = GDPRAction(type: .ShowPrivacyManager, id: "1234")
-        let cancelPMAction = GDPRAction(type: .PMCancel, id: "1234")
-        let acceptedVendors = ["123", "456", "789"]
-        let acceptedPurposes = ["123", "456", "789"]
-        let vendors = ["vendors": acceptedVendors]
-        let purposes = ["categories": acceptedPurposes]
-        let consents = [vendors, purposes]
-        let payload: NSDictionary = ["id": "455262", "consents": consents]
+        var mockConsentDelegate: MockConsentDelegate!
 
-        // this method is used to test whether webview is loaded or not successfully
-        describe("Test loadView method") {
-            beforeEach {
-                messageWebViewController = self.getMessageWebViewController()
+        beforeEach {
+            mockConsentDelegate = MockConsentDelegate()
+            messageWebViewController = MessageWebViewController(propertyId: 1, pmId: "pmId", consentUUID: "uuid", timeout: 1)
+            messageWebViewController.consentDelegate = mockConsentDelegate
+        }
+
+        describe("defaults") {
+            describe("isSecondLayerMessage") {
+                it("is set to false") {
+                    expect(messageWebViewController.isSecondLayerMessage).to(beFalse())
+                }
             }
+
+            describe("consentUILoaded") {
+                it("is set to false") {
+                    expect(messageWebViewController.consentUILoaded).to(beFalse())
+                }
+            }
+
+            describe("isPMLoaded") {
+                it("is set to false") {
+                    expect(messageWebViewController.isPMLoaded).to(beFalse())
+                }
+            }
+
+            describe("connectivityManager") {
+                it("is an instance of ConnectivityManager") {
+                    expect(messageWebViewController.connectivityManager).to(beAnInstanceOf(ConnectivityManager.self))
+                }
+            }
+        }
+
+        describe("Test loadView method") {
             it("Test MessageWebViewController calls loadView method") {
                 messageWebViewController.loadView()
                 expect(messageWebViewController.webview).notTo(beNil(), description: "Webview initialized successfully")
             }
         }
 
-        describe("Test GDPRConsentDelegate methods") {
-            beforeEach {
-                messageWebViewController = self.getMessageWebViewController()
-                messageWebViewController.consentDelegate = mockConsentDelegate
-            }
+        describe("GDPRConsentDelegate") {
             context("Test consentUIWillShow delegate method") {
                 it("Test MessageWebViewController calls consentUIWillShow delegate method") {
                     messageWebViewController.gdprConsentUIWillShow()
@@ -96,45 +117,168 @@ class MessageWebViewControllerSpec: QuickSpec, GDPRConsentDelegate, WKNavigation
                 }
             }
 
-            context("Test onAction delegate method") {
-                it("Test MessageWebViewController calls onAction delegate method for show PM action") {
-                    messageWebViewController.onAction(showPMAction)
-                    expect(mockConsentDelegate.isOnActionCalled).to(equal(true), description: "onAction delegate method calls successfully")
-                }
-            }
-
-            context("Test onAction delegate method") {
-                it("Test MessageWebViewController calls onAction delegate method for PM cancel action") {
-                    messageWebViewController.onAction(cancelPMAction)
-                    expect(mockConsentDelegate.isOnActionCalled).to(equal(true), description: "onAction delegate method calls successfully")
-                }
-            }
-
-            context("Test loadMessage  method") {
-                it("Test MessageWebViewController calls loadMessage delegate method") {
-                    let WRAPPER_API = URL(string: "https://wrapper-api.sp-prod.net/tcfv2/v1/gdpr/")!
-                    messageWebViewController.loadMessage(fromUrl: WRAPPER_API)
-                    expect(messageWebViewController).notTo(beNil(), description: "loadMessage delegate method calls successfully")
-                }
-            }
-            context("Test loadPrivacyManager method") {
-                it("Test MessageWebViewController calls loadPrivacyManager delegate method") {
-                    messageWebViewController.loadPrivacyManager()
-                    expect(messageWebViewController).notTo(beNil(), description: "loadPrivacyManager delegate method calls successfully")
+            describe("onAction") {
+                GDPRActionType.allCases.forEach { type in
+                    it("calls the onAction on consent delegate for action of type \(type)") {
+                        messageWebViewController.onAction(GDPRAction(type: type))
+                        expect(mockConsentDelegate.isOnActionCalled).to(beTruthy())
+                    }
                 }
 
-                it("Test pmUrl is called and returns url") {
-                    let pmURL = messageWebViewController.pmUrl()
-                    expect(pmURL).notTo(beNil(), description: "Able to get pmUrl")
+                context("for action type PMCancel") {
+                    context("and the 2nd layer message is loaded") {
+                        beforeEach {
+                            messageWebViewController.isSecondLayerMessage = true
+                            messageWebViewController.onAction(GDPRAction(type: .PMCancel))
+                        }
+
+                        it("calls the onAction with an action of type PMCancel") {
+                            expect(mockConsentDelegate.onActionCalledWith.type).to(equal(.PMCancel))
+                        }
+
+                        it("sets the isSecondLayerMessage flag to false") {
+                            expect(messageWebViewController.isSecondLayerMessage).to(beFalse())
+                        }
+                    }
+
+                    context("and the 1st layer message is loaded") {
+                        it("calls the onAction with an action of type Dismiss") {
+                            messageWebViewController.isSecondLayerMessage = false
+                            messageWebViewController.onAction(GDPRAction(type: .PMCancel))
+                            expect(mockConsentDelegate.onActionCalledWith.type).to(equal(.Dismiss))
+                        }
+                    }
+                }
+
+                context("for action type ShowPrivacyManager") {
+                    it("calls gdprMessageDidDisappear on the consent delegate") {
+                        messageWebViewController.onAction(GDPRAction(type: .ShowPrivacyManager))
+                        expect(mockConsentDelegate.isMessageDidDisappearCalled).to(beTruthy())
+                    }
+
+                    it("sets the isSecondLayerMessage flag to true") {
+                        messageWebViewController.onAction(GDPRAction(type: .ShowPrivacyManager))
+                        expect(messageWebViewController.isSecondLayerMessage).to(beTruthy())
+                    }
+
+                    context("and there's internet connection") {
+                        it("loads the webview with the PM URL") {
+                            let webviewMock = WebViewMock()
+                            messageWebViewController.connectivityManager = ConnectivityMock(connected: true)
+                            messageWebViewController.webview = webviewMock
+                            messageWebViewController.onAction(GDPRAction(type: .ShowPrivacyManager))
+                            expect(webviewMock.loadCalledWith.url).to(equal(messageWebViewController.pmUrl()))
+                        }
+                    }
+
+                    context("and there's no internet connection") {
+                        it("calls the onError callback") {
+                            messageWebViewController.connectivityManager = ConnectivityMock(connected: false)
+                            messageWebViewController.onAction(GDPRAction(type: .ShowPrivacyManager))
+                            expect(mockConsentDelegate.isOnErrorCalled).to(beTruthy())
+                        }
+                    }
+                }
+
+                // all action types other than PMCancel and ShowPrivacyManager
+                GDPRActionType
+                    .allCases
+                    .filter { !($0 == .PMCancel || $0 == .ShowPrivacyManager) }
+                    .forEach { type in
+                    context("when the action type is \(type)") {
+                        context("and the consent UI is open") {
+                            it("calls consentUIDidDisappear on the consent delegate") {
+                                messageWebViewController.consentUILoaded = true
+                                messageWebViewController.onAction(GDPRAction(type: type))
+                                expect(mockConsentDelegate.isConsentUIDidDisappearCalled).to(beTruthy(), description: type.description)
+                            }
+                        }
+
+                        context("and the consent UI is not open") {
+                            it("calls consentUIDidDisappear on the consent delegate") {
+                                messageWebViewController.consentUILoaded = false
+                                messageWebViewController.onAction(GDPRAction(type: type))
+                                expect(mockConsentDelegate.isConsentUIDidDisappearCalled).to(beFalse())
+                            }
+                        }
+
+                        context("and the pm is loaded") {
+                            beforeEach {
+                                messageWebViewController.isPMLoaded = true
+                                messageWebViewController.onAction(GDPRAction(type: type))
+                            }
+
+                            it("sets the isPMLoaded to false") {
+                                expect(messageWebViewController.isPMLoaded).to(beFalse())
+                            }
+
+                            it("calls gdprPMDidDisappear on the consent delegate") {
+                                expect(mockConsentDelegate.isGdprPMDidDisappearCalled).to(beTruthy())
+                            }
+                        }
+
+                        context("and the pm is not loaded") {
+                            it("calls gdprMessageDidDisappear on the consent delegate") {
+                                messageWebViewController.isPMLoaded = false
+                                messageWebViewController.onAction(GDPRAction(type: type))
+                                expect(mockConsentDelegate.isMessageDidDisappearCalled).to(beTruthy())
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        // this method is used to test whether viewWillDisappear is called or not successfully
-        describe("Test viewWillDisappear methods") {
-            beforeEach {
-                messageWebViewController = self.getMessageWebViewController()
+        describe("loadMessage") {
+            context("when there's internet connection") {
+                it("loads the webview with the url received as param") {
+                    let webviewMock = WebViewMock()
+                    messageWebViewController.connectivityManager = ConnectivityMock(connected: true)
+                    messageWebViewController.webview = webviewMock
+                    let url = URL(string: "www.example.com")!
+                    messageWebViewController.loadMessage(fromUrl: url)
+                    expect(webviewMock.loadCalledWith.url).to(equal(url))
+                }
             }
+
+            context("when there's no internet connection") {
+                it("calls the onError callback") {
+                    messageWebViewController.connectivityManager = ConnectivityMock(connected: false)
+                    let url = URL(string: "www.example.com")!
+                    messageWebViewController.loadMessage(fromUrl: url)
+                    expect(mockConsentDelegate.isOnErrorCalled).to(beTruthy())
+                }
+            }
+        }
+
+        describe("loadPrivacyManager") {
+            context("when there's internet connection") {
+                it("loads the webview with the PM URL") {
+                    let webviewMock = WebViewMock()
+                    messageWebViewController.connectivityManager = ConnectivityMock(connected: true)
+                    messageWebViewController.webview = webviewMock
+                    messageWebViewController.loadPrivacyManager()
+                    expect(webviewMock.loadCalledWith.url).to(equal(messageWebViewController.pmUrl()))
+                }
+            }
+
+            context("when there's no internet connection") {
+                it("calls the onError callback") {
+                    messageWebViewController.connectivityManager = ConnectivityMock(connected: false)
+                    messageWebViewController.loadPrivacyManager()
+                    expect(mockConsentDelegate.isOnErrorCalled).to(beTruthy())
+                }
+            }
+        }
+
+        describe("pmURL") {
+            it("returns an url with propertyId, pmId and consentUUID") {
+                let pmUrl = URL(string: "https://notice.sp-prod.net/privacy-manager/index.html?message_id=pmId&site_id=1&consentUUID=uuid")
+                expect(messageWebViewController.pmUrl()).to(equal(pmUrl))
+            }
+        }
+
+        describe("Test viewWillDisappear methods") {
             it("Test MessageWebViewController calls viewWillDisappear method") {
                 messageWebViewController.viewWillDisappear(false)
                 expect(messageWebViewController.consentDelegate).to(beNil(), description: "ConsentDelegate gets cleared")

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SimpleClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SimpleClientSpec.swift
@@ -13,16 +13,6 @@ import Nimble
 
 // swiftlint:disable force_cast function_body_length
 
-class ConnectivityMock: Connectivity {
-    let isConnected: Bool
-    init(connected: Bool) {
-        isConnected = connected
-    }
-    func isConnectedToNetwork() -> Bool {
-        return isConnected
-    }
-}
-
 class URLSessionDataTaskMock: SPURLSessionDataTask {
     var resumeWasCalled = false
 

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
@@ -12,36 +12,6 @@ import Quick
 import Nimble
 @testable import ConsentViewController
 
-public class MockHttp: HttpClient {
-    var getWasCalledWithUrl: URL?
-    var postWasCalledWithUrl: URL?
-    var postWasCalledWithBody: Data?
-    var success: Data?
-    var error: Error?
-
-    init(success: Data?) {
-        self.success = success
-    }
-
-    init(error: Error?) {
-        self.error = error
-    }
-
-    public func get(url: URL?, completionHandler: @escaping CompletionHandler) {}
-
-    func request(_ urlRequest: URLRequest, _ completionHandler: @escaping CompletionHandler) {}
-
-    public func post(url: URL?, body: Data?, completionHandler: @escaping CompletionHandler) {
-        postWasCalledWithUrl = url?.absoluteURL
-        postWasCalledWithBody = body
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1), execute: {
-            self.success != nil ?
-                completionHandler(self.success!, nil) :
-                completionHandler(nil, APIParsingError(url!.absoluteString, self.error))
-        })
-    }
-}
-
 class SourcePointClientSpec: QuickSpec {
     static let propertyId = 123
 


### PR DESCRIPTION
Ensure `onConsentReady` is always called after every action with exception of:
1. `ShowPrivacyOptions`
2. `PMCancel` when in the 2nd layer message. 