### PR TITLE
[SP-7704] Add callback for ATT action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 6.1.6 (August, 13, 2021)
+* Added `onIDFAStatusAction`  callback to load the messages based on IDFA status[#328](https://github.com/SourcePointUSA/ios-cmp-app/pull/328)
+
 # 6.1.5 (July, 23, 2021)
 * Expand `SPSDK` protocol to contain all public method/attributes of the SDK.
   * VERSION: String

--- a/ConsentViewController.podspec
+++ b/ConsentViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ConsentViewController'
-  s.version          = '6.1.5'
+  s.version          = '6.1.6'
   s.summary          = 'SourcePoint\'s ConsentViewController to handle privacy consents.'
   s.homepage         = 'https://www.sourcepoint.com'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -391,7 +391,9 @@ extension SPConsentManager: SPMessageUIDelegate {
             idfaStatus: status,
             iosVersion: deviceManager.osVersion(),
             partitionUUID: iOSMessagePartitionUUID
-        )
+        ) { [weak self] _ in
+            self?.delegate?.onIDFAStatusAction?()
+        }
     }
 
     func action(_ action: SPAction, from controller: SPMessageViewController) {

--- a/ConsentViewController/Classes/SPDelegate.swift
+++ b/ConsentViewController/Classes/SPDelegate.swift
@@ -13,6 +13,9 @@ import UIKit
     /// - Parameters:
     ///   - action: the user action
     @objc func onAction(_ action: SPAction, from controller: SPMessageViewController)
+
+    /// called when the user takes an action in the ATT prompt
+    @objc optional func onIDFAStatusAction()
 }
 
 @objc public protocol SPConsentDelegate {

--- a/ConsentViewController/Classes/SPError.swift
+++ b/ConsentViewController/Classes/SPError.swift
@@ -151,6 +151,11 @@ import Foundation
     override public var description: String { "The SDK got an unexpected response from /custom-consent endpoint" }
 }
 
+@objcMembers public class InvalidResponseATTMessageError: SPError {
+    override public var spCode: String { "sp_metric_invalid_response_ATT_message" }
+    override public var description: String { "The SDK got an unexpected response from /apple-tracking endpoint" }
+}
+
 /// Network Errors
 @objcMembers public class NoInternetConnection: SPError {
     override public var spCode: String { "sp_metric_no_internet_connection" }

--- a/README.md
+++ b/README.md
@@ -273,6 +273,20 @@ To display the App Tracking Transparency authorization request for accessing the
 ```
 ![App Tracking](https://github.com/SourcePointUSA/ios-cmp-app/blob/develop/wiki/assets/AppTracking.png)
 
+## Loading the Messages based on IDFA status
+In order to load the Messages once received IDFA status from user, use  `onIDFAStatusAction` callback method. Example:
+```swift
+func onIDFAStatusAction() {
+    consentManager.loadMessage()
+}
+```
+In Obj-C that'd be:
+```objc
+- (void)onIDFAStatusAction {
+    [consentManager loadMessageForAuthId: NULL];
+}
+```
+
 ## Frequently Asked Questions
 ### 1. How big is the SDK?
 The SDK is pretty slim, there are no assets, no dependencies, just pure code. Since we use Swift, its size will vary depending on the configuration of your project but it should not exceed `2 MB`.


### PR DESCRIPTION
Added `onIDFAStatusAction` callback to load the messages based on IDFA status.
In order to load the Messages once received IDFA status from user, use `onIDFAStatusAction` callback method. Example:

`func onIDFAStatusAction() {
    consentManager.loadMessage()
}`