### PR TITLE
SP-3552 add error codes

### DIFF
--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -98,6 +98,40 @@ import Foundation
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
+/// Invalid API Response Errors
+@objcMembers public class InvalidResponseError: GDPRConsentViewControllerError {
+    public override var failureReason: String? { decodingError?.failureReason ?? description }
+
+    let decodingError: DecodingError?
+
+    init(_ error: DecodingError? = nil) {
+        decodingError = error
+        super.init()
+    }
+
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}
+
+@objcMembers public class InvalidResponseWebMessageError: InvalidResponseError {
+    override public var spCode: String { "invalid_response_web_message" }
+    override public var description: String { "The SDK got an unexpected response from /message-url endpoint" }
+}
+
+@objcMembers public class InvalidResponseNativeMessageError: InvalidResponseError {
+    override public var spCode: String { "invalid_response_native_message" }
+    override public var description: String { "The SDK got an unexpected response from /native-message endpoint" }
+}
+
+@objcMembers public class InvalidResponseConsentError: InvalidResponseError {
+    override public var spCode: String { "invalid_response_consent" }
+    override public var description: String { "The SDK got an unexpected response from /consent endpoint" }
+}
+
+@objcMembers public class InvalidResponseCustomError: InvalidResponseError {
+    override public var spCode: String { "invalid_response_custom_consent" }
+    override public var description: String { "The SDK got an unexpected response from /custom-consent endpoint" }
+}
+
 /// Network Errors
 @objcMembers public class NoInternetConnection: GDPRConsentViewControllerError {
     override public var spCode: String { "no_internet_connection" }

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -9,14 +9,12 @@ import Foundation
 
 @objcMembers public class GDPRConsentViewControllerError: NSError, LocalizedError {
     public var spCode: String { "generic_sdk_error" }
-    public var spDescription: String { "Something went wrong in the SDK" }
+    public var spDescription: String { description }
+    override public var description: String { "Something went wrong in the SDK" }
+    public var failureReason: String? { description }
 
-    init() {
-        super.init(domain: "GDPRConsentViewController", code: 0, userInfo: nil)
-    }
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+    init() { super.init(domain: "GDPRConsentViewController", code: 0, userInfo: nil) }
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
 @objcMembers public class APIParsingError: GDPRConsentViewControllerError {
@@ -31,14 +29,11 @@ import Foundation
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    override public var description: String { return "Error parsing response from \(endpoint): \(parsingError.debugDescription)" }
-    public var errorDescription: String? { return description }
-    public var failureReason: String? { return description }
+    override public var description: String { "Error parsing response from \(endpoint): \(parsingError.debugDescription)" }
 }
 
 @objcMembers public class UnableToLoadJSReceiver: GDPRConsentViewControllerError {
-    public var failureReason: String? { return "Unable to load the JSReceiver.js resource." }
-    override public var description: String { return "\(failureReason!)" }
+    override public var description: String { "Unable to load the JSReceiver.js resource." }
 }
 
 @objcMembers public class MessageEventParsingError: GDPRConsentViewControllerError {
@@ -50,29 +45,29 @@ import Foundation
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    public var failureReason: String? { return "Could not parse message coming from the WebView \(message)" }
-    override public var description: String { return "\(failureReason!)" }
+    override public var description: String { "Could not parse message coming from the WebView \(message)" }
 }
 
 @objcMembers public class WebViewError: GDPRConsentViewControllerError {
+    override public var spCode: String { "web_view_error" }
+    override public var description: String {
+        "Something went wrong in the webview (code: \(errorCode ?? 0), title: \(title ?? "")"
+    }
+
     let errorCode: Int?
-    let title, stackTrace: String?
+    let title: String?
 
     init(code: Int? = nil, title: String? = nil, stackTrace: String? = nil) {
         self.errorCode = code
         self.title = title
-        self.stackTrace = stackTrace
         super.init()
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    public var failureReason: String? { return "Something went wrong in the webview (code: \(errorCode ?? 0), title: \(title ?? ""), stackTrace: \(stackTrace ?? ""))" }
-    override public var description: String { return "\(failureReason!)" }
 }
 
 @objcMembers public class InvalidArgumentError: GDPRConsentViewControllerError {
+    override public var description: String { message }
     let message: String
 
     init(message: String) {
@@ -81,19 +76,17 @@ import Foundation
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    public var failureReason: String? { return message }
-    override public var description: String { return message }
 }
 
 @objcMembers public class PostingConsentWithoutConsentUUID: GDPRConsentViewControllerError {
-    public var failureReason: String? { return "Tried to post consent but the stored consentUUID is empty or nil. Make sure to call .loadMessage or .loadPrivacyManager first." }
-    override public var description: String { return "\(failureReason!)" }
+    override public var description: String {
+        "Tried to post consent but the stored consentUUID is empty or nil. Make sure to call .loadMessage or .loadPrivacyManager first."
+    }
 }
 
 @objcMembers public class InvalidURLError: GDPRConsentViewControllerError {
-    override public var spDescription: String { description }
     override public var spCode: String { "invalid_url" }
+    override public var description: String { "Could not parse URL: \(urlString)" }
 
     let urlString: String
 
@@ -103,23 +96,17 @@ import Foundation
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    public var failureReason: String? { description }
-    override public var description: String { "Could not parse URL: \(urlString)" }
 }
 
 /// Network Errors
 @objcMembers public class NoInternetConnection: GDPRConsentViewControllerError {
-    override public var spDescription: String { "User has no Internet connection." }
     override public var spCode: String { "no_internet_connection" }
-
-    public var failureReason: String? { description }
     override public var description: String { "The device is not connected to the internet." }
 }
 
 @objcMembers public class ConnectionTimeOutError: GDPRConsentViewControllerError {
-    override public var spDescription: String { description }
     override public var spCode: String { "connection_timeout" }
+    override public var description: String { "Timed out when loading \(String(describing: url?.absoluteString)) after \(String(describing: timeout)) seconds" }
 
     let url: URL?
     let timeout: TimeInterval?
@@ -131,14 +118,13 @@ import Foundation
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    public var failureReason: String? { return description }
-    override public var description: String { return "Timed out when loading \(String(describing: url?.absoluteString)) after \(String(describing: timeout)) seconds" }
 }
 
 @objcMembers public class GenericNetworkError: GDPRConsentViewControllerError {
-    override public var spDescription: String { description }
     override public var spCode: String { "generic_network_request_\(response?.statusCode ?? 999)" }
+    override public var description: String {
+        "The server responsed with \(response?.statusCode ?? 999) when performing \(request.httpMethod ?? "<no verb>") \(response?.url?.absoluteString ?? "<no url>")"
+    }
 
     let request: URLRequest
     let response: HTTPURLResponse?
@@ -150,11 +136,6 @@ import Foundation
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    public var failureReason: String? { return description }
-    override public var description: String { return
-        "The server responsed with \(response?.statusCode ?? 999) when performing \(request.httpMethod ?? "<no verb>") \(response?.url?.absoluteString ?? "<no url>")"
-    }
 }
 
 @objcMembers public class InternalServerError: GenericNetworkError {

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 @objcMembers public class GDPRConsentViewControllerError: NSError, LocalizedError {
+    public var spCode: String { "generic_sdk_error" }
+    public var spDescription: String { "Something went wrong in the SDK" }
+    
     init() {
         super.init(domain: "GDPRConsentViewController", code: 0, userInfo: nil)
     }
@@ -53,11 +56,6 @@ import Foundation
 
 @objcMembers public class UnableToLoadJSReceiver: GDPRConsentViewControllerError {
     public var failureReason: String? { return "Unable to load the JSReceiver.js resource." }
-    override public var description: String { return "\(failureReason!)" }
-}
-
-@objcMembers public class NoInternetConnection: GDPRConsentViewControllerError {
-    public var failureReason: String? { return "The device is not connected to the internet." }
     override public var description: String { return "\(failureReason!)" }
 }
 
@@ -125,18 +123,30 @@ import Foundation
     override public var description: String { return "\(failureReason!)" }
 }
 
+/// Network Errors
+@objcMembers public class NoInternetConnection: GDPRConsentViewControllerError {
+    override public var spDescription: String { "User has no Internet connection." }
+    override public var spCode: String { "no_internet_connection" }
+    
+    public var failureReason: String? { "The device is not connected to the internet." }
+    override public var description: String { "\(failureReason!)" }
+}
+
 @objcMembers public class MessageTimeout: GDPRConsentViewControllerError {
+    override public var spDescription: String { description }
+    override public var spCode: String { "connection_timeout" }
+    
     let url: URL?
     let timeout: TimeInterval?
-
+    
     init(url: URL?, timeout: TimeInterval?) {
         self.url = url
         self.timeout = timeout
         super.init()
     }
-
+    
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
+    
     public var failureReason: String? { return description }
     override public var description: String { return "Timed out when loading \(String(describing: url?.absoluteString)) after \(String(describing: timeout)) seconds" }
 }

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -17,22 +17,6 @@ import Foundation
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
-/// TODO: Refactor these to be invalid request parsing erro
-@objcMembers public class APIParsingError: GDPRConsentViewControllerError {
-    private let parsingError: Error?
-    private let endpoint: String
-
-    init(_ endpoint: String, _ error: Error?) {
-        self.endpoint = endpoint
-        self.parsingError = error
-        super.init()
-    }
-
-    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    override public var description: String { "Error parsing response from \(endpoint): \(parsingError.debugDescription)" }
-}
-
 @objcMembers public class UnableToLoadJSReceiver: GDPRConsentViewControllerError {
     override public var description: String { "Unable to load the JSReceiver.js resource." }
 }
@@ -202,4 +186,19 @@ import Foundation
 
 @objcMembers public class ResourceNotFoundError: GenericNetworkError {
     override public var spCode: String { "resource_not_found_\(response?.statusCode ?? 400)" }
+}
+
+/// Invalid Request Error
+@objcMembers public class InvalidRequestError: GDPRConsentViewControllerError {
+    override public var spCode: String { "invalid_request_error" }
+    public override var failureReason: String? { decodingError?.failureReason ?? description }
+
+    let decodingError: DecodingError?
+
+    init(_ error: DecodingError? = nil) {
+        decodingError = error
+        super.init()
+    }
+
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -110,6 +110,18 @@ import Foundation
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
+@objcMembers public class RenderingAppError: GDPRConsentViewControllerError {
+    public override var spCode: String { renderingAppErrorCode ?? "rendering_app_error" }
+    public let renderingAppErrorCode: String?
+
+    init(_ renderingAppErrorCode: String?) {
+        self.renderingAppErrorCode = renderingAppErrorCode
+        super.init()
+    }
+
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}
+
 /// Invalid API Response Errors
 @objcMembers public class InvalidResponseError: GDPRConsentViewControllerError {
     public override var failureReason: String? { decodingError?.failureReason ?? description }

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -150,3 +150,22 @@ import Foundation
     public var failureReason: String? { return description }
     override public var description: String { return "Timed out when loading \(String(describing: url?.absoluteString)) after \(String(describing: timeout)) seconds" }
 }
+
+@objcMembers public class InternalServerError: GDPRConsentViewControllerError {
+    override public var spDescription: String { description }
+    override public var spCode: String { "internal_server_error_\(request.httpMethod ?? "500")" }
+    
+    let request: URLRequest
+    let response: HTTPURLResponse
+    
+    init(request: URLRequest, response: HTTPURLResponse) {
+        self.request = request
+        self.response = response
+        super.init()
+    }
+    
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    
+    public var failureReason: String? { return description }
+    override public var description: String { return "The server responsed with \(response.statusCode) when performing \(request.httpMethod ?? "<no verb>") \(response.url?.absoluteString ?? "<no url>")" }
+}

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -17,6 +17,7 @@ import Foundation
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
+/// TODO: Refactor these to be invalid request parsing erro
 @objcMembers public class APIParsingError: GDPRConsentViewControllerError {
     private let parsingError: Error?
     private let endpoint: String
@@ -82,6 +83,29 @@ import Foundation
     override public var description: String {
         "Tried to post consent but the stored consentUUID is empty or nil. Make sure to call .loadMessage or .loadPrivacyManager first."
     }
+}
+
+/// Invalid Rendering App (JSReceiver) event payloads
+@objcMembers public class InvalidEventPayloadError: GDPRConsentViewControllerError {
+    public override var failureReason: String? { description }
+    public override var spCode: String { "invalid_event_payload" }
+    public override var description: String {
+        "Could not parse the event: \(name) with body: \(body)"
+    }
+
+    let name, body: String
+
+    init(_ name: String? = nil, body: String? = nil) {
+        self.name = name ?? "<no name>"
+        self.body = body ?? "<no body>"
+        super.init()
+    }
+
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}
+
+@objcMembers public class InvalidOnActionEventPayloadError: InvalidEventPayloadError {
+    public override var spCode: String { "invalid_onAction_event_payload" }
 }
 
 @objcMembers public class InvalidURLError: GDPRConsentViewControllerError {

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -10,7 +10,7 @@ import Foundation
 @objcMembers public class GDPRConsentViewControllerError: NSError, LocalizedError {
     public var spCode: String { "generic_sdk_error" }
     public var spDescription: String { "Something went wrong in the SDK" }
-    
+
     init() {
         super.init(domain: "GDPRConsentViewController", code: 0, userInfo: nil)
     }
@@ -56,11 +56,11 @@ import Foundation
 }
 
 @objcMembers public class WebViewError: GDPRConsentViewControllerError {
-    let spCode: Int?
+    let errorCode: Int?
     let title, stackTrace: String?
 
     init(code: Int? = nil, title: String? = nil, stackTrace: String? = nil) {
-        self.spCode = code
+        self.errorCode = code
         self.title = title
         self.stackTrace = stackTrace
         super.init()
@@ -68,21 +68,7 @@ import Foundation
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    public var failureReason: String? { return "Something went wrong in the webview (code: \(spCode ?? 0), title: \(title ?? ""), stackTrace: \(stackTrace ?? ""))" }
-    override public var description: String { return "\(failureReason!)" }
-}
-
-@objcMembers public class URLParsingError: GDPRConsentViewControllerError {
-    let urlString: String
-
-    init(urlString: String) {
-        self.urlString = urlString
-        super.init()
-    }
-
-    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    public var failureReason: String? { return "Could not parse URL: \(urlString)" }
+    public var failureReason: String? { return "Something went wrong in the webview (code: \(errorCode ?? 0), title: \(title ?? ""), stackTrace: \(stackTrace ?? ""))" }
     override public var description: String { return "\(failureReason!)" }
 }
 
@@ -105,57 +91,76 @@ import Foundation
     override public var description: String { return "\(failureReason!)" }
 }
 
+@objcMembers public class InvalidURLError: GDPRConsentViewControllerError {
+    override public var spDescription: String { description }
+    override public var spCode: String { "invalid_url" }
+
+    let urlString: String
+
+    init(urlString: String) {
+        self.urlString = urlString
+        super.init()
+    }
+
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    public var failureReason: String? { description }
+    override public var description: String { "Could not parse URL: \(urlString)" }
+}
+
 /// Network Errors
 @objcMembers public class NoInternetConnection: GDPRConsentViewControllerError {
     override public var spDescription: String { "User has no Internet connection." }
     override public var spCode: String { "no_internet_connection" }
-    
-    public var failureReason: String? { "The device is not connected to the internet." }
-    override public var description: String { "\(failureReason!)" }
+
+    public var failureReason: String? { description }
+    override public var description: String { "The device is not connected to the internet." }
 }
 
-@objcMembers public class MessageTimeout: GDPRConsentViewControllerError {
+@objcMembers public class ConnectionTimeOutError: GDPRConsentViewControllerError {
     override public var spDescription: String { description }
     override public var spCode: String { "connection_timeout" }
-    
+
     let url: URL?
     let timeout: TimeInterval?
-    
+
     init(url: URL?, timeout: TimeInterval?) {
         self.url = url
         self.timeout = timeout
         super.init()
     }
-    
+
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-    
+
     public var failureReason: String? { return description }
     override public var description: String { return "Timed out when loading \(String(describing: url?.absoluteString)) after \(String(describing: timeout)) seconds" }
 }
 
 @objcMembers public class GenericNetworkError: GDPRConsentViewControllerError {
     override public var spDescription: String { description }
-    override public var spCode: String { "generic_network_request_\(request.httpMethod ?? "")" }
-    
+    override public var spCode: String { "generic_network_request_\(response?.statusCode ?? 999)" }
+
     let request: URLRequest
     let response: HTTPURLResponse?
-    
+
     init(request: URLRequest, response: HTTPURLResponse?) {
         self.request = request
         self.response = response
         super.init()
     }
-    
+
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-    
+
     public var failureReason: String? { return description }
-    override public var description: String { return "The server responsed with \(response?.statusCode ?? 999) when performing \(request.httpMethod ?? "<no verb>") \(response?.url?.absoluteString ?? "<no url>")" }
+    override public var description: String { return
+        "The server responsed with \(response?.statusCode ?? 999) when performing \(request.httpMethod ?? "<no verb>") \(response?.url?.absoluteString ?? "<no url>")"
+    }
 }
 
 @objcMembers public class InternalServerError: GenericNetworkError {
-    override public var spCode: String { "internal_server_error_\(request.httpMethod ?? "500")" }
+    override public var spCode: String { "internal_server_error_\(response?.statusCode ?? 500)" }
 }
 
 @objcMembers public class ResourceNotFoundError: GenericNetworkError {
-    override public var spCode: String { "resource_not_found_\(request.httpMethod ?? "400")" }
+    override public var spCode: String { "resource_not_found_\(response?.statusCode ?? 400)" }
 }

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -52,12 +52,6 @@ import Foundation
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
-@objcMembers public class PostingConsentWithoutConsentUUID: GDPRConsentViewControllerError {
-    override public var description: String {
-        "Tried to post consent but the stored consentUUID is empty or nil. Make sure to call .loadMessage or .loadPrivacyManager first."
-    }
-}
-
 /// Invalid Rendering App (JSReceiver) event payloads
 @objcMembers public class InvalidEventPayloadError: GDPRConsentViewControllerError {
     public override var failureReason: String? { description }
@@ -202,4 +196,10 @@ import Foundation
     }
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}
+
+@objcMembers public class PostingConsentWithoutConsentUUID: InvalidRequestError {
+    override public var description: String {
+        "Tried to post consent but the stored consentUUID is empty or nil. Make sure to call .loadMessage or .loadPrivacyManager first."
+    }
 }

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -18,6 +18,7 @@ import Foundation
 }
 
 @objcMembers public class UnableToLoadJSReceiver: GDPRConsentViewControllerError {
+    public override var spCode: String { "unable_to_load_jsreceiver" }
     override public var description: String { "Unable to load the JSReceiver.js resource." }
 }
 

--- a/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
+++ b/ConsentViewController/Classes/GDPRConsentViewControllerError.swift
@@ -37,18 +37,6 @@ import Foundation
     override public var description: String { "Unable to load the JSReceiver.js resource." }
 }
 
-@objcMembers public class MessageEventParsingError: GDPRConsentViewControllerError {
-    let message: String
-
-    init(message: String) {
-        self.message = message
-        super.init()
-    }
-
-    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-    override public var description: String { "Could not parse message coming from the WebView \(message)" }
-}
-
 @objcMembers public class WebViewError: GDPRConsentViewControllerError {
     override public var spCode: String { "web_view_error" }
     override public var description: String {

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -154,7 +154,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
         if let payloadData = try? JSONDecoder().decode(SPGDPRArbitraryJson.self, from: action.payload),
            let pm_url = payloadData["pm_url"]?.stringValue,
            let urlComponents = URLComponents(string: pm_url)?.queryItems {
-            pmTab = urlComponents.first { $0.name == "pmId" }?.value
+            pmTab = urlComponents.first { $0.name == "pmTab" }?.value
             pmId = urlComponents.first { $0.name == "message_id" }?.value ?? pmId
         }
     }

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -235,7 +235,6 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
             switch error.code {
             case .timedOut:
                 spError = MessageTimeout(url: error.failingURL, timeout: timeout)
-//            case .cannotFindHost, .dnsLookupFailed: 404
             case .networkConnectionLost, .notConnectedToInternet:
                 spError = NoInternetConnection()
             default:

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -278,11 +278,7 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
         case "onError":
             let payload = body["body"] as? [String: Any] ?? [:]
             let error = payload["error"] as? [String: Any] ?? [:]
-            onError(error: WebViewError(
-                code: error["code"] as? Int,
-                title: error["title"] as? String,
-                stackTrace: error["stackTrace"] as? String
-            ))
+            onError(error: RenderingAppError(error["code"] as? String))
         default:
             /// TODO: This should not trigger the `onError` but we should notifiy our custom metrics endpoint
             print(message.body)

--- a/ConsentViewController/Classes/MessageWebViewController.swift
+++ b/ConsentViewController/Classes/MessageWebViewController.swift
@@ -230,16 +230,19 @@ class MessageWebViewController: GDPRMessageViewController, WKUIDelegate, WKNavig
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        var spError: GDPRConsentViewControllerError = WebViewError(code: nil, title: error.localizedDescription)
         if let error = error as? URLError {
             switch error.code {
             case .timedOut:
-                onError(error: MessageTimeout(url: error.failingURL, timeout: timeout))
+                spError = MessageTimeout(url: error.failingURL, timeout: timeout)
+//            case .cannotFindHost, .dnsLookupFailed: 404
+            case .networkConnectionLost, .notConnectedToInternet:
+                spError = NoInternetConnection()
             default:
-                onError(error: WebViewError(code: error.code.rawValue, title: error.localizedDescription))
+                spError = WebViewError(code: error.code.rawValue, title: error.localizedDescription)
             }
-        } else {
-            onError(error: GeneralRequestError(nil, nil, error))
         }
+        onError(error: spError)
     }
 
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {

--- a/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
@@ -37,8 +37,8 @@ extension DispatchQueue: SPDispatchQueue {
 typealias CompletionHandler = (Data?, GDPRConsentViewControllerError?) -> Void
 
 protocol HttpClient {
-    func get(url: URL?, completionHandler: @escaping CompletionHandler)
-    func post(url: URL?, body: Data?, completionHandler: @escaping CompletionHandler)
+    func get(urlString: String, completionHandler: @escaping CompletionHandler)
+    func post(urlString: String, body: Data?, completionHandler: @escaping CompletionHandler)
 }
 
 class SimpleClient: HttpClient {
@@ -94,7 +94,7 @@ class SimpleClient: HttpClient {
         session.dataTask(urlRequest) { [weak self] data, response, error in
             self?.dispatchQueue.async { [weak self] in
                 self?.logResponse(urlRequest, data)
-                
+
                 if error != nil {
                     var spError = GenericNetworkError(request: urlRequest, response: response as? HTTPURLResponse)
                     if let response = response as? HTTPURLResponse {
@@ -108,30 +108,30 @@ class SimpleClient: HttpClient {
                         }
                     }
                     completionHandler(nil, spError)
+                } else {
+                    completionHandler(data, nil)
                 }
-                
-                completionHandler(data, nil)
             }
         }.resume()
     }
 
-    func post(url: URL?, body: Data?, completionHandler: @escaping CompletionHandler) {
-        guard let _url = url else {
-            completionHandler(nil, GenericNetworkError(url, nil, nil))
+    func post(urlString: String, body: Data?, completionHandler: @escaping CompletionHandler) {
+        guard let url = URL(string: urlString) else {
+            completionHandler(nil, InvalidURLError(urlString: urlString))
             return
         }
-        var urlRequest = URLRequest(url: _url)
+        var urlRequest = URLRequest(url: url)
         urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.httpMethod = "POST"
         urlRequest.httpBody = body
         request(urlRequest, completionHandler)
     }
 
-    func get(url: URL?, completionHandler: @escaping CompletionHandler) {
-        guard let _url = url else {
-            completionHandler(nil, GenericNetworkError(url, nil, nil))
+    func get(urlString: String, completionHandler: @escaping CompletionHandler) {
+        guard let url = URL(string: urlString) else {
+            completionHandler(nil, InvalidURLError(urlString: urlString))
             return
         }
-        request(URLRequest(url: _url), completionHandler)
+        request(URLRequest(url: url), completionHandler)
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -119,7 +119,7 @@ class SourcePointClient: SourcePointProtocol {
         return paramsString
     }
 
-    // swiftlint:disable:next function_parameter_count
+    // swiftlint:disable:next function_parameter_count line_length
     func getMessage(url: URL, consentUUID: GDPRUUID?, euconsent: String, authId: String?, meta: Meta, completionHandler: @escaping (MessageResponse?, GDPRConsentViewControllerError? ) -> Void) {
         guard let body = try? JSONEncoder().encode(MessageRequest(
             uuid: consentUUID,

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -121,31 +121,32 @@ class SourcePointClient: SourcePointProtocol {
 
     // swiftlint:disable:next function_parameter_count line_length
     func getMessage(url: URL, consentUUID: GDPRUUID?, euconsent: String, authId: String?, meta: Meta, completionHandler: @escaping (MessageResponse?, GDPRConsentViewControllerError? ) -> Void) {
-        guard let body = try? JSONEncoder().encode(MessageRequest(
-            uuid: consentUUID,
-            euconsent: euconsent,
-            authId: authId,
-            accountId: accountId,
-            propertyId: propertyId,
-            propertyHref: propertyName,
-            campaignEnv: campaignEnv,
-            targetingParams: targetingParamsToString(targetingParams),
-            requestUUID: requestUUID,
-            meta: meta
-        )) else {
-            completionHandler(nil, APIParsingError(url.absoluteString, nil))
-            return
-        }
-        client.post(urlString: url.absoluteString, body: body) { data, error in
-            if let error = error {
-                completionHandler(nil, error)
-            } else {
-                do {
-                    completionHandler(try JSONDecoder().decode(MessageResponse.self, from: data!), nil)
-                } catch {
-                    completionHandler(nil, InvalidResponseWebMessageError(error as? DecodingError))
+        do {
+            let body = try JSONEncoder().encode(MessageRequest(
+                uuid: consentUUID,
+                euconsent: euconsent,
+                authId: authId,
+                accountId: accountId,
+                propertyId: propertyId,
+                propertyHref: propertyName,
+                campaignEnv: campaignEnv,
+                targetingParams: targetingParamsToString(targetingParams),
+                requestUUID: requestUUID,
+                meta: meta
+            ))
+            client.post(urlString: url.absoluteString, body: body) { data, error in
+                if let error = error {
+                    completionHandler(nil, error)
+                } else {
+                    do {
+                        completionHandler(try JSONDecoder().decode(MessageResponse.self, from: data!), nil)
+                    } catch {
+                        completionHandler(nil, InvalidResponseWebMessageError(error as? DecodingError))
+                    }
                 }
             }
+        } catch {
+            completionHandler(nil, InvalidRequestError(error as? DecodingError))
         }
     }
 
@@ -166,9 +167,9 @@ class SourcePointClient: SourcePointProtocol {
     func postAction(action: GDPRAction, consentUUID: GDPRUUID, meta: Meta, completionHandler: @escaping (ActionResponse?, GDPRConsentViewControllerError?) -> Void) {
         let url = SourcePointClient.CONSENT_URL
 
-        guard
-            let pmPayload = try? JSONDecoder().decode(SPGDPRArbitraryJson.self, from: action.payload),
-            let body = try? JSONEncoder().encode(ActionRequest(
+        do {
+            let pmPayload = try JSONDecoder().decode(SPGDPRArbitraryJson.self, from: action.payload)
+            let body = try JSONEncoder().encode(ActionRequest(
                 propertyId: propertyId,
                 propertyHref: propertyName,
                 accountId: accountId,
@@ -182,20 +183,20 @@ class SourcePointClient: SourcePointProtocol {
                 meta: meta,
                 publisherData: action.publisherData,
                 consentLanguage: action.consentLanguage
-            )) else {
-                completionHandler(nil, APIParsingError(url.absoluteString, nil))
-                return
-        }
-        client.post(urlString: url.absoluteString, body: body) { data, error  in
-            if let error = error {
-                completionHandler(nil, error)
-            } else {
-                do {
-                    completionHandler(try JSONDecoder().decode(ActionResponse.self, from: data!), nil)
-                } catch {
-                    completionHandler(nil, InvalidResponseConsentError(error as? DecodingError))
+            ))
+            client.post(urlString: url.absoluteString, body: body) { data, error  in
+                if let error = error {
+                    completionHandler(nil, error)
+                } else {
+                    do {
+                        completionHandler(try JSONDecoder().decode(ActionResponse.self, from: data!), nil)
+                    } catch {
+                        completionHandler(nil, InvalidResponseConsentError(error as? DecodingError))
+                    }
                 }
             }
+        } catch {
+            completionHandler(nil, InvalidRequestError(error as? DecodingError))
         }
     }
 
@@ -205,27 +206,27 @@ class SourcePointClient: SourcePointProtocol {
         categories: [String],
         legIntCategories: [String],
         completionHandler: @escaping (CustomConsentResponse?, GDPRConsentViewControllerError?) -> Void) {
-        guard let body = try? JSONEncoder().encode(CustomConsentRequest(
-            consentUUID: consentUUID,
-            propertyId: propertyId,
-            vendors: vendors,
-            categories: categories,
-            legIntCategories: legIntCategories
-        )) else {
-            completionHandler(nil, APIParsingError("encoding custom consent", nil))
-            return
-        }
-
-        client.post(urlString: SourcePointClient.CUSTOM_CONSENT_URL.absoluteString, body: body) { data, error in
-            if let error = error {
-                completionHandler(nil, error)
-            } else {
-                do {
-                    completionHandler(try JSONDecoder().decode(CustomConsentResponse.self, from: data!), nil)
-                } catch {
-                    completionHandler(nil, InvalidResponseConsentError(error as? DecodingError))
+        do {
+            let body = try JSONEncoder().encode(CustomConsentRequest(
+                consentUUID: consentUUID,
+                propertyId: propertyId,
+                vendors: vendors,
+                categories: categories,
+                legIntCategories: legIntCategories
+            ))
+            client.post(urlString: SourcePointClient.CUSTOM_CONSENT_URL.absoluteString, body: body) { data, error in
+                if let error = error {
+                    completionHandler(nil, error)
+                } else {
+                    do {
+                        completionHandler(try JSONDecoder().decode(CustomConsentResponse.self, from: data!), nil)
+                    } catch {
+                        completionHandler(nil, InvalidResponseConsentError(error as? DecodingError))
+                    }
                 }
             }
+        } catch {
+            completionHandler(nil, InvalidRequestError(error as? DecodingError))
         }
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -137,7 +137,7 @@ class SourcePointClient: SourcePointProtocol {
             completionHandler(nil, APIParsingError(url.absoluteString, nil))
             return
         }
-        client.post(url: url, body: body) { data, error in
+        client.post(urlString: url.absoluteString, body: body) { data, error in
             do {
                 if let messageData = data {
                     let messageResponse = try (JSONDecoder().decode(MessageResponse.self, from: messageData))
@@ -188,7 +188,7 @@ class SourcePointClient: SourcePointProtocol {
                 completionHandler(nil, APIParsingError(url.absoluteString, nil))
                 return
         }
-        client.post(url: url, body: body) { data, error  in
+        client.post(urlString: url.absoluteString, body: body) { data, error  in
             do {
                 if let actionData = data {
                     let actionResponse = try (JSONDecoder().decode(ActionResponse.self, from: actionData))
@@ -219,7 +219,7 @@ class SourcePointClient: SourcePointProtocol {
             return
         }
 
-        client.post(url: SourcePointClient.CUSTOM_CONSENT_URL, body: body) { data, error in
+        client.post(urlString: SourcePointClient.CUSTOM_CONSENT_URL.absoluteString, body: body) { data, error in
             guard
                 let data = data,
                 let consentsResponse = try? (JSONDecoder().decode(CustomConsentResponse.self, from: data)),

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
@@ -16,11 +16,10 @@ class GDPRConsentViewControllerErrorSpec: QuickSpec {
         let url = "https://notice.sp-prod.net/?message_id=59706"
         describe("Test GDPRConsentViewControllerError methods") {
 
-            it("Test GeneralRequestError method") {
-                let url = URL(string: url)
-                let errorObject = GeneralRequestError(url, nil, nil)
-                expect(errorObject.description).to(
-                    equal("The request to: https://notice.sp-prod.net/?message_id=59706 failed with response: <Unknown Response> and error: <Unknown Error>"))
+            describe("GenericNetworkError") {
+                it("has spCode: generic_network_request") {
+                    expect(GenericNetworkError(request: URLRequest(url: URL()), response: nil).spCode).to(equal("generic_network_request"))
+                }
             }
 
             it("Test APIParsingError method") {

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
@@ -61,6 +61,36 @@ class GDPRConsentViewControllerErrorSpec: QuickSpec {
                 }
             }
 
+            describe("WebViewError") {
+                it("has spCode: web_view_error") {
+                    expect(WebViewError().spCode).to(equal("web_view_error"))
+                }
+            }
+
+            describe("InvalidResponseWebMessageError") {
+                it("has spCode: invalid_response_web_message") {
+                    expect(InvalidResponseWebMessageError().spCode).to(equal("invalid_response_web_message"))
+                }
+            }
+
+            describe("InvalidResponseNativeMessageError") {
+                it("has spCode: invalid_response_native_message") {
+                    expect(InvalidResponseNativeMessageError().spCode).to(equal("invalid_response_native_message"))
+                }
+            }
+
+            describe("InvalidResponseConsentError") {
+                it("has spCode: invalid_response_consent") {
+                    expect(InvalidResponseConsentError().spCode).to(equal("invalid_response_consent"))
+                }
+            }
+
+            describe("InvalidResponseCustomError") {
+                it("has spCode: invalid_response_custom_consent") {
+                    expect(InvalidResponseCustomError().spCode).to(equal("invalid_response_custom_consent"))
+                }
+            }
+
             it("Test APIParsingError method") {
                 let errorObject = APIParsingError(url, nil)
                 expect(errorObject.description).to(equal("Error parsing response from https://notice.sp-prod.net/?message_id=59706: nil"))
@@ -69,11 +99,6 @@ class GDPRConsentViewControllerErrorSpec: QuickSpec {
             it("Test MessageEventParsingError method") {
                 let errorObject = MessageEventParsingError(message: "The operation couldn't be completed")
                 expect(errorObject.failureReason).to(equal("Could not parse message coming from the WebView The operation couldn't be completed"))
-            }
-
-            it("Test WebViewError method") {
-                let errorObject = WebViewError()
-                expect(errorObject.failureReason).to(equal("Something went wrong in the webview (code: 0, title: , stackTrace: )"))
             }
 
             it("Test InvalidArgumentError method") {

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
@@ -10,26 +10,60 @@ import Quick
 import Nimble
 @testable import ConsentViewController
 
-class GDPRConsentViewControllerErrorSpec: QuickSpec {
+func emptyRequest() -> URLRequest {
+    return URLRequest(url: URL(string: "/")!)
+}
 
+func aResponseWith(status: Int) -> HTTPURLResponse {
+    return HTTPURLResponse(url: URL(string: "/")!, statusCode: status, httpVersion: nil, headerFields: nil)!
+}
+
+class GDPRConsentViewControllerErrorSpec: QuickSpec {
     override func spec() {
         let url = "https://notice.sp-prod.net/?message_id=59706"
-        describe("Test GDPRConsentViewControllerError methods") {
-
+        describe("GDPRConsentViewControllerErrorSpec") {
             describe("GenericNetworkError") {
-                it("has spCode: generic_network_request") {
-                    expect(GenericNetworkError(request: URLRequest(url: URL()), response: nil).spCode).to(equal("generic_network_request"))
+                it("has spCode: generic_network_request_{response.status}") {
+                    let error = GenericNetworkError(request: emptyRequest(), response: nil)
+                    expect(error.spCode).to(equal("generic_network_request_999"))
+                }
+            }
+
+            describe("NoInternetConnection") {
+                it("has spCode: no_internet_connection") {
+                    expect(NoInternetConnection().spCode).to(equal("no_internet_connection"))
+                }
+            }
+
+            describe("InternalServerError") {
+                it("has spCode: internal_server_error_{response.statusCode}") {
+                    let error = InternalServerError(request: emptyRequest(), response: aResponseWith(status: 502))
+                    expect(error.spCode).to(equal("internal_server_error_502"))
+                }
+            }
+
+            describe("ResourceNotFoundError") {
+                it("has spCode: resource_not_found_{response.statusCode}") {
+                    let error = ResourceNotFoundError(request: emptyRequest(), response: aResponseWith(status: 404))
+                    expect(error.spCode).to(equal("resource_not_found_404"))
+                }
+            }
+
+            describe("ConnectionTimeOutError") {
+                it("has spCode: connection_timeout") {
+                    expect(ConnectionTimeOutError(url: nil, timeout: nil).spCode).to(equal("connection_timeout"))
+                }
+            }
+
+            describe("InvalidURLError") {
+                it("has spCode: invalid_url") {
+                    expect(InvalidURLError(urlString: "").spCode).to(equal("invalid_url"))
                 }
             }
 
             it("Test APIParsingError method") {
                 let errorObject = APIParsingError(url, nil)
                 expect(errorObject.description).to(equal("Error parsing response from https://notice.sp-prod.net/?message_id=59706: nil"))
-            }
-
-            it("Test NoInternetConnection method") {
-                let errorObject = NoInternetConnection()
-                expect(errorObject.failureReason).to(equal("The device is not connected to the internet."))
             }
 
             it("Test MessageEventParsingError method") {
@@ -40,11 +74,6 @@ class GDPRConsentViewControllerErrorSpec: QuickSpec {
             it("Test WebViewError method") {
                 let errorObject = WebViewError()
                 expect(errorObject.failureReason).to(equal("Something went wrong in the webview (code: 0, title: , stackTrace: )"))
-            }
-
-            it("Test URLParsingError method") {
-                let errorObject = URLParsingError(urlString: url)
-                expect(errorObject.failureReason).to(equal("Could not parse URL: https://notice.sp-prod.net/?message_id=59706"))
             }
 
             it("Test InvalidArgumentError method") {

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
@@ -18,6 +18,8 @@ func aResponseWith(status: Int) -> HTTPURLResponse {
     return HTTPURLResponse(url: URL(string: "/")!, statusCode: status, httpVersion: nil, headerFields: nil)!
 }
 
+// swiftlint:disable function_body_length
+
 class GDPRConsentViewControllerErrorSpec: QuickSpec {
     override func spec() {
         let url = "https://notice.sp-prod.net/?message_id=59706"
@@ -88,6 +90,18 @@ class GDPRConsentViewControllerErrorSpec: QuickSpec {
             describe("InvalidResponseCustomError") {
                 it("has spCode: invalid_response_custom_consent") {
                     expect(InvalidResponseCustomError().spCode).to(equal("invalid_response_custom_consent"))
+                }
+            }
+
+            describe("InvalidEventPayloadError") {
+                it("has spCode: invalid_event_payload") {
+                    expect(InvalidEventPayloadError().spCode).to(equal("invalid_event_payload"))
+                }
+            }
+
+            describe("InvalidOnActionEventPayloadError") {
+                it("has spCode: invalid_event_payload") {
+                    expect(InvalidOnActionEventPayloadError().spCode).to(equal("invalid_onAction_event_payload"))
                 }
             }
 

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
@@ -22,7 +22,6 @@ func aResponseWith(status: Int) -> HTTPURLResponse {
 
 class GDPRConsentViewControllerErrorSpec: QuickSpec {
     override func spec() {
-        let url = "https://notice.sp-prod.net/?message_id=59706"
         describe("GDPRConsentViewControllerErrorSpec") {
             describe("GenericNetworkError") {
                 it("has spCode: generic_network_request_{response.status}") {
@@ -125,9 +124,10 @@ class GDPRConsentViewControllerErrorSpec: QuickSpec {
                 }
             }
 
-            it("Test APIParsingError method") {
-                let errorObject = APIParsingError(url, nil)
-                expect(errorObject.description).to(equal("Error parsing response from https://notice.sp-prod.net/?message_id=59706: nil"))
+            describe("UnableToLoadJSReceiver") {
+                it("has spCode: unable_to_load_jsreceiver") {
+                    expect(UnableToLoadJSReceiver().spCode).to(equal("unable_to_load_jsreceiver"))
+                }
             }
 
             it("Test InvalidArgumentError method") {

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
@@ -119,6 +119,12 @@ class GDPRConsentViewControllerErrorSpec: QuickSpec {
                 }
             }
 
+            describe("InvalidRequestError") {
+                it("has spCode: invalid_request_error") {
+                    expect(InvalidRequestError().spCode).to(equal("invalid_request_error"))
+                }
+            }
+
             it("Test APIParsingError method") {
                 let errorObject = APIParsingError(url, nil)
                 expect(errorObject.description).to(equal("Error parsing response from https://notice.sp-prod.net/?message_id=59706: nil"))

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerErrorSpec.swift
@@ -105,14 +105,23 @@ class GDPRConsentViewControllerErrorSpec: QuickSpec {
                 }
             }
 
+            describe("RenderingAppError") {
+                describe("if not code is provided") {
+                    it("its spCode should be rendering_app_error") {
+                        expect(RenderingAppError(nil).spCode).to(equal("rendering_app_error"))
+                    }
+                }
+
+                describe("if a code is provided") {
+                    it("its spCode should be the same as the code provided") {
+                        expect(RenderingAppError("foo").spCode).to(equal("foo"))
+                    }
+                }
+            }
+
             it("Test APIParsingError method") {
                 let errorObject = APIParsingError(url, nil)
                 expect(errorObject.description).to(equal("Error parsing response from https://notice.sp-prod.net/?message_id=59706: nil"))
-            }
-
-            it("Test MessageEventParsingError method") {
-                let errorObject = MessageEventParsingError(message: "The operation couldn't be completed")
-                expect(errorObject.failureReason).to(equal("Could not parse message coming from the WebView The operation couldn't be completed"))
             }
 
             it("Test InvalidArgumentError method") {

--- a/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRConsentViewControllerSpec.swift
@@ -104,7 +104,7 @@ class GDPRConsentViewControllerSpec: QuickSpec {
 
                 context("and the response is error") {
                     it("calls the onError method on its consent delegate") {
-                        sourcePointClient.error = APIParsingError("custom-consent", nil)
+                        sourcePointClient.error = GDPRConsentViewControllerError()
                         consentViewController.customConsentTo(vendors: [], categories: [], legIntCategories: []) { _ in }
                         expect(mockConsentDelegate.isOnErrorCalled).to(beTrue())
                     }
@@ -189,7 +189,7 @@ class GDPRConsentViewControllerSpec: QuickSpec {
                         describe("and the api returns an error") {
                             beforeEach {
                                 sourcePointClient.postActionResponse = nil
-                                sourcePointClient.error = APIParsingError("test", nil)
+                                sourcePointClient.error = GDPRConsentViewControllerError()
                             }
                             types.forEach { type in
                                 describe(type.description) {

--- a/Example/ConsentViewController_ExampleTests/Helpers/HttpMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/HttpMock.swift
@@ -10,8 +10,7 @@ import Foundation
 @testable import ConsentViewController
 
 class MockHttp: HttpClient {
-    var getWasCalledWithUrl: URL?
-    var postWasCalledWithUrl: URL?
+    var postWasCalledWithUrl: String!
     var postWasCalledWithBody: Data?
     var success: Data?
     var error: Error?
@@ -24,17 +23,17 @@ class MockHttp: HttpClient {
         self.error = error
     }
 
-    public func get(url: URL?, completionHandler: @escaping CompletionHandler) {}
+    public func get(urlString: String, completionHandler: @escaping CompletionHandler) {}
 
     func request(_ urlRequest: URLRequest, _ completionHandler: @escaping CompletionHandler) {}
 
-    public func post(url: URL?, body: Data?, completionHandler: @escaping CompletionHandler) {
-        postWasCalledWithUrl = url?.absoluteURL
+    public func post(urlString: String, body: Data?, completionHandler: @escaping CompletionHandler) {
+        postWasCalledWithUrl = urlString
         postWasCalledWithBody = body
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1), execute: {
             self.success != nil ?
                 completionHandler(self.success!, nil) :
-                completionHandler(nil, APIParsingError(url!.absoluteString, self.error))
+                completionHandler(nil, InvalidURLError(urlString: urlString))
         })
     }
 }

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -15,7 +15,7 @@ class SourcePointClientMock: SourcePointProtocol {
     var customConsentResponse: CustomConsentResponse?
     var getMessageResponse: MessageResponse?
     var postActionResponse: ActionResponse?
-    var error: APIParsingError?
+    var error: GDPRConsentViewControllerError?
     var postActionCalled = false, getMessageCalled = false, customConsentCalled = false
     var customConsentWasCalledWith: [String: Any?]!
 

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -36,12 +36,12 @@ class SourcePointClientMock: SourcePointProtocol {
                     euconsent: String,
                     authId: String?,
                     meta: Meta,
-                    completionHandler: @escaping (MessageResponse?, APIParsingError?) -> Void) {
+                    completionHandler: @escaping (MessageResponse?, GDPRConsentViewControllerError?) -> Void) {
         getMessageCalled = true
         completionHandler(getMessageResponse, error)
     }
 
-    func postAction(action: GDPRAction, consentUUID: GDPRUUID, meta: Meta, completionHandler: @escaping (ActionResponse?, APIParsingError?) -> Void) {
+    func postAction(action: GDPRAction, consentUUID: GDPRUUID, meta: Meta, completionHandler: @escaping (ActionResponse?, GDPRConsentViewControllerError?) -> Void) {
         postActionCalled = true
         completionHandler(postActionResponse, error)
     }
@@ -50,7 +50,7 @@ class SourcePointClientMock: SourcePointProtocol {
                        vendors: [String],
                        categories: [String],
                        legIntCategories: [String],
-                       completionHandler: @escaping (CustomConsentResponse?, APIParsingError?) -> Void) {
+                       completionHandler: @escaping (CustomConsentResponse?, GDPRConsentViewControllerError?) -> Void) {
         customConsentWasCalledWith = [
             "consentUUID": consentUUID,
             "vendors": vendors,

--- a/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/MessageWebViewControllerSpec.swift
@@ -263,7 +263,7 @@ class MessageWebViewControllerSpec: QuickSpec, GDPRConsentDelegate, WKNavigation
                             messageWebViewController.connectivityManager = ConnectivityMock(connected: true)
                             messageWebViewController.webview = webviewMock
                             messageWebViewController.onAction(GDPRAction(type: .ShowPrivacyManager))
-                            let expectedPMURL = "https://cdn.privacy-mgmt.com/privacy-manager/index.html?site_id=1&consentUUID=uuid&consentLanguage=EN&message_id=1234"
+                            let expectedPMURL = "https://cdn.privacy-mgmt.com/privacy-manager/index.html?site_id=1&consentUUID=uuid&message_id=1234&pmTab"
                             expect(webviewMock.loadCalledWith.url?.absoluteString).to(equal(expectedPMURL))
                         }
                     }
@@ -369,7 +369,7 @@ class MessageWebViewControllerSpec: QuickSpec, GDPRConsentDelegate, WKNavigation
                     messageWebViewController.connectivityManager = ConnectivityMock(connected: true)
                     messageWebViewController.webview = webviewMock
                     messageWebViewController.loadPrivacyManager()
-                    let expectedPMURL = "https://cdn.privacy-mgmt.com/privacy-manager/index.html?site_id=1&consentUUID=uuid&consentLanguage=EN&message_id=1234"
+                    let expectedPMURL = "https://cdn.privacy-mgmt.com/privacy-manager/index.html?site_id=1&consentUUID=uuid&message_id=1234&pmTab"
                     expect(webviewMock.loadCalledWith.url?.absoluteString).to(equal(expectedPMURL))
                 }
             }
@@ -384,8 +384,8 @@ class MessageWebViewControllerSpec: QuickSpec, GDPRConsentDelegate, WKNavigation
         }
 
         describe("pmURL") {
-            it("returns an url with propertyId and consentUUID") {
-                let pmUrl = URL(string: "https://cdn.privacy-mgmt.com/privacy-manager/index.html?site_id=1&consentUUID=uuid&consentLanguage=EN")
+            it("returns an url with propertyId, consentUUID and messageId") {
+                let pmUrl = URL(string: "https://cdn.privacy-mgmt.com/privacy-manager/index.html?site_id=1&consentUUID=uuid&message_id=1234&pmTab")
                 expect(messageWebViewController.pmUrl()).to(equal(pmUrl))
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SimpleClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SimpleClientSpec.swift
@@ -151,7 +151,7 @@ class SimpleClientSpec: QuickSpec {
                     let session = URLSessionMock(
                         configuration: URLSessionConfiguration.default,
                         data: nil,
-                        error: GeneralRequestError(nil, nil, nil)
+                        error: GenericNetworkError(nil, nil, nil)
                     )
                     let client = SimpleClient(
                         connectivityManager: ConnectivityMock(connected: true),

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SimpleClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SimpleClientSpec.swift
@@ -145,13 +145,13 @@ class SimpleClientSpec: QuickSpec {
                 }
             }
 
-            describe("when the result data from the call is nil") {
+            describe("when the error from the call is not nil") {
                 it("calls the completionHandler with the error") {
                     var error: GDPRConsentViewControllerError?
                     let session = URLSessionMock(
                         configuration: URLSessionConfiguration.default,
                         data: nil,
-                        error: GenericNetworkError(nil, nil, nil)
+                        error: GenericNetworkError(request: URLRequest(url: URL(string: "/")!), response: nil)
                     )
                     let client = SimpleClient(
                         connectivityManager: ConnectivityMock(connected: true),

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
@@ -224,7 +224,7 @@ class SourcePointClientSpec: QuickSpec {
 
                 context("on failure") {
                     beforeEach {
-                        client = self.getClient(MockHttp(error: APIParsingError("foo", nil)))
+                        client = self.getClient(MockHttp(error: GDPRConsentViewControllerError()))
                     }
 
                     it("calls the completion handler with an GDPRConsentViewControllerError") {

--- a/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SourcePointClient/SourcePointClientSpec.swift
@@ -58,7 +58,7 @@ class SourcePointClientSpec: QuickSpec {
                         authId: "auth id",
                         meta: "meta",
                         completionHandler: { _, _  in})
-                    expect(httpClient?.postWasCalledWithUrl).to(equal(URL(string: "https://cdn.privacy-mgmt.com/wrapper/tcfv2/v1/gdpr/message-url?inApp=true")))
+                    expect(httpClient?.postWasCalledWithUrl).to(equal("https://cdn.privacy-mgmt.com/wrapper/tcfv2/v1/gdpr/message-url?inApp=true"))
                 }
 
                 it("calls POST on the http client with the right body") {
@@ -125,7 +125,7 @@ class SourcePointClientSpec: QuickSpec {
                 it("calls post on the http client with the right url") {
                     let acceptAllAction = GDPRAction(type: .AcceptAll, id: "1234")
                     client.postAction(action: acceptAllAction, consentUUID: "consent uuid", meta: "meta", completionHandler: { _, _  in})
-                    expect(httpClient?.postWasCalledWithUrl).to(equal(URL(string: "https://cdn.privacy-mgmt.com/wrapper/tcfv2/v1/gdpr/consent?inApp=true")))
+                    expect(httpClient?.postWasCalledWithUrl).to(equal("https://cdn.privacy-mgmt.com/wrapper/tcfv2/v1/gdpr/consent?inApp=true"))
                 }
 
                 it("calls POST on the http client with the right body") {
@@ -161,7 +161,7 @@ class SourcePointClientSpec: QuickSpec {
                 it("makes a POST to SourcePointClient.CUSTOM_CONSENT_URL") {
                     let http = MockHttp(success: "".data(using: .utf8)!)
                     self.getClient(http).customConsent(toConsentUUID: "", vendors: [], categories: [], legIntCategories: []) { _, _ in }
-                    expect(http.postWasCalledWithUrl).to(equal(SourcePointClient.CUSTOM_CONSENT_URL.absoluteURL))
+                    expect(http.postWasCalledWithUrl).to(equal(SourcePointClient.CUSTOM_CONSENT_URL.absoluteURL.absoluteString))
                 }
 
                 it("makes a POST with the correct body") {

--- a/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
+++ b/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
@@ -18,7 +18,7 @@ class SPGDPRExampleAppUITests: QuickSpec {
         beforeSuite {
             self.continueAfterFailure = false
             self.app = ExampleApp()
-            Nimble.AsyncDefaults.Timeout = 5
+            Nimble.AsyncDefaults.Timeout = 20
             Nimble.AsyncDefaults.PollInterval = 0.5
         }
 

--- a/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
+++ b/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
@@ -18,7 +18,7 @@ class SPGDPRExampleAppUITests: QuickSpec {
         beforeSuite {
             self.continueAfterFailure = false
             self.app = ExampleApp()
-            Nimble.AsyncDefaults.Timeout = 20
+            Nimble.AsyncDefaults.Timeout = 5
             Nimble.AsyncDefaults.PollInterval = 0.5
         }
 


### PR DESCRIPTION
1. Refactor error classes and their usage to align with the new [error list ](https://docs.google.com/spreadsheets/d/1MnzMbXZIPv4kT5GXoRUG9b3ks4_NGR8cdlbAy19J4BY/edit?ts=5fce0e32#gid=995431333) (this list will be soon public and hosted in a git repo).

2. Refactor the way we deal with query params in our `MessageWebViewController`. No longer storing the query params as a property.