### PR TITLE
SP-8097 implement `onSPFinished`

### DIFF
--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -461,7 +461,7 @@ extension SPConsentManager: SPMessageUIDelegate {
     }
 
     public func action(_ action: SPAction, from controller: UIViewController) {
-        delegate?.onAction(action, from: controller)
+        onAction(action, from: controller)
         switch action.type {
         case .AcceptAll, .RejectAll, .SaveAndExit:
             report(action: action)
@@ -484,15 +484,21 @@ extension SPConsentManager: SPMessageUIDelegate {
                 self?.reportIdfaStatus(status: status, messageId: Int(spController?.messageId ?? ""))
                 if status == .accepted {
                     action.type = .IDFAAccepted
-                    self?.delegate?.onAction(action, from: controller)
+                    self?.onAction(action, from: controller)
                 } else if status == .denied {
                     action.type = .IDFADenied
-                    self?.delegate?.onAction(action, from: controller)
+                    self?.onAction(action, from: controller)
                 }
                 self?.nextMessageIfAny(controller)
             }
         default:
             nextMessageIfAny(controller)
+        }
+    }
+
+    func onAction(_ action: SPAction, from controller: UIViewController) {
+        DispatchQueue.main.async { [weak self] in
+            self?.delegate?.onAction(action, from: controller)
         }
     }
 }

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -63,6 +63,8 @@ import UIKit
     var propertyId: Int? { storage.propertyId }
     var propertyIdString: String { propertyId != nil ? String(propertyId!) : "" }
     var iOSMessagePartitionUUID: String?
+    var messagesToShow = 0
+    var responsesToReceive = 0
 
     init(
         accountId: Int,
@@ -81,6 +83,12 @@ import UIKit
         self.spClient = spClient
         self.storage = storage
         self.deviceManager = deviceManager
+    }
+
+    func handleSDKDone() {
+        if messagesToShow == 0, responsesToReceive == 0 {
+            delegate?.onSPFinished?(userData: userData)
+        }
     }
 
     func renderNextMessageIfAny() {
@@ -158,9 +166,11 @@ import UIKit
     }
 
     func report(action: SPAction) {
+        responsesToReceive += 1
         switch action.campaignType {
         case .ccpa:
             spClient.postCCPAAction(authId: authId, action: action, localState: storage.localState, idfaStatus: idfaStatus) { [weak self] result in
+                self?.responsesToReceive -= 1
                 switch result {
                 case .success((let localState, let consents)):
                     let userData = SPUserData(
@@ -172,13 +182,14 @@ import UIKit
                         userData: userData,
                         propertyId: self?.propertyId
                     )
-                    self?.delegate?.onConsentReady?(userData: userData)
+                    self?.onConsentReceived()
                 case .failure(let error):
                     self?.onError(error)
                 }
             }
         case .gdpr:
             spClient.postGDPRAction(authId: authId, action: action, localState: storage.localState, idfaStatus: idfaStatus) { [weak self] result in
+                self?.responsesToReceive -= 1
                 switch result {
                 case .success((let localState, let consents)):
                     let userData = SPUserData(
@@ -190,7 +201,7 @@ import UIKit
                         userData: userData,
                         propertyId: self?.propertyId
                     )
-                    self?.delegate?.onConsentReady?(userData: userData)
+                    self?.onConsentReceived()
                 case .failure(let error):
                     self?.onError(error)
                 }
@@ -215,6 +226,11 @@ import UIKit
         ).loadPrivacyManager(url: pmURL)
     }
     #endif
+
+    func onConsentReceived() {
+        delegate?.onConsentReady?(userData: storage.userData)
+        handleSDKDone()
+    }
 
     public func onError(_ error: SPError) {
         spClient.errorMetrics(
@@ -248,6 +264,7 @@ import UIKit
 
     public func loadMessage(forAuthId authId: String? = nil) {
         self.authId = authId
+        responsesToReceive += 1
         spClient.getMessages(
             campaigns: campaigns,
             authId: authId,
@@ -255,6 +272,7 @@ import UIKit
             idfaStaus: idfaStatus,
             consentLanguage: messageLanguage
         ) { [weak self] result in
+            self?.responsesToReceive -= 1
             switch result {
             case .success(let messagesResponse):
                 self?.storeData(
@@ -278,8 +296,9 @@ import UIKit
                         $0.type
                     )}
                     .reversed()
+                    self?.messagesToShow = self?.messageControllersStack.count ?? 0
                 if self?.messageControllersStack.isEmpty ?? true {
-                    self?.delegate?.onConsentReady?(userData: self?.storage.userData ?? SPUserData())
+                    self?.onConsentReceived()
                 } else {
                     self?.renderNextMessageIfAny()
                 }
@@ -290,6 +309,7 @@ import UIKit
     }
 
     public func loadGDPRPrivacyManager(withId id: String, tab: SPPrivacyManagerTab = .Default) {
+        messagesToShow += 1
         #if os(iOS)
         guard let pmUrl = Constants.GDPR_PM_URL.appendQueryItems([
             "message_id": id,
@@ -310,7 +330,6 @@ import UIKit
                     self?.onError(SPError())
                     return
                 }
-
                 let pmViewController = SPGDPRNativePrivacyManagerViewController(
                     messageId: id,
                     campaignType: .gdpr,
@@ -329,6 +348,7 @@ import UIKit
     }
 
     public func loadCCPAPrivacyManager(withId id: String, tab: SPPrivacyManagerTab = .Default) {
+        messagesToShow += 1
         #if os(iOS)
         guard let pmUrl = Constants.CCPA_PM_URL.appendQueryItems([
             "message_id": id,
@@ -414,6 +434,8 @@ extension SPConsentManager: SPMessageUIDelegate {
     public func finished(_ vcFinished: UIViewController) {
         DispatchQueue.main.async { [weak self] in
             self?.delegate?.onSPUIFinished(vcFinished)
+            self?.messagesToShow -= 1
+            self?.handleSDKDone()
         }
     }
 
@@ -460,7 +482,6 @@ extension SPConsentManager: SPMessageUIDelegate {
             SPIDFAStatus.requestAuthorisation { [weak self] status in
                 let spController = controller as? SPMessageViewController
                 self?.reportIdfaStatus(status: status, messageId: Int(spController?.messageId ?? ""))
-                self?.nextMessageIfAny(controller)
                 if status == .accepted {
                     action.type = .IDFAAccepted
                     self?.delegate?.onAction(action, from: controller)
@@ -468,6 +489,7 @@ extension SPConsentManager: SPMessageUIDelegate {
                     action.type = .IDFADenied
                     self?.delegate?.onAction(action, from: controller)
                 }
+                self?.nextMessageIfAny(controller)
             }
         default:
             nextMessageIfAny(controller)

--- a/ConsentViewController/Classes/SPDelegate.swift
+++ b/ConsentViewController/Classes/SPDelegate.swift
@@ -27,8 +27,13 @@ import UIKit
 
     /// called after the user takes an action and the SDK receives consent data back from the server
     /// - Parameters:
-    ///  - consents: is the consent profile
+    ///  - userData: is the consent profile
     @objc optional func onConsentReady(userData: SPUserData)
+
+    /// called when the SDK is done. That will happen if there's no more messages to be displayed and all network requests are done.
+    /// - Parameters:
+    ///  - userData: is the consent profile
+    @objc optional func onSPFinished(userData: SPUserData)
 
     /// called if something goes wrong during the entire lifecycle of the SDK
     @objc optional func onError(error: SPError)

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -87,6 +87,10 @@ extension ViewController: SPDelegate {
         updatePMButtons(ccpaApplies: consentManager.ccpaApplies, gdprApplies: consentManager.gdprApplies)
     }
 
+    func onSPFinished(userData: SPUserData) {
+        print("SDK DONE")
+    }
+
     func onError(error: SPError) {
         print("Something went wrong: ", error)
     }


### PR DESCRIPTION
* implement `onSPFinished` delegate method
* make sure `onAction` is always called on the main thread
---
The `onSPFinished` delegate method is guaranteed to be called once at the end of the SDK's lifecycle unless something goes wrong (in this case, the `onError` will be called instead). 