### PR TITLE
Fix issue when GDPRMessage didn't have all its fields present when JSON encoded

### DIFF
--- a/ConsentViewController/Classes/GDPRMessage.swift
+++ b/ConsentViewController/Classes/GDPRMessage.swift
@@ -56,6 +56,14 @@ public typealias CustomFields = [String: String]
         )
     }
 
+    public override func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(choiceId, forKey: .choiceId)
+        try container.encode(choiceType, forKey: .choiceType)
+    }
+
     enum CodingKeys: String, CodingKey {
         case text, style, customFields, choiceId, choiceType
     }

--- a/Example/ConsentViewController_ExampleTests/GDPRMessageSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRMessageSpec.swift
@@ -44,6 +44,38 @@ class GDPRMessageSpec: QuickSpec {
             it("Test GDPRMessage method") {
                 expect(gdprMessage?.title.style.color).to(equal("#00FA9A"))
             }
+
+            context("Test JSON Encoding") {
+                var actual: GDPRMessage?
+                beforeEach {
+                    guard let data = try? JSONEncoder().encode(gdprMessage) else {
+                                      fail("Failed to encode \(String(describing: GDPRMessage.self))")
+                                      return
+                                  }
+
+                    actual = try? JSONDecoder().decode(GDPRMessage.self, from: data)
+                }
+
+                it("has matching title text") {
+                    expect(actual?.title.text).to(equal(gdprMessage?.title.text))
+                }
+
+                it("has matching body text") {
+                    expect(actual?.body.text).to(equal(gdprMessage?.body.text))
+                }
+
+                it("has matching action choice type") {
+                    expect(actual?.actions.first?.choiceType).to(equal(gdprMessage?.actions.first?.choiceType))
+                }
+
+                it("has matching action choice id") {
+                    expect(actual?.actions.first?.choiceId).to(equal(gdprMessage?.actions.first?.choiceId))
+                }
+
+                it("has matching action custom fields") {
+                    expect(actual?.customFields).to(equal(gdprMessage?.customFields))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Context 
This PR fixes an issue when `GDPRMessage` -> `JSON` encoding produced a JSON without `choiceType` and `choiceId` fields for the `MessageAttributeAction` objects. 

## Affected Functionality 
- `GDPRMessage` JSON Encoding 
