### PR TITLE
#229 Make sure that SDK calls onError delegate when webView fails to load url

### DIFF
--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -211,8 +211,13 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        if let error = error as? URLError, error.code == .timedOut {
-            onError(error: MessageTimeout(url: error.failingURL, timeout: timeout))
+        if let error = error as? URLError {
+            switch error.code {
+            case .timedOut:
+                onError(error: MessageTimeout(url: error.failingURL, timeout: timeout))
+            default:
+                onError(error: WebViewError(code: error.code.rawValue, title: error.localizedDescription))
+            }
         }
     }
 

--- a/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
@@ -339,6 +339,20 @@ class MessageWebViewControllerSpec: QuickSpec, GDPRConsentDelegate, WKNavigation
                     expect(mockConsentDelegate.isOnErrorCalled).to(beTruthy())
                 }
             }
+
+            context("when there's internet connect but load of message fails with bad server response") {
+                it("call the onError callback") {
+                    let webView = WKWebView()
+                    messageWebViewController.connectivityManager = ConnectivityMock(connected: true)
+                    messageWebViewController.webview = webView
+                    let navigation = webView.load(URLRequest(url: URL(string: "www.example.com")!))
+
+                    let error = URLError(.badServerResponse)
+                    messageWebViewController.webView(webView, didFailProvisionalNavigation: navigation, withError: error)
+
+                    expect(mockConsentDelegate.isOnErrorCalled).to(beTruthy())
+                }
+            }
         }
 
         describe("loadPrivacyManager") {


### PR DESCRIPTION
This PR fixes the following issue https://github.com/SourcePointUSA/ios-cmp-app/issues/229 