### PR TITLE
SP-5535 update userConsents after calling customConsentTo

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,6 +4,9 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
+defaults:
+  run:
+    working-directory: Example
 jobs:
   lint:
     runs-on: macos-latest
@@ -12,17 +15,23 @@ jobs:
       - name: Installing SwiftLint
         run: brew install swiftlint
       - name: linting
-        run: cd Example && swiftlint lint
-  test:
+        run: swiftlint lint
+  example-app-tests:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: CocoaPod Install
-        run: cd Example && pod install
       - name: Example app Unit and UI testing -> iPhone 11 (iOS 14.0)
-        run: xcodebuild test -scheme ConsentViewController_Example -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.0' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+        run: xcodebuild test -scheme ConsentViewController_Example -workspace ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.0' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+  native-app-tests:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
       - name: NativeMessage UI testing -> iPhone 11 (iOS 14.0)
-        run: xcodebuild test -scheme NativeMessageExample -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.0' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
-      - name: SourcePointMetaApp UI testing -> iPhone 11 (iOS 14.0)
-        run: xcodebuild test -scheme SourcePointMetaApp -workspace Example/ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.0' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+        run: xcodebuild test -scheme NativeMessageExample -workspace ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.0' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+  meta-app-tests:
+      runs-on: macos-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: SourcePointMetaApp UI testing -> iPhone 11 (iOS 14.0)
+          run: xcodebuild test -scheme SourcePointMetaApp -workspace ConsentViewController.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.0' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
 

--- a/ConsentViewController/Classes/GDPRConsentViewController.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewController.swift
@@ -303,15 +303,17 @@ typealias Meta = String
                 return
             }
 
-            completionHandler(GDPRUserConsent(
+            let updatedUserConsents = GDPRUserConsent(
                 acceptedVendors: response.vendors,
                 acceptedCategories: response.categories,
                 legitimateInterestCategories: response.legIntCategories,
                 specialFeatures: response.specialFeatures,
                 vendorGrants: response.grants,
                 euconsent: euconsent,
-                tcfData: tcfData)
+                tcfData: tcfData
             )
+            self?.localStorage.userConsents = updatedUserConsents
+            completionHandler(updatedUserConsents)
         }
     }
 

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -249,7 +249,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
         case "onAction":
             guard
                 let payload = body["body"] as? [String: Any],
-                let consentLanguage = payload["consentLanguage"] as? String? ?? "",
+                let consentLanguage = payload["consentLanguage"] as? String?,
                 let typeString = payload["type"] as? Int,
                 let actionPayload = payload["payload"] as? [String: Any],
                 let actionJson = try? SPGDPRArbitraryJson(actionPayload),

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -69,8 +69,9 @@ class GDPRConsentViewControllerSpec: QuickSpec {
                 }
 
                 context("and the response is successfull") {
-                    it("calls the completion handler with a GDPRUserConsents") {
-                        let grants = ["vendorId": GDPRVendorGrant(vendorGrant: true, purposeGrants: ["purposeId": true])]
+                    let grants = ["vendorId": GDPRVendorGrant(vendorGrant: true, purposeGrants: ["purposeId": true])]
+
+                    beforeEach {
                         sourcePointClient.customConsentResponse = CustomConsentResponse(
                             vendors: ["vendor"],
                             categories: ["category"],
@@ -78,8 +79,17 @@ class GDPRConsentViewControllerSpec: QuickSpec {
                             specialFeatures: ["specialFeature"],
                             grants: grants
                         )
+                    }
+
+                    it("updates its own userConsents property with the result") {
                         consentViewController.customConsentTo(vendors: [], categories: [], legIntCategories: []) { consents in
-                            let userConsents = GDPRUserConsent(
+                            expect(consentViewController.userConsents).toEventually(equal(consents))
+                        }
+                    }
+
+                    it("calls the completion handler with a GDPRUserConsents") {
+                        consentViewController.customConsentTo(vendors: [], categories: [], legIntCategories: []) { consents in
+                            expect(consents).toEventually(equal(GDPRUserConsent(
                                 acceptedVendors: ["vendor"],
                                 acceptedCategories: ["category"],
                                 legitimateInterestCategories: ["legInt"],
@@ -87,8 +97,7 @@ class GDPRConsentViewControllerSpec: QuickSpec {
                                 vendorGrants: grants,
                                 euconsent: "",
                                 tcfData: SPGDPRArbitraryJson()
-                            )
-                            expect(consents).toEventually(equal(userConsents))
+                            )))
                         }
                     }
                 }


### PR DESCRIPTION
After calling the `.customConsentTo()` method, the `GDPRConsentViewController#userConsents` is not updated. 

This PR fixes this issue (and updates the GitHub workflow file to execute test targets in parallel). 