### PR TITLE
Use messageLanguage property in getMessages request

### DIFF
--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -140,7 +140,8 @@ import Foundation
             campaigns: campaigns,
             authId: authId,
             localState: storage.localState,
-            idfaStaus: idfaStatus
+            idfaStaus: idfaStatus,
+            consentLanguage: messageLanguage
         ) { [weak self] result in
             switch result {
             case .success(let messagesResponse):

--- a/ConsentViewController/Classes/SPMessageLanguage.swift
+++ b/ConsentViewController/Classes/SPMessageLanguage.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Languages supported by Message and PM
-@objc public enum SPMessageLanguage: Int {
+@objc public enum SPMessageLanguage: Int, Codable {
     case BrowserDefault
     case English
     case Bulgarian

--- a/ConsentViewController/Classes/SourcePointClient/MessageRequest.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MessageRequest.swift
@@ -39,6 +39,7 @@ struct MessageRequest: Equatable, Encodable {
     let accountId: Int
     let idfaStatus: SPIDFAStatus
     let localState: SPJson
+    let consentLanguage: SPMessageLanguage
     let campaigns: CampaignsRequest
     let includeData = [
         "localState": ["type": "RecordString"],

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -47,6 +47,7 @@ protocol SourcePointProtocol {
         authId: String?,
         localState: SPJson,
         idfaStaus: SPIDFAStatus,
+        consentLanguage: SPMessageLanguage,
         handler: @escaping MessagesHandler)
 
     func getNativePrivacyManager(
@@ -150,6 +151,7 @@ class SourcePointClient: SourcePointProtocol {
         authId: String?,
         localState: SPJson,
         idfaStaus: SPIDFAStatus,
+        consentLanguage: SPMessageLanguage,
         handler: @escaping MessagesHandler) {
         _ = JSONEncoder().encodeResult(MessageRequest(
             authId: authId,
@@ -158,6 +160,7 @@ class SourcePointClient: SourcePointProtocol {
             accountId: accountId,
             idfaStatus: idfaStaus,
             localState: localState,
+            consentLanguage: consentLanguage,
             campaigns: CampaignsRequest(from: campaigns)
         )).map { body in
             client.post(urlString: SourcePointClient.GET_MESSAGES_URL.absoluteString, body: body) { result in


### PR DESCRIPTION
The messageLanguage property on SPConsentManager is now passed into the getMessages method and allows retrieval of localized consent messages on iOS.