### PR TITLE
Run UI tests on GitHub actions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: CocoaPod Install
         run: cd Example && pod install
-      - name: iOS build
-        run: xcodebuild build-for-testing -scheme ConsentViewController_ExampleTests -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.5'
       - name: testing -> iPhone 11 (iOS 13.5)
-        run: xcodebuild test-without-building -scheme ConsentViewController_ExampleTests -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.5'
+        run: xcodebuild test -scheme ConsentViewController_Example -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.5' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,4 +20,4 @@ jobs:
       - name: CocoaPod Install
         run: cd Example && pod install
       - name: testing -> iPhone 11 (iOS 13.5)
-        run: xcodebuild test -scheme ConsentViewController_Example -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.5' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+        run: xcodebuild test -scheme ConsentViewController_Example -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.5' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
@@ -28,7 +28,13 @@ class SourcePointClientSpec: QuickSpec {
     }
 
     override func spec() {
-        Nimble.AsyncDefaults.Timeout = 2
+        beforeSuite {
+            Nimble.AsyncDefaults.Timeout = 2
+        }
+
+        afterSuite {
+            Nimble.AsyncDefaults.Timeout = 1
+        }
 
         var client: SourcePointClient!
         var httpClient: MockHttp?
@@ -220,7 +226,7 @@ class SourcePointClientSpec: QuickSpec {
 
                 context("on failure") {
                     beforeEach {
-                        client = self.getClient(MockHttp(error: nil))
+                        client = self.getClient(MockHttp(error: APIParsingError("foo", nil)))
                     }
 
                     it("calls the completion handler with an GDPRConsentViewControllerError") {

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
@@ -28,13 +28,7 @@ class SourcePointClientSpec: QuickSpec {
     }
 
     override func spec() {
-        beforeSuite {
-            Nimble.AsyncDefaults.Timeout = 2
-        }
-
-        afterSuite {
-            Nimble.AsyncDefaults.Timeout = 1
-        }
+        Nimble.AsyncDefaults.Timeout = 2
 
         var client: SourcePointClient!
         var httpClient: MockHttp?

--- a/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
+++ b/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
@@ -10,11 +10,11 @@ import XCTest
 import Nimble
 
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
-/// a certain amount of time. 5 seconds by default
+/// a certain amount of time. 10 seconds by default
 public func showUp() -> Predicate<XCUIElement> {
     return Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-        return PredicateStatus(bool: actual.waitForExistence(timeout: 5))
+        return PredicateStatus(bool: actual.waitForExistence(timeout: 10))
     }
 }
 

--- a/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
+++ b/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import Nimble
+import Quick
 
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
 /// a certain amount of time. 10 seconds by default
@@ -32,6 +33,8 @@ public func showUp(in timeout: TimeInterval) -> Predicate<XCUIElement> {
 public func disappear() -> Predicate<XCUIElement> {
     return Predicate.simple("disappear") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
+        QuickSpec.current.expectation(for: NSPredicate(format: "exists == FALSE"), evaluatedWith: actual, handler: nil)
+        QuickSpec.current.waitForExpectations(timeout: 5.0, handler: nil)
         return PredicateStatus(bool: !actual.exists)
     }
 }

--- a/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
+++ b/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
@@ -20,6 +20,8 @@ class SPGDPRExampleAppUITests: QuickSpec {
             self.app = ExampleApp(XCUIApplication())
             self.app.launch()
             self.app.clearConsentButton.tap()
+            Nimble.AsyncDefaults.Timeout = 10
+            Nimble.AsyncDefaults.PollInterval = 1
         }
 
         afterSuite {
@@ -27,6 +29,8 @@ class SPGDPRExampleAppUITests: QuickSpec {
             /// This is a side effect. We need to "force" the UserDefaults to synchronise otherwise
             /// it won't store its in-memory values on the file system in time before closing the app.
             UserDefaults.standard.synchronize()
+            Nimble.AsyncDefaults.Timeout = 1
+            Nimble.AsyncDefaults.PollInterval = 0.01
         }
 
         describe("SPGDPRExampleAppUITests") {

--- a/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
+++ b/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
@@ -41,11 +41,11 @@ class SPGDPRExampleAppUITests: QuickSpec {
 
                 it("2. have the message disappear after rejecting all") {
                     self.app.rejectAllButton.tap()
-                    expect(self.app.consentMessage).toEventually(disappear())
+                    expect(self.app.consentMessage).to(disappear())
                 }
 
                 it("3. vendor x should be 'Rejected'") {
-                    expect(self.app.vendorXConsentStatus).to(equal("Rejected"))
+                    expect(self.app.vendorXConsentStatus).toEventually(equal("Rejected"))
                 }
 
                 it("4. have the vendor x 'Accepted' after tapping on Accept Vendor X button") {
@@ -60,7 +60,7 @@ class SPGDPRExampleAppUITests: QuickSpec {
 
                 it("6. the vendor x 'Rejected' after tapping on Clear Consents button") {
                     self.app.clearConsentButton.tap()
-                    expect(self.app.vendorXConsentStatus).to(equal("Rejected"))
+                    expect(self.app.vendorXConsentStatus).toEventually(equal("Rejected"))
                 }
 
                 it("7. the Privacy Manager should open when taping on Privacy Settings button") {
@@ -70,7 +70,7 @@ class SPGDPRExampleAppUITests: QuickSpec {
 
                 it("8. the Privacy Manager should close after tapping on Accept All") {
                     self.app.acceptAllButton.tap()
-                    expect(self.app.privacyManager).toEventually(disappear())
+                    expect(self.app.privacyManager).to(disappear())
                 }
 
                 it("9. have the vendor x 'Accepted'") {


### PR DESCRIPTION
This PR:
* fixes a failing unit test
* increases UI timeout threshold from 5 to 10 seconds
* refactors the custom matcher `disappear` to avoid "random" failures when running ui tests from the command line.

Once this PR is merged we'll have UI tests running on GitHub 🎉 