### PR TITLE
[DIA-1000] gracefully degradation onError

### DIFF
--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -249,9 +249,7 @@ import UIKit
         let userData = storage.userData
         if !userData.isEqual(SPUserData()) {
             delegate?.onConsentReady?(userData: userData)
-        }
-        else
-        {
+        } else {
             if cleanUserDataOnError {
                 SPConsentManager.clearAllData()
             }

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -14,9 +14,9 @@ import UIKit
     static public var shouldCallErrorMetrics = true
 
     // MARK: - SPSDK
-    /// By default, the SDK will remove all user consent data from UserDefaults, possibly triggering a message to be displayed again next time
-    /// `.loadMessage` is called.
-    /// Set this flag to `false` if you wish to opt-out from this behaviour.
+    /// By default, the SDK preservs all user consent data from UserDefaults in case `OnError` event happens.
+    /// Set this flag to `true` if you wish to opt-out from this behaviour.
+    /// If set to `true` will remove all user consent data from UserDefaults, possibly triggering a message to be displayed again next time
     public var cleanUserDataOnError: Bool = false
 
     /// The timeout interval in seconds for the message being displayed

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -17,7 +17,7 @@ import UIKit
     /// By default, the SDK will remove all user consent data from UserDefaults, possibly triggering a message to be displayed again next time
     /// `.loadMessage` is called.
     /// Set this flag to `false` if you wish to opt-out from this behaviour.
-    public var cleanUserDataOnError: Bool = true
+    public var cleanUserDataOnError: Bool = false
 
     /// The timeout interval in seconds for the message being displayed
     public var messageTimeoutInSeconds = SPConsentManager.DefaultTimeout {

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -246,10 +246,17 @@ import UIKit
 
     public func onError(_ error: SPError) {
         logErrorMetrics(error)
-        if cleanUserDataOnError {
-            SPConsentManager.clearAllData()
+        let userData = storage.userData
+        if !userData.isEqual(SPUserData()) {
+            delegate?.onConsentReady?(userData: userData)
         }
-        delegate?.onError?(error: error)
+        else
+        {
+            if cleanUserDataOnError {
+                SPConsentManager.clearAllData()
+            }
+            delegate?.onError?(error: error)
+        }
     }
 
     private func logErrorMetrics(_ error: SPError) {

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -244,7 +244,7 @@ import UIKit
         handleSDKDone()
     }
 
-    public func onError(_ error: SPError) {
+    public func gracefullyDegradeOnError(_ error: SPError) {
         logErrorMetrics(error)
         let userData = storage.userData
         if !userData.isEqual(SPUserData()) {
@@ -255,6 +255,14 @@ import UIKit
             }
             delegate?.onError?(error: error)
         }
+    }
+
+    public func onError(_ error: SPError) {
+        logErrorMetrics(error)
+        if cleanUserDataOnError {
+            SPConsentManager.clearAllData()
+        }
+        delegate?.onError?(error: error)
     }
 
     private func logErrorMetrics(_ error: SPError) {
@@ -338,7 +346,7 @@ import UIKit
                     self?.renderNextMessageIfAny()
                 }
             case .failure(let error):
-                self?.onError(error)
+                self?.gracefullyDegradeOnError(error)
             }
         }
     }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPANativePrivacyManagerViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPANativePrivacyManagerViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Foundation
+//swiftlint:disable function_body_length
 
 @objcMembers class SPCCPANativePrivacyManagerViewController: SPNativeScreenViewController, SPNativePrivacyManagerHome {
     weak var delegate: SPNativePMDelegate?
@@ -91,7 +92,7 @@ import Foundation
         // override in order to disable menu button closing the Privacy Manager
     }
 
-    func setFocusGuidesForButtons(){
+    func setFocusGuidesForButtons() {
         let visibleButtons: [UIView] = actionsContainer.arrangedSubviews.filter({!$0.isHidden})
         for i in 0...visibleButtons.count-2 {
             addFocusGuide(from: visibleButtons[i], to: visibleButtons[i+1], direction: .bottomTop)

--- a/README.md
+++ b/README.md
@@ -194,8 +194,9 @@ Make sure to check XCode's quick help of `SPUserData` for more information on wh
 
 ### optional onError(error: SPError)
 In case of an error, the SDK will wrap the error in one of the `SPError` classes and eventually call the `onError(_ error: SPError)` callback. 
-By default, the SDK will also remove all consent data from the device. This _may_ cause a consent message to be shown again, depending on your scenario. This was implemented on purpose to be the most compliant as possible. Since there are no consent data, vendors should refrain from performing logic that depend on it.
-This behaviour can be opted-out by setting the flag  `consentManager.cleanUserDataOnError` to `false`, after you initialise `SPConsentManager`.
+
+By default, the SDK preservs all user consent data from UserDefaults in case of `OnError` event is called.
+Set `consentManager.cleanUserDataOnError` flag to `true` after you initialise `SPConsentManager` if you wish to opt-out from this behaviour. If set to `true` such use case will erase all user consent data from UserDefaults. This _may_ cause a consent message to be shown again, depending on your scenario. 
 
 ## Adding or Removing custom consents 
 It's possible to programatically consent the current user to a list of custom vendors, categories and legitimate interest caregories with the method:
@@ -368,11 +369,8 @@ The `onConsentReady` delegate method sends the consent action to the server and 
 
 ### `onError()`
 
-The SDK will in all cases wrap the error in one of the SPError class and eventually call the func `onError(_ error: SPError)` callback. By default, the SDK will also remove all consent data from the device. This may cause a consent message to be shown again, depending on your scenario.
-
-This was implemented on purpose to be the most safe possible. Since there are no consent data, vendors should refrain from performing logic that depends on it.
-
-This behaviour can be opted-out by setting the flag `consentManager.cleanUserDataOnError` to false, after you initialise `SPConsentManager`.
+The SDK will in all cases wrap the error in one of the SPError class and eventually call the func `onError(_ error: SPError)` callback. By default, the SDK preservs all user consent data from UserDefaults in case of `OnError` event is called.
+Set `consentManager.cleanUserDataOnError` flag to `true` after you initialise `SPConsentManager` if you wish to opt-out from this behaviour. If set to `true` such use case will erase all user consent data from UserDefaults. This _may_ cause a consent message to be shown again, depending on your scenario. 
 
 ## Delete user data
 Utilize the following method if an end-user requests to have their data deleted:


### PR DESCRIPTION
Now `SPConsentManager` fires `onConsentReady` instead of `onError` IF ` SPUserData` is not empty in `SPUserDefaults`
