### PR TITLE
[SP-5244] Add support for consent language

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: CocoaPod Install
         run: cd Example && pod install
-      - name: Example app Unit and UI testing -> iPhone 11 (iOS 13.7)
-        run: xcodebuild test -scheme ConsentViewController_Example -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.7' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
-      - name: NativeMessage UI testing -> iPhone 11 (iOS 13.7)
-        run: xcodebuild test -scheme NativeMessageExample -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.7' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
-      - name: SourcePointMetaApp UI testing -> iPhone 11 (iOS 13.7)
-        run: xcodebuild test -scheme SourcePointMetaApp -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.7' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+      - name: Example app Unit and UI testing -> iPhone 11 (iOS 14.0)
+        run: xcodebuild test -scheme ConsentViewController_Example -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.0' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+      - name: NativeMessage UI testing -> iPhone 11 (iOS 14.0)
+        run: xcodebuild test -scheme NativeMessageExample -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.0' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+      - name: SourcePointMetaApp UI testing -> iPhone 11 (iOS 14.0)
+        run: xcodebuild test -scheme SourcePointMetaApp -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.0' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
 

--- a/ConsentViewController/Assets/GDPRJSReceiver.js
+++ b/ConsentViewController/Assets/GDPRJSReceiver.js
@@ -25,15 +25,16 @@
     };
   }(postToWebView);
 
-  var getActionFromMessage = function (actions) {
-    var choiceAction = actions.filter(function (action) {
+  var getActionFromMessage = function (eventData) {
+    var choiceAction = eventData.payload.filter(function (action) {
       return action.type === 'choice';
     })[0] || {};
     var choiceData = choiceAction.data || {};
     return {
       id: String(choiceData.choice_id),
       type: choiceData.type,
-      payload: { pm_url: choiceData.iframe_url }
+      payload: { pm_url: choiceData.iframe_url },
+      consentLanguage : eventData.consentLanguage
     };
   };
 
@@ -45,8 +46,8 @@
           break;
         case "sp.hideMessage":
           eventData.fromPM ?
-            SDK.onAction({ type: eventData.actionType, payload: eventData.payload }) :
-            SDK.onAction(getActionFromMessage(eventData.payload));
+            SDK.onAction({ type: eventData.actionType, payload: eventData.payload, consentLanguage: eventData.consentLanguage }) :
+            SDK.onAction(getActionFromMessage(eventData));
           break;
         default:
           eventData.payload.action = eventData.name;
@@ -81,7 +82,8 @@
               name: event.name,
               fromPM: isFromPM(event),
               actionType: event.actionType,
-              payload: event.payload || event.actions || {}
+              payload: event.payload || event.actions || {},
+              consentLanguage: event.consentLanguage
             });
       } catch (error) {
         SDK.onError(error);

--- a/ConsentViewController/Classes/GDPRAction.swift
+++ b/ConsentViewController/Classes/GDPRAction.swift
@@ -33,7 +33,7 @@ import Foundation
 @objcMembers public class GDPRAction: NSObject {
     public let type: GDPRActionType
     public let id: String?
-    public var consentLanguage: String?
+    public let consentLanguage: String?
     public let payload: Data
     public var publisherData: [String: SPGDPRArbitraryJson?] = [:]
 

--- a/ConsentViewController/Classes/GDPRAction.swift
+++ b/ConsentViewController/Classes/GDPRAction.swift
@@ -33,11 +33,15 @@ import Foundation
 @objcMembers public class GDPRAction: NSObject {
     public let type: GDPRActionType
     public let id: String?
+    public let consentLanguage: String?
     public let payload: Data
     public var publisherData: [String: SPGDPRArbitraryJson?] = [:]
 
     public override var description: String {
-        "GDPRAction(type: \(type), id: \(id ?? ""), payload: \(String(data: payload, encoding: .utf8) ?? ""), publisherData: \(String(describing: publisherData))"
+        """
+        GDPRAction(type: \(type), id: \(id ?? ""), consentLanguage: \(consentLanguage ?? ""), \
+        payload: \(String(data: payload, encoding: .utf8) ?? ""), publisherData: \(String(describing: publisherData))
+        """
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
@@ -46,13 +50,15 @@ import Foundation
         }
         return other.type == type &&
             other.id == id &&
+            other.consentLanguage == consentLanguage &&
             other.payload == payload &&
             other.publisherData == publisherData
     }
 
-    public init(type: GDPRActionType, id: String? = nil, payload: Data = "{}".data(using: .utf8)!) {
+    public init(type: GDPRActionType, id: String? = nil, consentLanguage: String? = nil, payload: Data = "{}".data(using: .utf8)!) {
         self.type = type
         self.id = id
+        self.consentLanguage = consentLanguage
         self.payload = payload
     }
 }

--- a/ConsentViewController/Classes/GDPRAction.swift
+++ b/ConsentViewController/Classes/GDPRAction.swift
@@ -33,7 +33,7 @@ import Foundation
 @objcMembers public class GDPRAction: NSObject {
     public let type: GDPRActionType
     public let id: String?
-    public let consentLanguage: String?
+    public var consentLanguage: String?
     public let payload: Data
     public var publisherData: [String: SPGDPRArbitraryJson?] = [:]
 

--- a/ConsentViewController/Classes/GDPRNativeMessageViewController.swift
+++ b/ConsentViewController/Classes/GDPRNativeMessageViewController.swift
@@ -86,7 +86,7 @@ import UIKit
 
     func action(_ action: GDPRActionType) {
         if let messageAction = message.actions.first(where: { message in message.choiceType == action }) {
-            let action = GDPRAction(type: messageAction.choiceType, id: String(messageAction.choiceId))
+            let action = GDPRAction(type: messageAction.choiceType, id: String(messageAction.choiceId), consentLanguage: Locale.preferredLanguages[0].uppercased())
             consentViewController.consentDelegate?.onAction?(action)
         }
     }

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -170,7 +170,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
             showPrivacyManagerFromMessageAction()
         case .PMCancel:
             consentDelegate?.onAction?(
-                GDPRAction(type: isSecondLayerMessage ? .PMCancel : .Dismiss, id: action.id, payload: action.payload)
+                GDPRAction(type: isSecondLayerMessage ? .PMCancel : .Dismiss, id: action.id, consentLanguage: action.consentLanguage, payload: action.payload)
             )
             cancelPMAction()
         default:
@@ -249,6 +249,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
         case "onAction":
             guard
                 let payload = body["body"] as? [String: Any],
+                let consentLanguage = payload["consentLanguage"] as? String,
                 let typeString = payload["type"] as? Int,
                 let actionPayload = payload["payload"] as? [String: Any],
                 let actionJson = try? SPGDPRArbitraryJson(actionPayload),
@@ -258,7 +259,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
                 onError(error: MessageEventParsingError(message: Optional(message.body).debugDescription))
                 return
             }
-            onAction(GDPRAction(type: actionType, id: payload["id"] as? String, payload: payloadData))
+            onAction(GDPRAction(type: actionType, id: payload["id"] as? String, consentLanguage: consentLanguage, payload: payloadData))
         case "onError":
             let payload = body["body"] as? [String: Any] ?? [:]
             let error = payload["error"] as? [String: Any] ?? [:]

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -249,7 +249,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
         case "onAction":
             guard
                 let payload = body["body"] as? [String: Any],
-                let consentLanguage = payload["consentLanguage"] as? String,
+                let consentLanguage = payload["consentLanguage"] as? String ?? "",
                 let typeString = payload["type"] as? Int,
                 let actionPayload = payload["payload"] as? [String: Any],
                 let actionJson = try? SPGDPRArbitraryJson(actionPayload),

--- a/ConsentViewController/Classes/SourcePointClient/ActionRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ActionRequestResponse.swift
@@ -20,9 +20,10 @@ struct ActionRequest: Codable, Equatable {
     let pmSaveAndExitVariables: SPGDPRArbitraryJson
     let meta: Meta
     let publisherData: [String: SPGDPRArbitraryJson?]?
+    let consentLanguage: String?
 
     enum CodingKeys: String, CodingKey {
-        case propertyId, propertyHref, accountId, actionType, choiceId, privacyManagerId, requestFromPM, uuid, requestUUID, pmSaveAndExitVariables, meta
+        case propertyId, propertyHref, accountId, actionType, choiceId, privacyManagerId, requestFromPM, uuid, requestUUID, pmSaveAndExitVariables, meta, consentLanguage
         case publisherData = "pubData"
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -182,7 +182,9 @@ class SourcePointClient: SourcePointProtocol {
                 requestUUID: requestUUID,
                 pmSaveAndExitVariables: pmPayload,
                 meta: meta,
-                publisherData: action.publisherData
+                publisherData: action.publisherData,
+                consentLanguage: (action.consentLanguage != nil) ?
+                    action.consentLanguage : Locale.preferredLanguages[0].uppercased()
             )) else {
                 completionHandler(nil, APIParsingError(url.absoluteString, nil))
                 return

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -183,8 +183,7 @@ class SourcePointClient: SourcePointProtocol {
                 pmSaveAndExitVariables: pmPayload,
                 meta: meta,
                 publisherData: action.publisherData,
-                consentLanguage: (action.consentLanguage != nil) ?
-                    action.consentLanguage : Locale.preferredLanguages[0].uppercased()
+                consentLanguage: action.consentLanguage
             )) else {
                 completionHandler(nil, APIParsingError(url.absoluteString, nil))
                 return

--- a/Example/ConsentViewController_ExampleTests/ActionRequestSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/ActionRequestSpec.swift
@@ -27,7 +27,8 @@ class ActionRequestSpec: QuickSpec {
             requestUUID: requestUUID,
             pmSaveAndExitVariables: try! SPGDPRArbitraryJson(["foo": "bar"]),
             meta: "meta",
-            publisherData: try! ["pubFoo": SPGDPRArbitraryJson("pubBar")]
+            publisherData: try! ["pubFoo": SPGDPRArbitraryJson("pubBar")],
+            consentLanguage: "EN"
         )
         let actionString = """
         {
@@ -35,6 +36,7 @@ class ActionRequestSpec: QuickSpec {
                 "foo": "bar"
             },
             "uuid": "consentUUID",
+            "consentLanguage":"EN",
             "privacyManagerId": "pmId",
             "choiceId": "choiceId",
             "requestFromPM": false,

--- a/Example/ConsentViewController_ExampleTests/GDPRActionSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRActionSpec.swift
@@ -15,6 +15,7 @@ import Nimble
 
 class GDPRActionSpec: QuickSpec {
     override func spec() {
+
         describe("GDPRAction") {
             it("publisherData is set to empty dictionary by default") {
                 expect(GDPRAction(type: .AcceptAll).publisherData).to(equal([:]))
@@ -25,11 +26,13 @@ class GDPRActionSpec: QuickSpec {
                     let payload = "".data(using: .utf8)!
                     let type = GDPRActionType.AcceptAll
                     let id = "something"
-                    let action = GDPRAction(type: .AcceptAll, id: "something", payload: payload)
+                    let consentLanguage = "EN"
+                    let action = GDPRAction(type: .AcceptAll, id: "something", consentLanguage: "EN", payload: payload)
 
                     expect(action.type).to(equal(type))
                     expect(action.id).to(equal(id))
                     expect(action.payload).to(equal(payload))
+                    expect(action.consentLanguage).to(equal(consentLanguage))
                 }
 
                 it("initialises id to nil by default") {
@@ -40,6 +43,11 @@ class GDPRActionSpec: QuickSpec {
                 it("initialises data to data encoded \"{}\" by default") {
                     let action = GDPRAction(type: .AcceptAll)
                     expect(action.payload).to(equal("{}".data(using: .utf8)))
+                }
+
+                it("initialises consentLanguage to nil by default") {
+                    let action = GDPRAction(type: .AcceptAll)
+                    expect(action.consentLanguage).to(beNil())
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
@@ -129,7 +129,7 @@ class SourcePointClientSpec: QuickSpec {
                 }
 
                 it("calls POST on the http client with the right body") {
-                    let action = GDPRAction(type: .AcceptAll, id: "1234")
+                    let action = GDPRAction(type: .AcceptAll, id: "1234", consentLanguage: "EN")
                     action.publisherData = ["foo": try? SPGDPRArbitraryJson("bar")]
                     let actionRequest = ActionRequest(
                         propertyId: client.propertyId,
@@ -143,7 +143,8 @@ class SourcePointClientSpec: QuickSpec {
                         requestUUID: client.requestUUID,
                         pmSaveAndExitVariables: SPGDPRArbitraryJson(),
                         meta: "meta",
-                        publisherData: action.publisherData
+                        publisherData: action.publisherData,
+                        consentLanguage: "EN"
                     )
                     client.postAction(
                         action: action,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -2224,7 +2224,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/Nimble/Nimble-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2314,7 +2314,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2426,7 +2426,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2649,7 +2649,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/Quick/Quick-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/Quick/Quick-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/Quick/Quick.modulemap";
 				PRODUCT_MODULE_NAME = Quick;
@@ -2680,7 +2680,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/IQKeyboardManagerSwift/IQKeyboardManagerSwift-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/IQKeyboardManagerSwift/IQKeyboardManagerSwift-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/IQKeyboardManagerSwift/IQKeyboardManagerSwift.modulemap";
 				PRODUCT_MODULE_NAME = IQKeyboardManagerSwift;
@@ -2778,7 +2778,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/Quick/Quick-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/Quick/Quick-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/Quick/Quick.modulemap";
 				PRODUCT_MODULE_NAME = Quick;
@@ -2810,7 +2810,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/IQKeyboardManagerSwift/IQKeyboardManagerSwift-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/IQKeyboardManagerSwift/IQKeyboardManagerSwift-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/IQKeyboardManagerSwift/IQKeyboardManagerSwift.modulemap";
 				PRODUCT_MODULE_NAME = IQKeyboardManagerSwift;
@@ -3018,7 +3018,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/Nimble/Nimble-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
 				PRODUCT_MODULE_NAME = Nimble;

--- a/Example/SourcePointMetaAppUITests/Helpers/MetaApp.swift
+++ b/Example/SourcePointMetaAppUITests/Helpers/MetaApp.swift
@@ -76,15 +76,15 @@ class MetaApp: XCUIApplication {
     }
 
     var deletePropertyButton: XCUIElement {
-        propertyItem.buttons["trailing2"].firstMatch
+        propertyItem.buttons.element(boundBy: 2).firstMatch
     }
 
     var editPropertyButton: XCUIElement {
-        propertyItem.buttons["trailing1"].firstMatch
+        propertyItem.buttons.element(boundBy: 1).firstMatch
     }
 
     var resetPropertyButton: XCUIElement {
-        propertyItem.buttons["trailing0"].firstMatch
+        propertyItem.buttons.element(boundBy: 0).firstMatch
     }
 
     var addPropertyButton: XCUIElement {

--- a/Example/SourcePointMetaAppUITests/Helpers/MetaApp.swift
+++ b/Example/SourcePointMetaAppUITests/Helpers/MetaApp.swift
@@ -335,7 +335,7 @@ extension MetaApp: GDPRUI {
     }
 
     var dismissMessageButton: XCUIElement {
-        webViews.containing(NSPredicate(format: "label CONTAINS[cd] 'X'")).firstMatch
+        staticTexts["X"].firstMatch
     }
 
     var termsAndConditionsLink: XCUIElement {


### PR DESCRIPTION
1. In Web message case we are sending **consentLanguage** to sendConsent API call, consentLanguage is captured from action event.
1. In Native message case we are sending **Locale** value as consentLanguage value to sendConsent API call.