### PR TITLE
Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,38 @@ We also support [Swift Package Manager](https://swift.org/package-manager/). It 
 
 To add our SDK package as dependency to your Xcode project, In Xcode select File > Swift Packages > Add Package Dependency and enter our SDK repository URL.
 
+Or you can use `Package.swift` file and add the dependency there:
+
+```swift
+// swift-tools-version:5.5
+
+import PackageDescription
+
+let package = Package(
+    name: "MyPackage",
+    platforms: [.iOS(.v15), .macOS(.v12)],
+    products: [
+        .library(name: "MyPackage", targets: ["MyPackage"]),
+    ],
+    dependencies: [
+        .package(
+            name: "ConsentViewController",
+            url: "https://github.com/SourcePointUSA/ios-cmp-app",
+                .upToNextMinor(from: "6.7.0")
+        ),
+    ],
+    targets: [
+        .target(
+            name: "MyPackage",
+            dependencies: [
+                "ConsentViewController"
+            ]
+        )
+    ]
+)
+
+```
+
 ### Manually add XCFramework
 If you prefer not to use any of the dependency managers. You can add `ConsentViewController.xcframework` as a library to your project or workspace.
 1. Download the [latest code version](https://github.com/SourcePointUSA/ios-cmp-app.git).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ class ViewController: UIViewController {
     lazy var consentManager: SPConsentManager = { SPConsentManager(
         accountId: 22,
         propertyName: try! SPPropertyName("mobile.multicampaign.demo"),
-        campaignsEnv: .Public // optional - Public by default
+        campaignsEnv: .Public, // optional - Public by default
         campaigns: SPCampaigns(
             gdpr: SPCampaign(), // optional
             ccpa: SPCampaign(), // optional


### PR DESCRIPTION
# README.md improvements


## Missing comma

Noticed that a comma was missing on the README.md. This PR adds that comma.

```swift
    lazy var consentManager: SPConsentManager = { SPConsentManager(
        ...
-        campaignsEnv: .Public // optional - Public by default
+        campaignsEnv: .Public, // optional - Public by default
        ...
    )}()
```

## Information on how to add the SDK through `Package.swift`

Added an example on how to add the SDK through the `Package.swift` file instead of through Xcode menus.
