### PR TITLE
[SP-4113] implement publisherData on GDPRAction class

### DIFF
--- a/ConsentViewController/Classes/GDPRAction.swift
+++ b/ConsentViewController/Classes/GDPRAction.swift
@@ -34,9 +34,10 @@ import Foundation
     public let type: GDPRActionType
     public let id: String?
     public let payload: Data
+    public var publisherData: [String: SPGDPRArbitraryJson?]?
 
     public override var description: String {
-          "GDPRAction(type: \(type), id: \(id ?? ""), payload: \(String(data: payload, encoding: .utf8) ?? "")"
+        "GDPRAction(type: \(type), id: \(id ?? ""), payload: \(String(data: payload, encoding: .utf8) ?? ""), publisherData: \(String(describing: publisherData))"
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
@@ -45,7 +46,8 @@ import Foundation
         }
         return other.type == type &&
             other.id == id &&
-            other.payload == payload
+            other.payload == payload &&
+            other.publisherData == publisherData
     }
 
     public init(type: GDPRActionType, id: String? = nil, payload: Data = "{}".data(using: .utf8)!) {

--- a/ConsentViewController/Classes/GDPRAction.swift
+++ b/ConsentViewController/Classes/GDPRAction.swift
@@ -34,7 +34,7 @@ import Foundation
     public let type: GDPRActionType
     public let id: String?
     public let payload: Data
-    public var publisherData: [String: SPGDPRArbitraryJson?]?
+    public var publisherData: [String: SPGDPRArbitraryJson?] = [:]
 
     public override var description: String {
         "GDPRAction(type: \(type), id: \(id ?? ""), payload: \(String(data: payload, encoding: .utf8) ?? ""), publisherData: \(String(describing: publisherData))"

--- a/ConsentViewController/Classes/SPGDPRArbitraryJson.swift
+++ b/ConsentViewController/Classes/SPGDPRArbitraryJson.swift
@@ -197,7 +197,7 @@ public enum SPGDPRArbitraryJson: Codable, CustomStringConvertible, Equatable {
     }
 }
 
-extension SPGDPRArbitraryJson {
+public extension SPGDPRArbitraryJson {
     init(_ value: Any) throws {
         if let string = value as? String { self = .string(string) } else if let number = value as? NSNumber {
             switch CFGetTypeID(number as CFTypeRef) {

--- a/ConsentViewController/Classes/SourcePointClient/ActionRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ActionRequestResponse.swift
@@ -17,6 +17,12 @@ struct ActionRequest: Codable, Equatable {
     let requestUUID: UUID
     let pmSaveAndExitVariables: SPGDPRArbitraryJson
     let meta: Meta
+    let publisherData: [String: SPGDPRArbitraryJson?]?
+
+    enum CodingKeys: String, CodingKey {
+        case propertyId, propertyHref, accountId, actionType, choiceId, privacyManagerId, requestFromPM, uuid, requestUUID, pmSaveAndExitVariables, meta
+        case publisherData = "pubData"
+    }
 }
 
 struct ActionResponse: Codable {

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -181,7 +181,8 @@ class SourcePointClient: SourcePointProtocol {
                 uuid: consentUUID,
                 requestUUID: requestUUID,
                 pmSaveAndExitVariables: pmPayload,
-                meta: meta
+                meta: meta,
+                publisherData: action.publisherData
             )) else {
                 completionHandler(nil, APIParsingError(url.absoluteString, nil))
                 return

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		82EA4E362491328A00DC01C9 /* InMemoryStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */; };
 		82EA4FA42488EB7300BA48BF /* GDPRUserDefaultsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82ACF6AB2487E73C006E207A /* GDPRUserDefaultsSpec.swift */; };
 		82EA4FA62489171200BA48BF /* GDPRLocalStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4FA52489171200BA48BF /* GDPRLocalStorageSpec.swift */; };
+		82F8B1AA24EBC7560055F430 /* ActionRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F8B1A924EBC7560055F430 /* ActionRequestSpec.swift */; };
 		82F9411824A10379007D30B1 /* CustomMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F9411724A10379007D30B1 /* CustomMatchers.swift */; };
 		82F9411A24A10416007D30B1 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F9411924A10416007D30B1 /* ExampleApp.swift */; };
 		9DC3F61E36BDC23B604C7050 /* Pods_NativeMessageExampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 10E13DDF8ED9430133DBA078 /* Pods_NativeMessageExampleUITests.framework */; };
@@ -273,6 +274,7 @@
 		8277C33B22BBD22C00F1607F /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		82813A69248A69F000521571 /* GDPRCampaignEnvSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRCampaignEnvSpec.swift; sourceTree = "<group>"; };
 		82ACF6AB2487E73C006E207A /* GDPRUserDefaultsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRUserDefaultsSpec.swift; sourceTree = "<group>"; };
+		82CC8B8224F6680600D94AA7 /* SPGDPRExampleAppDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SPGDPRExampleAppDebug.entitlements; sourceTree = "<group>"; };
 		82CC8CD724ACF6970030B28B /* MessageRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRequestSpec.swift; sourceTree = "<group>"; };
 		82D8FEDC23DC753400F28D74 /* NativeMessageExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NativeMessageExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		82D8FEDE23DC753400F28D74 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 		82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GDPRLocalStorageMock.swift; path = Helpers/GDPRLocalStorageMock.swift; sourceTree = "<group>"; };
 		82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InMemoryStorageMock.swift; path = Helpers/InMemoryStorageMock.swift; sourceTree = "<group>"; };
 		82EA4FA52489171200BA48BF /* GDPRLocalStorageSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRLocalStorageSpec.swift; sourceTree = "<group>"; };
+		82F8B1A924EBC7560055F430 /* ActionRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionRequestSpec.swift; sourceTree = "<group>"; };
 		82F9411724A10379007D30B1 /* CustomMatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMatchers.swift; sourceTree = "<group>"; };
 		82F9411924A10416007D30B1 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 		82FC4D3A23983231002F08E5 /* ConsentViewController_ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ConsentViewController_ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -730,6 +733,7 @@
 		607FACC71AFB9204008FA782 = {
 			isa = PBXGroup;
 			children = (
+				82CC8B8224F6680600D94AA7 /* SPGDPRExampleAppDebug.entitlements */,
 				607FACF51AFB993E008FA782 /* Podspec Metadata */,
 				607FACD21AFB9204008FA782 /* Example for ConsentViewController */,
 				82D8FEDD23DC753400F28D74 /* NativeMessageExample */,
@@ -959,6 +963,7 @@
 				8248A498247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift */,
 				82813A69248A69F000521571 /* GDPRCampaignEnvSpec.swift */,
 				82CC8CD724ACF6970030B28B /* MessageRequestSpec.swift */,
+				82F8B1A924EBC7560055F430 /* ActionRequestSpec.swift */,
 			);
 			path = ConsentViewController_ExampleTests;
 			sourceTree = "<group>";
@@ -1871,6 +1876,7 @@
 				6D605DF42423523700BB3E5F /* GDPRMessageViewControllerSpec.swift in Sources */,
 				826D31AD2498DE340026A6B9 /* MockConsentDelegate.swift in Sources */,
 				8248A499247E5FCC00A7D9AD /* GDPRUserConsentsSpec.swift in Sources */,
+				82F8B1AA24EBC7560055F430 /* ActionRequestSpec.swift in Sources */,
 				6D687AD724A8F1C1001DFB11 /* MessageMock.swift in Sources */,
 				82665C312444ECF600CCE738 /* SPGDPRArbitraryJsonSpec.swift in Sources */,
 				82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */,
@@ -2215,6 +2221,7 @@
 			baseConfigurationReference = 90A0A3C27697E730D7630402 /* Pods-ConsentViewController_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = SPGDPRExampleAppDebug.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Vilas Mane (MRXLYP9499)";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 6KYEQLUC5A;

--- a/Example/ConsentViewController_ExampleTests/ActionRequestSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/ActionRequestSpec.swift
@@ -1,0 +1,64 @@
+//
+//  ActionRequest.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 18.08.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import ConsentViewController
+
+// swiftlint:disable force_try function_body_length
+
+class ActionRequestSpec: QuickSpec {
+    override func spec() {
+        let requestUUID = UUID()
+        let action = ActionRequest(
+            propertyId: 1,
+            propertyHref: try! GDPRPropertyName("property-name"),
+            accountId: 1,
+            actionType: 1,
+            choiceId: "choiceId",
+            privacyManagerId: "pmId",
+            requestFromPM: false,
+            uuid: "consentUUID",
+            requestUUID: requestUUID,
+            pmSaveAndExitVariables: try! SPGDPRArbitraryJson(["foo": "bar"]),
+            meta: "meta",
+            publisherData: try! ["pubFoo": SPGDPRArbitraryJson("pubBar")]
+        )
+        let actionString = """
+        {
+            "pmSaveAndExitVariables": {
+                "foo": "bar"
+            },
+            "uuid": "consentUUID",
+            "privacyManagerId": "pmId",
+            "choiceId": "choiceId",
+            "requestFromPM": false,
+            "accountId": 1,
+            "actionType": 1,
+            "requestUUID": "\(requestUUID.uuidString)",
+            "meta": "meta",
+            "propertyId": 1,
+            "propertyHref": "https:\\/\\/property-name",
+            "pubData": {
+                "pubFoo": "pubBar"
+            }
+        }
+        """.filter { !" \n\t\r".contains($0) }
+
+        it("can be encoded to JSON") {
+            let actionEncoded = String(data: try! JSONEncoder().encode(action), encoding: .utf8)
+            expect(actionString).to(equal(actionEncoded))
+        }
+
+        it("can be decoded from JSON") {
+            let actionDecoded = try! JSONDecoder()
+                .decode(ActionRequest.self, from: actionString.data(using: .utf8)!)
+            expect(action).to(equal(actionDecoded))
+        }
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/GDPRActionSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRActionSpec.swift
@@ -16,6 +16,10 @@ import Nimble
 class GDPRActionSpec: QuickSpec {
     override func spec() {
         describe("GDPRAction") {
+            it("publisherData is set to empty dictionary by default") {
+                expect(GDPRAction(type: .AcceptAll).publisherData).to(equal([:]))
+            }
+
             describe("init") {
                 it("initialises type, id and payload") {
                     let payload = "".data(using: .utf8)!

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
@@ -130,6 +130,7 @@ class SourcePointClientSpec: QuickSpec {
 
                 it("calls POST on the http client with the right body") {
                     let action = GDPRAction(type: .AcceptAll, id: "1234")
+                    action.publisherData = ["foo": try? SPGDPRArbitraryJson("bar")]
                     let actionRequest = ActionRequest(
                         propertyId: client.propertyId,
                         propertyHref: client.propertyName,
@@ -141,7 +142,9 @@ class SourcePointClientSpec: QuickSpec {
                         uuid: "uuid",
                         requestUUID: client.requestUUID,
                         pmSaveAndExitVariables: SPGDPRArbitraryJson(),
-                        meta: "meta")
+                        meta: "meta",
+                        publisherData: action.publisherData
+                    )
                     client.postAction(
                         action: action,
                         consentUUID: "uuid",


### PR DESCRIPTION
The publisher can now add their own arbitrary data to the action payload. 
```swift
// GDPRConsentDelegate
    func onAction(_ action: GDPRAction) {
        action.publisherData = ["my data": try? SPGDPRArbitraryJson("foo bar")]
    }
```
This will be encoded into:
```json
{
  ...,
  "pubData": {
     "my data": "foo bar"
  }
}
```
and sent to our endpoints / logs. Where it can then be retrieved via APIs. 
