### PR TITLE
Swift Package Manager Support for SPM 5.3+ 

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ConsentViewController/Classes/Bundle+Framework.swift
+++ b/ConsentViewController/Classes/Bundle+Framework.swift
@@ -1,5 +1,5 @@
 //
-//  Bundle+Framwork.swift
+//  Bundle+Framework.swift
 //  
 //
 //  Created by Ivan Lisovyi on 27.09.20.

--- a/ConsentViewController/Classes/Bundle+Framework.swift
+++ b/ConsentViewController/Classes/Bundle+Framework.swift
@@ -1,0 +1,19 @@
+//
+//  Bundle+Framwork.swift
+//  
+//
+//  Created by Ivan Lisovyi on 27.09.20.
+//
+
+import class Foundation.Bundle
+
+extension Foundation.Bundle {
+    /// Returns the resource bundle associated with the current Swift module.
+    static var framework: Bundle = {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: GDPRConsentViewController.self)
+        #endif
+    }()
+}

--- a/ConsentViewController/Classes/GDPRNativeMessageViewController.swift
+++ b/ConsentViewController/Classes/GDPRNativeMessageViewController.swift
@@ -34,7 +34,7 @@ import UIKit
     public init(messageContents: GDPRMessage, consentViewController: GDPRMessageUIDelegate) {
         message = messageContents
         self.consentViewController = consentViewController
-        super.init(nibName: "GDPRNativeMessageViewController", bundle: Bundle.init(for: GDPRNativeMessageViewController.self))
+        super.init(nibName: "GDPRNativeMessageViewController", bundle: Bundle.framework)
     }
 
     public required init?(coder: NSCoder) {

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -19,10 +19,8 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
     lazy var webview: WKWebView? = {
         let config = WKWebViewConfiguration()
         let userContentController = WKUserContentController()
-        guard let scriptSource = try? String(
-            contentsOfFile: Bundle(for: GDPRConsentViewController.self).path(forResource:
-                MessageWebViewController.MESSAGE_HANDLER_NAME, ofType: "js")!)
-            else {
+        guard let path = Bundle.framework.path(forResource: Self.MESSAGE_HANDLER_NAME, ofType: "js"),
+              let scriptSource = try? String(contentsOfFile: path) else {
             consentDelegate?.onError?(error: UnableToLoadJSReceiver())
             return nil
         }

--- a/ConsentViewController/Classes/SourcePointClient/ActionRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ActionRequestResponse.swift
@@ -5,6 +5,8 @@
 //  Created by Andre Herculano on 03.07.20.
 //
 
+import Foundation
+
 struct ActionRequest: Codable, Equatable {
     let propertyId: Int
     let propertyHref: GDPRPropertyName

--- a/ConsentViewController/Classes/SourcePointClient/MessageRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MessageRequestResponse.swift
@@ -5,6 +5,8 @@
 //  Created by Andre Herculano on 03.07.20.
 //
 
+import Foundation
+
 struct MessageRequest: Equatable {
     let uuid: GDPRUUID?
     let euconsent: String

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ConsentViewController (5.2.5)
+  - ConsentViewController (5.2.8)
   - IQKeyboardManagerSwift (6.5.5)
   - Nimble (8.0.7)
   - Quick (2.2.0)
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ConsentViewController: 8cdf4b9c2fa0cae0a186fa90ac64325757424d82
+  ConsentViewController: 3a3c60dfddbb441aa11521579f49d0ee5666ff10
   IQKeyboardManagerSwift: 0fb93310284665245591f50f7a5e38de615960b7
   Nimble: a73af6ecd4c9106f434f3d55fc54570be3739e0b
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e

--- a/Example/Pods/Local Podspecs/ConsentViewController.podspec.json
+++ b/Example/Pods/Local Podspecs/ConsentViewController.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ConsentViewController",
-  "version": "5.2.5",
+  "version": "5.2.8",
   "summary": "SourcePoint's ConsentViewController to handle privacy consents.",
   "homepage": "https://www.sourcepoint.com",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/SourcePointUSA/ios-cmp-app.git",
-    "tag": "5.2.5"
+    "tag": "5.2.8"
   },
   "swift_versions": "5.0",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ConsentViewController (5.2.5)
+  - ConsentViewController (5.2.8)
   - IQKeyboardManagerSwift (6.5.5)
   - Nimble (8.0.7)
   - Quick (2.2.0)
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ConsentViewController: 8cdf4b9c2fa0cae0a186fa90ac64325757424d82
+  ConsentViewController: 3a3c60dfddbb441aa11521579f49d0ee5666ff10
   IQKeyboardManagerSwift: 0fb93310284665245591f50f7a5e38de615960b7
   Nimble: a73af6ecd4c9106f434f3d55fc54570be3739e0b
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e

--- a/Example/Pods/Target Support Files/ConsentViewController/ConsentViewController-Info.plist
+++ b/Example/Pods/Target Support Files/ConsentViewController/ConsentViewController-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>5.2.5</string>
+  <string>5.2.8</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/ConsentViewController/ResourceBundle-ConsentViewController-ConsentViewController-Info.plist
+++ b/Example/Pods/Target Support Files/ConsentViewController/ResourceBundle-ConsentViewController-ConsentViewController-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>5.2.5</string>
+  <string>5.2.8</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+  name: "ConsentViewController",
+  platforms: [
+    .iOS(.v10)
+  ],
+  products: [
+    .library(
+      name: "ConsentViewController",
+      targets: ["ConsentViewController"]),
+  ],
+  dependencies: [],
+  targets: [
+    .target(
+      name: "ConsentViewController",
+      dependencies: [],
+      path: "ConsentViewController",
+      resources: [
+        .copy("Assets/GDPRJSReceiver.js")
+      ]
+    )
+  ],
+  swiftLanguageVersions: [.v5]
+)
+


### PR DESCRIPTION
## Context 
This PR adds a proper SPM support to the library. Supersedes #213 

## Changes 
- Add `Package.swift` 
- Copy `.js` resource from Assets folder into package bundle in `Package.swift`
- Add a new extension to return the bundle depending on the installation method (e.g. SPM or Cocoapods/Carthage). See `Bundle+Framework.swift`.
- Run pod install on Example project to use a new framework version 

## Testing 
- This changes has been tested using `NativeConsentExample` and `ConsentViewController_Example` for both SPM and Cocoapods installation methods. 

