### PR TITLE
add propertyId to local storage

### DIFF
--- a/ConsentViewController/Classes/LocalStorage/SPLocalStorage.swift
+++ b/ConsentViewController/Classes/LocalStorage/SPLocalStorage.swift
@@ -46,6 +46,7 @@ protocol SPLocalStorage {
     var usPrivacyString: String? { get set }
     var userData: SPUserData { get set }
     var localState: SPJson { get set }
+    var propertyId: Int? { get set }
 
     func clear()
 

--- a/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
+++ b/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
@@ -78,5 +78,6 @@ class SPUserDefaults: SPLocalStorage {
         tcfData = [:]
         usPrivacyString = ""
         userData = SPUserData()
+        propertyId = nil
     }
 }

--- a/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
+++ b/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
@@ -12,12 +12,22 @@ class SPUserDefaults: SPLocalStorage {
     static public let IAB_KEY_PREFIX = "IABTCF_"
     static public let US_PRIVACY_STRING_KEY = "IABUSPrivacy_String"
 
+    static let PROPERTY_ID = "\(SP_KEY_PREFIX)propertyId"
     static let LOCAL_STATE_KEY = "\(SP_KEY_PREFIX)localState"
     static let USER_DATA_KEY = "\(SP_KEY_PREFIX)userData"
     static let IAB_CMP_SDK_ID_KEY = "\(IAB_KEY_PREFIX)CmpSdkID"
     static let IAB_CMP_SDK_ID = 6
 
     var storage: Storage
+
+    var propertyId: Int? {
+        get {
+            storage.object(ofType: Int.self, forKey: SPUserDefaults.PROPERTY_ID)
+        }
+        set {
+            storage.setObject(newValue, forKey: SPUserDefaults.PROPERTY_ID)
+        }
+    }
 
     var tcfData: [String: Any]? {
         get {

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -30,7 +30,7 @@ import Foundation
 
     var ccpaUUID: String { storage.localState["ccpa"]?.dictionaryValue?["uuid"] as? String ?? "" }
     var gdprUUID: String { storage.localState["gdpr"]?.dictionaryValue?["uuid"] as? String ?? "" }
-    var propertyId: Int?
+    var propertyId: Int? { storage.propertyId }
     var propertyIdString: String { propertyId != nil ? String(propertyId!) : "" }
     var iOSMessagePartitionUUID: String?
 
@@ -126,7 +126,8 @@ import Foundation
         }
     }
 
-    func storeData(localState: SPJson, userData: SPUserData) {
+    func storeData(localState: SPJson, userData: SPUserData, propertyId: Int?) {
+        storage.propertyId = propertyId
         storage.localState = localState
         storage.userData = userData
         if let tcData = userData.gdpr?.consents?.tcfData {
@@ -150,9 +151,9 @@ import Foundation
             case .success(let messagesResponse):
                 self?.storeData(
                     localState: messagesResponse.localState,
-                    userData: SPUserData(from: messagesResponse)
+                    userData: SPUserData(from: messagesResponse),
+                    propertyId: messagesResponse.propertyId
                 )
-                self?.propertyId = messagesResponse.propertyId
                 self?.messageControllersStack = messagesResponse.campaigns
                     .filter { $0.message != nil }
                     .filter {
@@ -192,7 +193,8 @@ import Foundation
                     )
                     self?.storeData(
                         localState: localState,
-                        userData: userData
+                        userData: userData,
+                        propertyId: self?.propertyId
                     )
                     self?.delegate?.onConsentReady?(userData: userData)
                 case .failure(let error):
@@ -209,7 +211,8 @@ import Foundation
                     )
                     self?.storeData(
                         localState: localState,
-                        userData: userData
+                        userData: userData,
+                        propertyId: self?.propertyId
                     )
                     self?.delegate?.onConsentReady?(userData: userData)
                 case .failure(let error):


### PR DESCRIPTION
Property id is necessary when loading a PM that belongs to a property group. 
We currently receive `propertyId` from the call to `/get_messages` and keep it in memory. But if the SDK is instantiated only for loading the PMs, the field would be `nil`. 
This PR fixes this issue by storing the `propertyId` in the local storage (UserDefaults) and using it whenever necessary.