### PR TITLE
Fix linting issues *and* removing several forced unwrapping

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,11 +5,47 @@
 
 disabled_rules:
   - switch_case_alignment
+  - void_function_in_ternary
+opt_in_rules:
+  - force_unwrapping
+  - trailing_semicolon
+  - trailing_whitespace
+  - type_body_length
+  - type_contents_order
+  - type_name
+  - unavailable_function
+  - unneeded_break_in_switch
+  - unneeded_parentheses_in_closure_argument
+  - unowned_variable_capture
+  - untyped_error_in_catch
+  - unused_capture_list
+  - unused_closure_parameter
+  - unused_control_flow_label
+  - unused_declaration
+  - unused_enumerated
+  - unused_import
+  - unused_optional_binding
+  - unused_setter_value
+  - valid_ibinspectable
+  - vertical_parameter_alignment
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace
+  - vertical_whitespace_between_cases
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - void_return
+  - weak_delegate
+  - xct_specific_matcher
+  - xctfail_message
+  - yoda_condition
 included: # paths to include during linting. `--path` is ignored if present.
  - ConsentViewController/Classes
- - Example/ConsentViewController_ExampleTests
+ - Example
 excluded: # paths to ignore during linting. Takes precedence over `included`.
-  - Pods
+  - Example/AuthExample
+  - Example/Pods
+  - Example/SourcePointMetaAppUITests
+  - Example/SourcePointMetaApp
 identifier_name:
   min_length:
     - 1

--- a/ConsentViewController/Classes/ConnectivityManager.swift
+++ b/ConsentViewController/Classes/ConnectivityManager.swift
@@ -13,7 +13,6 @@ protocol Connectivity {
 }
 
 final class ConnectivityManager: Connectivity {
-
     /// Initializer support for Instance.
     public init() {}
 

--- a/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
@@ -75,16 +75,13 @@ protocol CampaignConsent {
  That is, if the user has rejected `.All` or `.None` vendors/categories, those arrays will be empty.
  */
 @objcMembers public class SPCCPAConsent: NSObject, Codable, CampaignConsent {
+    enum CodingKeys: CodingKey {
+        case status, rejectedVendors, rejectedCategories, uspstring, uuid, childPmId, consentStatus
+    }
+
     /// represents the default state of the consumer prior to seeing the consent message
     /// - seealso: https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md#us-privacy-string-format
     public static let defaultUsPrivacyString = "1---"
-
-    public static func empty() -> SPCCPAConsent { SPCCPAConsent(
-        status: .RejectedNone,
-        rejectedVendors: [],
-        rejectedCategories: [],
-        uspstring: defaultUsPrivacyString
-    )}
 
     /// Indicates if the user has rejected `.All`, `.Some` or `.None` of the vendors **and** categories.
     public var status: CCPAConsentStatus
@@ -111,12 +108,9 @@ protocol CampaignConsent {
 
     var consentStatus: ConsentStatus
 
-    public static func rejectedNone () -> SPCCPAConsent { SPCCPAConsent(
-        status: CCPAConsentStatus.RejectedNone,
-        rejectedVendors: [],
-        rejectedCategories: [],
-        uspstring: ""
-    )}
+    override open var description: String {
+        "UserConsent(uuid: \(uuid ?? ""), status: \(status.rawValue), rejectedVendors: \(rejectedVendors), rejectedCategories: \(rejectedCategories), uspstring: \(uspstring))"
+    }
 
     init(
         uuid: String? = nil,
@@ -136,26 +130,6 @@ protocol CampaignConsent {
         self.consentStatus = consentStatus
     }
 
-    open override var description: String {
-        "UserConsent(uuid: \(uuid ?? ""), status: \(status.rawValue), rejectedVendors: \(rejectedVendors), rejectedCategories: \(rejectedCategories), uspstring: \(uspstring))"
-    }
-
-    enum CodingKeys: CodingKey {
-        case status, rejectedVendors, rejectedCategories, uspstring, uuid, childPmId, consentStatus
-    }
-
-    public override func isEqual(_ object: Any?) -> Bool {
-        if let other = object as? SPCCPAConsent {
-            return other.uuid == uuid &&
-            other.rejectedCategories.elementsEqual(rejectedCategories) &&
-            other.rejectedVendors.elementsEqual(rejectedVendors) &&
-            other.status == status &&
-            other.uspstring == uspstring
-        } else {
-            return false
-        }
-    }
-
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         status = try container.decode(CCPAConsentStatus.self, forKey: .status)
@@ -165,5 +139,31 @@ protocol CampaignConsent {
         uuid = try container.decodeIfPresent(String.self, forKey: .uuid)
         childPmId = try container.decodeIfPresent(String.self, forKey: .childPmId)
         consentStatus = try (try? container.decode(ConsentStatus.self, forKey: .consentStatus)) ?? ConsentStatus(from: decoder)
+    }
+
+    public static func rejectedNone () -> SPCCPAConsent { SPCCPAConsent(
+        status: CCPAConsentStatus.RejectedNone,
+        rejectedVendors: [],
+        rejectedCategories: [],
+        uspstring: ""
+    )}
+
+    public static func empty() -> SPCCPAConsent { SPCCPAConsent(
+        status: .RejectedNone,
+        rejectedVendors: [],
+        rejectedCategories: [],
+        uspstring: defaultUsPrivacyString
+    )}
+
+    override public func isEqual(_ object: Any?) -> Bool {
+        if let other = object as? SPCCPAConsent {
+            return other.uuid == uuid &&
+            other.rejectedCategories.elementsEqual(rejectedCategories) &&
+            other.rejectedVendors.elementsEqual(rejectedVendors) &&
+            other.status == status &&
+            other.uspstring == uspstring
+        } else {
+            return false
+        }
     }
 }

--- a/ConsentViewController/Classes/Consents/SPUserData.swift
+++ b/ConsentViewController/Classes/Consents/SPUserData.swift
@@ -16,12 +16,12 @@ public class SPConsent<ConsentType: Codable & Equatable>: NSObject, Codable {
     /// based on the user's IP. **SP does not store the user's IP.**
     public let applies: Bool
 
+    override public var description: String { "applies: \(applies), consents: \(String(describing: consents))" }
+
     public init(consents: ConsentType?, applies: Bool) {
         self.consents = consents
         self.applies = applies
     }
-
-    public override var description: String { "applies: \(applies), consents: \(String(describing: consents))" }
 
     override public func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? Self else { return false }
@@ -38,6 +38,8 @@ public class SPConsent<ConsentType: Codable & Equatable>: NSObject, Codable {
     /// - SeeAlso: `SPCCPAConsent`
     public let ccpa: SPConsent<SPCCPAConsent>?
 
+    override public var description: String { "gdpr: \(String(describing: gdpr)), ccpa: \(String(describing: ccpa))" }
+
     public init(
         gdpr: SPConsent<SPGDPRConsent>? = nil,
         ccpa: SPConsent<SPCCPAConsent>? = nil
@@ -46,9 +48,7 @@ public class SPConsent<ConsentType: Codable & Equatable>: NSObject, Codable {
         self.ccpa = ccpa
     }
 
-    public override var description: String { "gdpr: \(String(describing: gdpr)), ccpa: \(String(describing: ccpa))" }
-
-    open override func isEqual(_ object: Any?) -> Bool {
+    override open func isEqual(_ object: Any?) -> Bool {
         if let object = object as? SPUserData {
             return  self.gdpr?.applies == object.gdpr?.applies &&
                     self.gdpr?.consents?.uuid == object.gdpr?.consents?.uuid &&

--- a/ConsentViewController/Classes/Constants.swift
+++ b/ConsentViewController/Classes/Constants.swift
@@ -5,6 +5,8 @@
 //  Created by Andre Herculano on 22.09.21.
 //
 
+// swiftlint:disable force_unwrapping
+
 import Foundation
 import UIKit
 

--- a/ConsentViewController/Classes/LocalStorage/SPLocalStorage.swift
+++ b/ConsentViewController/Classes/LocalStorage/SPLocalStorage.swift
@@ -52,7 +52,7 @@ protocol SPLocalStorage {
 
     var spState: SourcepointClientCoordinator.State? { get set }
 
-    func clear()
-
     init(storage: Storage)
+
+    func clear()
 }

--- a/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
+++ b/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 class SPUserDefaults: SPLocalStorage {
-    static public let SP_KEY_PREFIX = "sp_"
-    static public let IAB_KEY_PREFIX = "IABTCF_"
-    static public let US_PRIVACY_STRING_KEY = "IABUSPrivacy_String"
+    public static let SP_KEY_PREFIX = "sp_"
+    public static let IAB_KEY_PREFIX = "IABTCF_"
+    public static let US_PRIVACY_STRING_KEY = "IABUSPrivacy_String"
 
     static let LOCAL_STATE_KEY = "\(SP_KEY_PREFIX)localState"
     static let USER_DATA_KEY = "\(SP_KEY_PREFIX)userData"
@@ -82,9 +82,9 @@ class SPUserDefaults: SPLocalStorage {
     }
 
     func dictionaryRepresentation() -> [String: Any?] {[
-        SPUserDefaults.USER_DATA_KEY: userData,
-        SPUserDefaults.US_PRIVACY_STRING_KEY: usPrivacyString,
-        SPUserDefaults.LOCAL_STATE_KEY: localState
+        Self.USER_DATA_KEY: userData,
+        Self.US_PRIVACY_STRING_KEY: usPrivacyString,
+        Self.LOCAL_STATE_KEY: localState
     ].merging(tcfData ?? [:]) { item, _ in item }}
 
     func clear() {

--- a/ConsentViewController/Classes/SPAction.swift
+++ b/ConsentViewController/Classes/SPAction.swift
@@ -53,27 +53,16 @@ import Foundation
         }
         return nil
     }
-    public var pmPayload: SPJson = SPJson()
+    public var pmPayload = SPJson()
     public var publisherData: SPPublisherData = [:]
     public var customActionId: String?
 
-    public override var description: String {
+    override public var description: String {
         """
         SPAction(type: \(type), consentLanguage: \(consentLanguage ?? ""), \
         payload: \(pmPayload), publisherData: \(String(describing: publisherData)),
         customActionId: \(customActionId ?? ""))
         """
-    }
-
-    public override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? SPAction else {
-            return false
-        }
-        return other.type == type &&
-            other.consentLanguage == consentLanguage &&
-            other.pmURL == pmURL &&
-            other.pmPayload == pmPayload &&
-            other.publisherData == publisherData
     }
 
     public init(
@@ -90,5 +79,16 @@ import Foundation
         self.pmPayload = pmPayload
         self.pmURL = pmurl
         self.customActionId = customActionId
+    }
+
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? SPAction else {
+            return false
+        }
+        return other.type == type &&
+        other.consentLanguage == consentLanguage &&
+        other.pmURL == pmURL &&
+        other.pmPayload == pmPayload &&
+        other.publisherData == publisherData
     }
 }

--- a/ConsentViewController/Classes/SPCampaignEnv.swift
+++ b/ConsentViewController/Classes/SPCampaignEnv.swift
@@ -43,9 +43,9 @@ extension SPCampaignEnv: Codable {
     public init(from decoder: Decoder) throws {
         do {
             if #available(iOS 11, *) {
-                self = try SPCampaignEnv.decodeFromSingleValue(decoder)!
+                self = try SPCampaignEnv.decodeFromSingleValue(decoder)
             } else {
-                self = try SPCampaignEnv.decodeFromArray(decoder)!
+                self = try SPCampaignEnv.decodeFromArray(decoder)
             }
         } catch {
             throw DecodingError.dataCorrupted(DecodingError.Context(
@@ -55,14 +55,14 @@ extension SPCampaignEnv: Codable {
         }
     }
 
-    static func decodeFromSingleValue(_ decoder: Decoder) throws -> SPCampaignEnv? {
+    static func decodeFromSingleValue(_ decoder: Decoder) throws -> SPCampaignEnv {
         let container = try decoder.singleValueContainer()
-        return SPCampaignEnv(stringValue: try container.decode(String.self))
+        return SPCampaignEnv(stringValue: try container.decode(String.self)) ?? .Public
     }
 
-    static func decodeFromArray(_ decoder: Decoder) throws -> SPCampaignEnv? {
+    static func decodeFromArray(_ decoder: Decoder) throws -> SPCampaignEnv {
         var container = try decoder.unkeyedContainer()
-        return SPCampaignEnv(stringValue: try container.decode(String.self))
+        return SPCampaignEnv(stringValue: try container.decode(String.self)) ?? .Public
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/ConsentViewController/Classes/SPCampaigns.swift
+++ b/ConsentViewController/Classes/SPCampaigns.swift
@@ -15,7 +15,7 @@ public typealias SPTargetingParams = [String: String]
     let targetingParams: SPTargetingParams
     let groupPmId: String?
 
-    public override var description: String {
+    override public var description: String {
         "SPCampaign(targetingParams: \(targetingParams), groupPmId: \(groupPmId as Any))"
     }
 
@@ -35,7 +35,7 @@ public typealias SPTargetingParams = [String: String]
     let environment: SPCampaignEnv
     let gdpr, ccpa, ios14: SPCampaign?
 
-    public override var description: String {
+    override public var description: String {
         """
         SPCampaigns
             - gdpr: \(gdpr as Any)

--- a/ConsentViewController/Classes/SPDateCreated.swift
+++ b/ConsentViewController/Classes/SPDateCreated.swift
@@ -25,7 +25,7 @@ public struct SPDateCreated: Codable, Equatable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         originalDateString = try container.decode(String.self)
-        date = Self.format.date(from: originalDateString)!
+        date = Self.format.date(from: originalDateString) ?? Date()
     }
 
     static func now() -> SPDateCreated {

--- a/ConsentViewController/Classes/SPDateCreated.swift
+++ b/ConsentViewController/Classes/SPDateCreated.swift
@@ -17,19 +17,19 @@ public struct SPDateCreated: Codable, Equatable {
     let originalDateString: String
     let date: Date
 
-    static func now() -> SPDateCreated {
-        SPDateCreated(date: Date())
-    }
-
     private init(date: Date) {
         self.date = date
-        originalDateString = SPDateCreated.format.string(from: date)
+        originalDateString = Self.format.string(from: date)
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         originalDateString = try container.decode(String.self)
-        date = SPDateCreated.format.date(from: originalDateString)!
+        date = Self.format.date(from: originalDateString)!
+    }
+
+    static func now() -> SPDateCreated {
+        SPDateCreated(date: Date())
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/ConsentViewController/Classes/SPDeviceManager.swift
+++ b/ConsentViewController/Classes/SPDeviceManager.swift
@@ -17,7 +17,7 @@ struct SPDevice: SPDeviceManager {
     /// Returns the Version of the OS. E.g 1.2
     /// - SeeAlso: UIDevice.current.systemVersion
     func osVersion() -> String {
-        return UIDevice.current.systemVersion
+        UIDevice.current.systemVersion
     }
 
     /// Tries to get the device family from its unix. If none can be found it returns `apple-unknown`.

--- a/ConsentViewController/Classes/SPError.swift
+++ b/ConsentViewController/Classes/SPError.swift
@@ -304,3 +304,8 @@ import Foundation
 @objcMembers public class InvalidChoiceAllResponseError: SPError {
     override public var spCode: String { "sp_metric_invalid_choice_all_response" }
 }
+
+// swiftlint:disable:next type_name
+@objcMembers public class UnableToConvertConsentSnapshotIntoJsonError: SPError {
+    override public var spCode: String { "sp_metric_error_converting_consent_snapshot_to_json" }
+}

--- a/ConsentViewController/Classes/SPError.swift
+++ b/ConsentViewController/Classes/SPError.swift
@@ -22,11 +22,14 @@ import Foundation
         originalError = error
         self.campaignType = campaignType
     }
-    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
 }
 
 @objcMembers public class UnableToFindView: SPError {
-    public override var spCode: String { "sp_metric_unable_to_find_view" }
+    override public var spCode: String { "sp_metric_unable_to_find_view" }
     override public var description: String { "Unable to find view with id: (\(viewId))" }
 
     let viewId: String
@@ -36,11 +39,12 @@ import Foundation
         super.init()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
 @objcMembers public class UnableToLoadJSReceiver: SPError {
-    public override var spCode: String { "sp_metric_unable_to_load_jsreceiver" }
+    override public var spCode: String { "sp_metric_unable_to_load_jsreceiver" }
     override public var description: String { "Unable to load the JSReceiver.js resource." }
 }
 
@@ -60,6 +64,7 @@ import Foundation
         self.campaignType = campaignType
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
@@ -72,6 +77,7 @@ import Foundation
         super.init()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
@@ -85,14 +91,15 @@ import Foundation
         super.init()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
 /// Invalid Rendering App (JSReceiver) event payloads
 @objcMembers public class InvalidEventPayloadError: SPError {
-    public override var failureReason: String { description }
-    public override var spCode: String { "sp_metric_invalid_event_payload" }
-    public override var description: String {
+    override public var failureReason: String { description }
+    override public var spCode: String { "sp_metric_invalid_event_payload" }
+    override public var description: String {
         "Could not parse the event: \(name) with body: \(body)"
     }
 
@@ -104,11 +111,12 @@ import Foundation
         super.init()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
 @objcMembers public class InvalidOnActionEventPayloadError: InvalidEventPayloadError {
-    public override var spCode: String { "sp_metric_invalid_onAction_event_payload" }
+    override public var spCode: String { "sp_metric_invalid_onAction_event_payload" }
 }
 
 @objcMembers public class InvalidURLError: SPError {
@@ -122,11 +130,12 @@ import Foundation
         super.init()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
 @objcMembers public class RenderingAppError: SPError {
-    public override var spCode: String { renderingAppErrorCode ?? "sp_metric_rendering_app_error" }
+    override public var spCode: String { renderingAppErrorCode ?? "sp_metric_rendering_app_error" }
     public let renderingAppErrorCode: String?
 
     init(campaignType: SPCampaignType, _ renderingAppErrorCode: String?) {
@@ -135,11 +144,12 @@ import Foundation
         self.campaignType = campaignType
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
 @objcMembers public class UnableToInjectMessageIntoRenderingApp: SPError {
-    public override var spCode: String { "sp_metric_unable_to_stringify_msgJSON" }
+    override public var spCode: String { "sp_metric_unable_to_stringify_msgJSON" }
     override public var description: String { "The SDK could convert the message into JSON." }
 }
 
@@ -219,6 +229,7 @@ import Foundation
         self.campaignType = campaignType
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
@@ -237,6 +248,7 @@ import Foundation
         super.init()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
@@ -258,7 +270,7 @@ import Foundation
         "Tried to post consent but the stored consentUUID is empty or nil. Make sure to call .loadMessage or .loadPrivacyManager first."
     }
 
-    public override var campaignType: SPCampaignType { get { .gdpr } set {} }
+    override public var campaignType: SPCampaignType { get { .gdpr } set {} }
 }
 
 @objcMembers public class InvalidMetaDataQueryParamsError: SPError {

--- a/ConsentViewController/Classes/SPIDFAStatus.swift
+++ b/ConsentViewController/Classes/SPIDFAStatus.swift
@@ -5,9 +5,9 @@
 //  Created by Andre Herculano on 09.02.21.
 //
 
-import Foundation
-import AppTrackingTransparency
 import AdSupport
+import AppTrackingTransparency
+import Foundation
 
 /// Maps `ATTrackingManager.requestTrackingAuthorization` into our own enum.
 /// It covers also the case when `ATTrackingManager.AuthorizationStatus` is not available.
@@ -20,6 +20,31 @@ import AdSupport
     case denied = 2
     /// the IDFA is not available in this version of the OS
     case unavailable = 3
+
+    public var description: String {
+        switch self {
+        case .unknown: return "unknown"
+        case .accepted: return "accepted"
+        case .denied: return "denied"
+        case .unavailable: return "unavailable"
+        }
+    }
+
+    @available(iOS 14, tvOS 14, *)
+    public init(fromApple status: ATTrackingManager.AuthorizationStatus) {
+        switch status {
+        case .authorized:
+            self = .accepted
+
+        case .denied, .restricted:
+            self = .denied
+
+        case .notDetermined:
+            self = .unknown
+        @unknown default:
+            self = .unknown
+        }
+    }
 
     /// Prompts the user to allow access to the IDFA and calls the callback with the result.
     /// If the user has already been prompted, it calls the callback with the current status.
@@ -46,29 +71,6 @@ import AdSupport
             return .unavailable
         }
     }
-
-    public var description: String {
-        switch self {
-        case .unknown: return "unknown"
-        case .accepted: return "accepted"
-        case .denied: return "denied"
-        case .unavailable: return "unavailable"
-        }
-    }
-
-    @available(iOS 14, tvOS 14, *)
-    public init(fromApple status: ATTrackingManager.AuthorizationStatus) {
-        switch status {
-        case .authorized:
-            self = .accepted
-        case .denied, .restricted:
-            self = .denied
-        case .notDetermined:
-            self = .unknown
-        @unknown default:
-            self = .unknown
-        }
-    }
 }
 
 extension SPIDFAStatus: Codable {
@@ -78,6 +80,7 @@ extension SPIDFAStatus: Codable {
         case .accepted: try container.encode("accepted")
         case .denied: try container.encode("denied")
         case .unknown: try container.encode("unknown")
+
         default:
             try container.encode("unavailable")
         }

--- a/ConsentViewController/Classes/SPJson.swift
+++ b/ConsentViewController/Classes/SPJson.swift
@@ -8,6 +8,102 @@
 import Foundation
 
 public enum SPJson: Codable, CustomStringConvertible, Equatable {
+    case string(String)
+    case number(Double)
+    case object([Key: SPJson])
+    case array([SPJson])
+    case bool(Bool)
+    case null
+
+    public struct Key: CodingKey, Hashable, CustomStringConvertible {
+        public var description: String {
+            stringValue
+        }
+
+        public let stringValue: String
+        public init(_ string: String) { self.stringValue = string }
+        public init?(stringValue: String) { self.init(stringValue) }
+        public var intValue: Int? { nil }
+        public init?(intValue: Int) { nil }
+    }
+
+    public var objectValue: [String: SPJson]? {
+        switch self {
+            case .object(let object):
+                let mapped: [String: SPJson] = Dictionary(uniqueKeysWithValues:
+                                                            object.map { key, value in (key.stringValue, value) })
+                return mapped
+            default: return nil
+        }
+    }
+
+    public var arrayValue: [SPJson]? {
+        switch self {
+            case .array(let array): return array
+            default: return nil
+        }
+    }
+
+    public var stringValue: String? {
+        switch self {
+            case .string(let string): return string
+            default: return nil
+        }
+    }
+
+    public var nullValue: Any? {
+        nil
+    }
+
+    public var doubleValue: Double? {
+        switch self {
+            case .number(let number): return number
+            default: return nil
+        }
+    }
+
+    public var intValue: Int? {
+        switch self {
+            case .number(let number): return Int(number)
+            default: return nil
+        }
+    }
+
+    public var boolValue: Bool? {
+        switch self {
+            case .bool(let bool): return bool
+            default: return nil
+        }
+    }
+
+    public var anyValue: Any? {
+        switch self {
+            case .string(let string): return string
+
+            case .number(let number):
+                if let int = Int(exactly: number) { return int } else { return number }
+            case .bool(let bool): return bool
+
+            case .object(let object):
+                return Dictionary(uniqueKeysWithValues:
+                                    object.compactMap { key, value -> (String, Any)? in
+                    if let nonNilValue = value.anyValue {
+                        return (key.stringValue, nonNilValue)
+                    } else { return nil }
+                })
+
+            case .array(let array):
+                return array.compactMap { $0.anyValue }
+
+            case .null:
+                return nil
+        }
+    }
+
+    public var dictionaryValue: [String: Any]? {
+        anyValue as? [String: Any]
+    }
+
     public var description: String {
         switch self {
         case .string(let string): return "\"\(string)\""
@@ -17,9 +113,10 @@ public enum SPJson: Codable, CustomStringConvertible, Equatable {
             } else {
                 return "\(double)"
             }
+
         case .object(let object):
             let keyValues = object
-                .map { (key, value) in "\"\(key)\": \(value)" }
+                .map { key, value in "\"\(key)\": \(value)" }
                 .joined(separator: ",")
             return "{\(keyValues)}"
         case .array(let array):
@@ -30,25 +127,6 @@ public enum SPJson: Codable, CustomStringConvertible, Equatable {
             return "null"
         }
     }
-
-    public struct Key: CodingKey, Hashable, CustomStringConvertible {
-        public var description: String {
-            return stringValue
-        }
-
-        public let stringValue: String
-        public init(_ string: String) { self.stringValue = string }
-        public init?(stringValue: String) { self.init(stringValue) }
-        public var intValue: Int? { return nil }
-        public init?(intValue: Int) { return nil }
-    }
-
-    case string(String)
-    case number(Double)
-    case object([Key: SPJson])
-    case array([SPJson])
-    case bool(Bool)
-    case null
 
     /// Creates the equivalent of an empty object JSON
     public init() {
@@ -65,20 +143,23 @@ public enum SPJson: Codable, CustomStringConvertible, Equatable {
         } else if let number = try? decoder.singleValueContainer().decode(Double.self) { self = .number(number) } else if let object = try? decoder.container(keyedBy: Key.self) {
             var result: [Key: SPJson] = [:]
             for key in object.allKeys {
-                result[key] = (try? object.decode(SPJson.self, forKey: key)) ?? .null
+                result[key] = (try? object.decode(Self.self, forKey: key)) ?? .null
             }
             self = .object(result)
         } else if var array = try? decoder.unkeyedContainer() {
             var result: [SPJson] = []
             for _ in 0..<(array.count ?? 0) {
-                result.append(try array.decode(SPJson.self))
+                result.append(try array.decode(Self.self))
             }
             self = .array(result)
         } else if let bool = try? decoder.singleValueContainer().decode(Bool.self) {
             self = .bool(bool)
         } else if let isNull = try? decoder.singleValueContainer().decodeNil(), isNull { self = .null
-        } else { throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [],
-                                                                       debugDescription: "Unknown SPJson type")) }
+        } else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(
+                codingPath: [],
+                debugDescription: "Unknown SPJson type"))
+        }
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -86,118 +167,50 @@ public enum SPJson: Codable, CustomStringConvertible, Equatable {
         case .string(let string):
             var container = encoder.singleValueContainer()
             try container.encode(string)
+
         case .number(let number):
             var container = encoder.singleValueContainer()
             try container.encode(number)
+
         case .bool(let bool):
             var container = encoder.singleValueContainer()
             try container.encode(bool)
+
         case .object(let object):
             var container = encoder.container(keyedBy: Key.self)
             for (key, value) in object {
                 try container.encode(value, forKey: key)
             }
+
         case .array(let array):
             var container = encoder.unkeyedContainer()
             for value in array {
                 try container.encode(value)
             }
+
         case .null:
             var container = encoder.singleValueContainer()
             try container.encodeNil()
         }
     }
 
-    public var objectValue: [String: SPJson]? {
-        switch self {
-        case .object(let object):
-            let mapped: [String: SPJson] = Dictionary(uniqueKeysWithValues:
-                object.map { (key, value) in (key.stringValue, value) })
-            return mapped
-        default: return nil
-        }
-    }
-
-    public var arrayValue: [SPJson]? {
-        switch self {
-        case .array(let array): return array
-        default: return nil
-        }
+    public subscript(dynamicMember member: String) -> SPJson {
+        self[member] ?? .null
     }
 
     public subscript(key: String) -> SPJson? {
         guard let jsonKey = Key(stringValue: key),
-            case .object(let object) = self,
-            let value = object[jsonKey]
-            else { return nil }
+              case .object(let object) = self,
+              let value = object[jsonKey]
+        else { return nil }
         return value
-    }
-
-    public var stringValue: String? {
-        switch self {
-        case .string(let string): return string
-        default: return nil
-        }
-    }
-
-    public var nullValue: Any? {
-        return nil
-    }
-
-    public var doubleValue: Double? {
-        switch self {
-        case .number(let number): return number
-        default: return nil
-        }
-    }
-
-    public var intValue: Int? {
-        switch self {
-        case .number(let number): return Int(number)
-        default: return nil
-        }
     }
 
     public subscript(index: Int) -> SPJson? {
         switch self {
-        case .array(let array): return array[index]
-        default: return nil
+            case .array(let array): return array[index]
+            default: return nil
         }
-    }
-
-    public var boolValue: Bool? {
-        switch self {
-        case .bool(let bool): return bool
-        default: return nil
-        }
-    }
-
-    public var anyValue: Any? {
-        switch self {
-        case .string(let string): return string
-        case .number(let number):
-            if let int = Int(exactly: number) { return int } else { return number }
-        case .bool(let bool): return bool
-        case .object(let object):
-            return Dictionary(uniqueKeysWithValues:
-                object.compactMap { (key, value) -> (String, Any)? in
-                    if let nonNilValue = value.anyValue {
-                        return (key.stringValue, nonNilValue)
-                    } else { return nil }
-                })
-        case .array(let array):
-            return array.compactMap { $0.anyValue }
-        case .null:
-            return nil
-        }
-    }
-
-    public var dictionaryValue: [String: Any]? {
-        return anyValue as? [String: Any]
-    }
-
-    public subscript(dynamicMember member: String) -> SPJson {
-        return self[member] ?? .null
     }
 }
 
@@ -207,8 +220,10 @@ public extension SPJson {
             switch CFGetTypeID(number as CFTypeRef) {
             case CFBooleanGetTypeID():
                 self = .bool(number.boolValue)
+
             case CFNumberGetTypeID():
                 self = .number(number.doubleValue)
+
             default:
                 throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Cannot encode value"))
             }

--- a/ConsentViewController/Classes/SPMessage.swift
+++ b/ConsentViewController/Classes/SPMessage.swift
@@ -8,5 +8,4 @@
 import Foundation
 
 @objcMembers public class SPMessage {
-
 }

--- a/ConsentViewController/Classes/SPMessageLanguage.swift
+++ b/ConsentViewController/Classes/SPMessageLanguage.swift
@@ -185,6 +185,7 @@ import Foundation
             self = .Swedish
         case "TR":
             self = .Turkish
+
         default:
             return nil
         }

--- a/ConsentViewController/Classes/SPMessageViewController.swift
+++ b/ConsentViewController/Classes/SPMessageViewController.swift
@@ -53,7 +53,8 @@ extension RenderingAppEvents: RawRepresentable {
 
 extension RenderingAppEvents: ExpressibleByStringLiteral {
     init(stringLiteral value: String) {
-        self.init(rawValue: value)!
+        let event = RenderingAppEvents(rawValue: value)
+        self = event ?? .unknown(value)
     }
 }
 

--- a/ConsentViewController/Classes/SPMessageViewController.swift
+++ b/ConsentViewController/Classes/SPMessageViewController.swift
@@ -5,6 +5,8 @@
 //  Created by Andre Herculano on 03.03.21.
 //
 
+// swiftlint:disable unavailable_function
+
 import Foundation
 import UIKit
 
@@ -26,6 +28,17 @@ extension RenderingAppEvents: RawRepresentable {
 
     typealias RawValue = String
 
+    var rawValue: String {
+        switch self {
+            case .readyForPreload: return "readyForPreload"
+            case .onMessageReady: return "onMessageReady"
+            case .onPMReady: return "onPMReady"
+            case .onAction: return "onAction"
+            case .onError: return "onError"
+            case let .unknown(event): return event ?? ""
+        }
+    }
+
     init?(rawValue: String) {
         switch rawValue {
         case "readyForPreload": self = .readyForPreload
@@ -34,17 +47,6 @@ extension RenderingAppEvents: RawRepresentable {
         case "onAction": self = .onAction
         case "onError": self = .onError
         case let event: self = .unknown(event)
-        }
-    }
-
-    var rawValue: String {
-        switch self {
-        case .readyForPreload: return "readyForPreload"
-        case .onMessageReady: return "onMessageReady"
-        case .onPMReady: return "onPMReady"
-        case .onAction: return "onAction"
-        case .onError: return "onError"
-        case let .unknown(event): return event ?? ""
         }
     }
 }

--- a/ConsentViewController/Classes/SPNativeMessage.swift
+++ b/ConsentViewController/Classes/SPNativeMessage.swift
@@ -8,36 +8,11 @@
 import Foundation
 
 @objc public class SPNativeMessage: NSObject, Decodable, SPMessageView {
-    /// Used to notify the `SPConsentManager` about its different lifecycle events.
-    public weak var messageUIDelegate: SPMessageUIDelegate?
-
-    /// Indicates the type of the campaign for this message
-    /// - SeeMore: `SPCampaignType`
-    public var campaignType: SPCampaignType
-
-    /// The id of the message received from the server
-    public var messageId: String = ""
-
-    /// Unused by the native message
-    public var timeout: TimeInterval = 10.0
-
-    public func loadMessage() {
-        messageUIDelegate?.loaded?(self)
-    }
-
-    /// no-op the SPNativeMessage class is not responsible for loading the Privacy Manager
-    /// The will get a call to `onSPUIReady(_ controller: UIViewController)` when the PM
-    /// is ready to be displayed
-    public func loadPrivacyManager(url: URL) {
-    }
-
-    /// no-op the SPNativeMessage class is not responsible for loading the Privacy Manager
-    /// The will get a call to `onSPUIFinished(_ controller: UIViewController)` when the PM
-    /// is ready to be closed
-    public func closePrivacyManager() {
-    }
-
     public typealias CustomFields = [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case title, body, actions, customFields
+    }
 
     @objc public class AttributeStyle: NSObject, Codable {
         public let fontFamily: String
@@ -94,7 +69,7 @@ import Foundation
             )
         }
 
-        public override func encode(to encoder: Encoder) throws {
+        override public func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
 
             var container = encoder.container(keyedBy: CodingKeys.self)
@@ -105,6 +80,19 @@ import Foundation
             case text, style, customFields, choiceType, url
         }
     }
+
+    /// Used to notify the `SPConsentManager` about its different lifecycle events.
+    public weak var messageUIDelegate: SPMessageUIDelegate?
+
+    /// Indicates the type of the campaign for this message
+    /// - SeeMore: `SPCampaignType`
+    public var campaignType: SPCampaignType
+
+    /// The id of the message received from the server
+    public var messageId: String = ""
+
+    /// Unused by the native message
+    public var timeout: TimeInterval = 10.0
 
     public let title: Attribute
     public let body: Attribute
@@ -128,7 +116,19 @@ import Foundation
         campaignType = .unknown
     }
 
-    enum CodingKeys: String, CodingKey {
-        case title, body, actions, customFields
+    public func loadMessage() {
+        messageUIDelegate?.loaded?(self)
+    }
+
+    /// no-op the SPNativeMessage class is not responsible for loading the Privacy Manager
+    /// The will get a call to `onSPUIReady(_ controller: UIViewController)` when the PM
+    /// is ready to be displayed
+    public func loadPrivacyManager(url: URL) {
+    }
+
+    /// no-op the SPNativeMessage class is not responsible for loading the Privacy Manager
+    /// The will get a call to `onSPUIFinished(_ controller: UIViewController)` when the PM
+    /// is ready to be closed
+    public func closePrivacyManager() {
     }
 }

--- a/ConsentViewController/Classes/SPPrivacyManagerTab.swift
+++ b/ConsentViewController/Classes/SPPrivacyManagerTab.swift
@@ -39,6 +39,7 @@ import Foundation
             self = .Vendors
         case "features":
             self = .Features
+
         default:
             return nil
         }

--- a/ConsentViewController/Classes/SPPropertyName.swift
+++ b/ConsentViewController/Classes/SPPropertyName.swift
@@ -14,6 +14,27 @@ import Foundation
     /// Up and lowercase letters, dots, semicollons, numbers and dashes
     static let validPattern = "^[a-zA-Z.:/0-9-]*$"
 
+    let rawValue: String
+
+    override public var description: String {
+        rawValue.replacingOccurrences(of: "https://", with: "")
+    }
+
+    /// - Parameter rawValue: the exact name of your property as created in SourcePoint's dashboard.
+    /// - Throws: `InvalidArgumentError` if the property name contain anything other than letters, numbers, . (dots), : (semicolons) and / (slashes).
+    public init(_ rawValue: String) throws {
+        var validRawValue = try Self.validate(rawValue)
+        if !validRawValue.starts(with: "https://") && !validRawValue.starts(with: "http://") {
+            validRawValue = "https://" + validRawValue
+        }
+        self.rawValue = validRawValue
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.rawValue = try Self.validate(try container.decode(String.self))
+    }
+
     private static func validate(_ string: String) throws -> String {
         let regex = try NSRegularExpression(pattern: validPattern, options: [])
         if regex.matches(in: string, options: [], range: NSRange(location: 0, length: string.count)).isEmpty {
@@ -23,32 +44,12 @@ import Foundation
         }
     }
 
-    let rawValue: String
-    public override var description: String {
-        rawValue.replacingOccurrences(of: "https://", with: "")
-    }
-
-    /// - Parameter rawValue: the exact name of your property as created in SourcePoint's dashboard.
-    /// - Throws: `InvalidArgumentError` if the property name contain anything other than letters, numbers, . (dots), : (semicolons) and / (slashes).
-    public init(_ rawValue: String) throws {
-        var validRawValue = try SPPropertyName.validate(rawValue)
-        if !validRawValue.starts(with: "https://") && !validRawValue.starts(with: "http://") {
-            validRawValue = "https://" + validRawValue
-        }
-        self.rawValue = validRawValue
-    }
-
-    required public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.rawValue = try SPPropertyName.validate(try container.decode(String.self))
-    }
-
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(self.rawValue)
     }
 
-    public override func isEqual(_ object: Any?) -> Bool {
+    override public func isEqual(_ object: Any?) -> Bool {
         if let other = object as? SPPropertyName {
             return other.rawValue == rawValue
         } else {

--- a/ConsentViewController/Classes/SPSDK.swift
+++ b/ConsentViewController/Classes/SPSDK.swift
@@ -8,18 +8,19 @@
 import Foundation
 
 @objc public protocol SPCCPA {
-    @objc func loadCCPAPrivacyManager(withId id: String, tab: SPPrivacyManagerTab, useGroupPmIfAvailable: Bool)
     @objc var ccpaApplies: Bool { get }
+
+    @objc func loadCCPAPrivacyManager(withId id: String, tab: SPPrivacyManagerTab, useGroupPmIfAvailable: Bool)
 }
 
 @objc public protocol SPGDPR {
-    @objc func loadGDPRPrivacyManager(withId id: String, tab: SPPrivacyManagerTab, useGroupPmIfAvailable: Bool)
     @objc var gdprApplies: Bool { get }
+
+    @objc func loadGDPRPrivacyManager(withId id: String, tab: SPPrivacyManagerTab, useGroupPmIfAvailable: Bool)
 }
 
 @objc public protocol SPSDK: SPGDPR, SPCCPA, SPMessageUIDelegate {
     @objc static var VERSION: String { get }
-    @objc static func clearAllData()
     @objc var cleanUserDataOnError: Bool { get set }
     @objc var messageTimeoutInSeconds: TimeInterval { get set }
     @objc var privacyManagerTab: SPPrivacyManagerTab { get set }
@@ -33,6 +34,7 @@ import Foundation
         language: SPMessageLanguage,
         delegate: SPDelegate?
     )
+    @objc static func clearAllData()
     @objc func loadMessage(forAuthId authId: String?, publisherData: SPPublisherData?)
     @objc func customConsentGDPR(
         vendors: [String],

--- a/ConsentViewController/Classes/SPStringifiedJSON.swift
+++ b/ConsentViewController/Classes/SPStringifiedJSON.swift
@@ -28,6 +28,10 @@ extension SPStringifiedJSON: Collection {
     var startIndex: Index { raw.startIndex }
     var endIndex: Index { raw.endIndex }
 
+    func index(after i: SPStringifiedJSON.DictionaryType.Index) -> SPStringifiedJSON.DictionaryType.Index {
+        raw.index(after: i)
+    }
+
     subscript(index: Index) -> DictionaryType.Element {
         raw[index]
     }
@@ -39,9 +43,5 @@ extension SPStringifiedJSON: Collection {
         set {
             raw[key] = newValue
         }
-    }
-
-    func index(after i: SPStringifiedJSON.DictionaryType.Index) -> SPStringifiedJSON.DictionaryType.Index {
-        raw.index(after: i)
     }
 }

--- a/ConsentViewController/Classes/SPStringifiedJSON.swift
+++ b/ConsentViewController/Classes/SPStringifiedJSON.swift
@@ -12,7 +12,11 @@ class SPStringifiedJSON: Codable {
     var raw = DictionaryType()
 
     required init(from decoder: Decoder) throws {
-        let data = try decoder.singleValueContainer().decode(String.self).data(using: .utf8)!
+        guard let data = try decoder.singleValueContainer().decode(String.self).data(using: .utf8) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(
+                codingPath: [], debugDescription: "Unable to transform string field into Data"
+            ))
+        }
         raw = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] ?? [:]
     }
 

--- a/ConsentViewController/Classes/SourcePointClient/ChoiceAllResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ChoiceAllResponse.swift
@@ -49,6 +49,11 @@ struct ChoiceAllBodyRequest: QueryParamEncodable {
 }
 
 extension ChoiceAllResponse.CCPA: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case dateCreated, consentedAll, rejectedAll, status, rejectedVendors, rejectedCategories, gpcEnabled
+        case uspstring = "uspString"
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         try self.init(
@@ -61,10 +66,5 @@ extension ChoiceAllResponse.CCPA: Decodable {
             rejectedCategories: ((container.decodeIfPresent([String?].self, forKey: .rejectedCategories)) ?? []).compactMap { $0 },
             gpcEnabled: container.decodeIfPresent(Bool.self, forKey: .gpcEnabled)
         )
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case dateCreated, consentedAll, rejectedAll, status, rejectedVendors, rejectedCategories, gpcEnabled
-        case uspstring = "uspString"
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/ChoiceRequests.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ChoiceRequests.swift
@@ -11,7 +11,7 @@ struct GDPRChoiceBody: Encodable, Equatable {
     let authId, uuid, messageId, consentAllRef, vendorListId: String?
     let pubData: SPPublisherData
     let pmSaveAndExitVariables: SPJson?
-    let sendPVData = true // TODO: ask Sid/Dan what is this
+    let sendPVData: Bool
     let propertyId: Int
     let sampleRate: Float?
     let idfaStatus: SPIDFAStatus?
@@ -26,7 +26,7 @@ struct CCPAChoiceBody: Encodable, Equatable {
     let authId, uuid, messageId: String?
     let pubData: SPPublisherData
     let pmSaveAndExitVariables: SPJson?
-    let sendPVData = true // TODO: ask Sid/Dan what is this
+    let sendPVData: Bool
     let propertyId: Int
     let sampleRate: Float?
     let includeData = [

--- a/ConsentViewController/Classes/SourcePointClient/ChoiceResponses.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ChoiceResponses.swift
@@ -29,6 +29,10 @@ struct CCPAChoiceResponse: Equatable {
 }
 
 extension CCPAChoiceResponse: Decodable {
+    enum CodingKeys: CodingKey {
+        case uuid, dateCreated, consentedAll, rejectedAll, status, uspstring, rejectedVendors, rejectedCategories, gpcEnabled
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         try self.init(
@@ -42,9 +46,5 @@ extension CCPAChoiceResponse: Decodable {
             rejectedVendors: ((container.decodeIfPresent([String?].self, forKey: .rejectedVendors)) ?? []).compactMap { $0 },
             rejectedCategories: ((container.decodeIfPresent([String?].self, forKey: .rejectedCategories)) ?? []).compactMap { $0 }
         )
-    }
-
-    enum CodingKeys: CodingKey {
-        case uuid, dateCreated, consentedAll, rejectedAll, status, uspstring, rejectedVendors, rejectedCategories, gpcEnabled
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/ConsentRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ConsentRequestResponse.swift
@@ -33,6 +33,10 @@ struct CCPAConsentRequest: Encodable, Equatable {
 }
 
 struct ConsentResponse: Decodable & Equatable {
+    enum Keys: CodingKey {
+        case localState, userConsent
+    }
+
     let localState: SPJson
     let userConsent: Consent
 
@@ -45,9 +49,5 @@ struct ConsentResponse: Decodable & Equatable {
         case .ccpa(let consents): consents.uuid = localState["ccpa"]?["uuid"]?.stringValue
         default: break
         }
-    }
-
-    enum Keys: CodingKey {
-        case localState, userConsent
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/GDPRPrivacyManagerViewResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/GDPRPrivacyManagerViewResponse.swift
@@ -12,6 +12,15 @@ struct GDPRVendor: Decodable {
         case IAB, CUSTOM
     }
 
+    enum Keys: String, CodingKey {
+        case policyUrl, vendorId, name
+        case iabId
+        case iabSpecialPurposes, iabFeatures, iabSpecialFeatures
+        case description, cookieHeader
+        case vendorType
+        case consentCategories, legIntCategories
+    }
+
     struct Category: Decodable {
         let type: GDPRCategory.CategoryType
         let iabId: Int?
@@ -31,7 +40,7 @@ struct GDPRVendor: Decodable {
         name = try container.decode(String.self, forKey: .name)
         policyUrl = try? container.decodeIfPresent(URL.self, forKey: .policyUrl)
         vendorId = try container.decode(String.self, forKey: .vendorId)
-        vendorType = try container.decode(GDPRVendor.VendorType.self, forKey: .vendorType)
+        vendorType = try container.decode(Self.VendorType.self, forKey: .vendorType)
         iabId = try container.decodeIfPresent(Int.self, forKey: .iabId)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         cookieHeader = try container.decodeIfPresent(String.self, forKey: .cookieHeader)
@@ -40,15 +49,6 @@ struct GDPRVendor: Decodable {
         iabSpecialPurposes = try container.decode([String].self, forKey: .iabSpecialPurposes)
         iabFeatures = try container.decode([String].self, forKey: .iabFeatures)
         iabSpecialFeatures = try container.decode([String].self, forKey: .iabSpecialFeatures)
-    }
-
-    enum Keys: String, CodingKey {
-        case policyUrl, vendorId, name
-        case iabId
-        case iabSpecialPurposes, iabFeatures, iabSpecialFeatures
-        case description, cookieHeader
-        case vendorType
-        case consentCategories, legIntCategories
     }
 }
 
@@ -79,8 +79,10 @@ extension PrivacyManagerViewResponse: Decodable {
         switch campaignType {
         case .gdpr:
             self = .gdpr(try GDPRPrivacyManagerViewResponse(from: decoder))
+
         case .ccpa:
             self = .ccpa(try CCPAPrivacyManagerViewResponse(from: decoder))
+
         default:
             self = .unknown
         }
@@ -101,6 +103,11 @@ struct CCPAVendor: Hashable {
 }
 
 extension CCPAVendor: Decodable {
+    enum Keys: String, CodingKey {
+        case _id, name, policyUrl
+        case nullablePurposes = "purposes"
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: Keys.self)
         _id = try container.decode(String.self, forKey: ._id)
@@ -111,11 +118,6 @@ extension CCPAVendor: Decodable {
             policyUrl = nil
         }
         nullablePurposes = try container.decodeIfPresent([String?].self, forKey: .nullablePurposes)
-    }
-
-    enum Keys: String, CodingKey {
-        case _id, name, policyUrl
-        case nullablePurposes = "purposes"
     }
 }
 

--- a/ConsentViewController/Classes/SourcePointClient/IDFAStatusReportRequest.swift
+++ b/ConsentViewController/Classes/SourcePointClient/IDFAStatusReportRequest.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 struct AppleTrackingPayload: Codable {
-    let appleChoice: SPIDFAStatus
-    let appleMsgId: Int?
-    let messagePartitionUUID: String?
-
     enum CodingKeys: String, CodingKey {
         case appleChoice, appleMsgId
         case messagePartitionUUID = "partition_uuid"
     }
+
+    let appleChoice: SPIDFAStatus
+    let appleMsgId: Int?
+    let messagePartitionUUID: String?
 }
 
 struct IDFAStatusReportRequest: Codable {

--- a/ConsentViewController/Classes/SourcePointClient/MessagesResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MessagesResponse.swift
@@ -11,6 +11,7 @@ protocol Defaultable: Decodable & CaseIterable & RawRepresentable
 where RawValue: Decodable, AllCases: BidirectionalCollection { }
 extension Defaultable {
     init(from decoder: Decoder) throws {
+        // swiftlint:disable:next force_unwrapping
         self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? Self.allCases.last!
     }
 }
@@ -110,6 +111,7 @@ extension MessageJson: Codable {
     static func messageFromStringified<T: Decodable>(_ decoder: Decoder) throws -> T {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let stringifiedMessage = try container.decode(String.self, forKey: .message_json_string)
+        // swiftlint:disable:next force_unwrapping
         return try JSONDecoder().decode(T.self, from: stringifiedMessage.data(using: .utf8)!)
     }
 

--- a/ConsentViewController/Classes/SourcePointClient/QueryParamEncodableProtocol.swift
+++ b/ConsentViewController/Classes/SourcePointClient/QueryParamEncodableProtocol.swift
@@ -26,7 +26,7 @@ extension QueryParamEncodable {
         Mirror(reflecting: self)
             .children
             .sorted { $0.label ?? "" > $1.label ?? "" }
-            .reduce(into: [:]) { (properties, property) in
+            .reduce(into: [:]) { properties, property in
                 if let label = property.label, let value = property.value as? QueryParamEncodable {
                     properties[label] = value.stringified()
                 }

--- a/ConsentViewController/Classes/SourcePointClient/SPNativeUI.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SPNativeUI.swift
@@ -68,6 +68,10 @@ class SPNativeUISettings: NSObject, Decodable {
 }
 
 class SPNativeUISettingsText: SPNativeUISettings {
+    enum Keys: CodingKey {
+        case text
+    }
+
     let text: String
 
     required init(from decoder: Decoder) throws {
@@ -75,28 +79,24 @@ class SPNativeUISettingsText: SPNativeUISettings {
         text = try container.decode(String.self, forKey: .text)
         try super.init(from: decoder)
     }
-
-    enum Keys: CodingKey {
-        case text
-    }
 }
 
 class SPNativeUI: NSObject, Decodable {
-    let id: String
-    let type: SPNativeUIType
-
     public enum CodingKeys: CodingKey {
         case id, type
     }
+
+    let id: String
+    let type: SPNativeUIType
 }
 
 class SPNativeView: SPNativeUI {
+    enum CodingKeys: String, CodingKey {
+        case children, settings
+    }
+
     var children: [SPNativeUI] = []
     let settings: SPNativeUISettings
-
-    func byId(_ id: String) -> SPNativeUI? {
-        children.first { $0.id == id }
-    }
 
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -109,16 +109,22 @@ class SPNativeView: SPNativeUI {
             switch type {
             case .NativeView:
                 children.append(try tempComponentsContainer.decode(SPNativeView.self))
+
             case .NativeText:
                 children.append(try tempComponentsContainer.decode(SPNativeText.self))
+
             case .NativeButton:
                 children.append(try tempComponentsContainer.decode(SPNativeButton.self))
+
             case .LongButton:
                 children.append(try tempComponentsContainer.decode(SPNativeLongButton.self))
+
             case .Slider:
                 children.append(try tempComponentsContainer.decode(SPNativeSlider.self))
+
             case .NativeImage:
                 children.append(try tempComponentsContainer.decode(SPNativeImage.self))
+
             default:
                 children.append(try tempComponentsContainer.decode(SPNativeUI.self))
             }
@@ -126,41 +132,45 @@ class SPNativeView: SPNativeUI {
         try super.init(from: decoder)
     }
 
-    enum CodingKeys: String, CodingKey {
-        case children, settings
+    func byId(_ id: String) -> SPNativeUI? {
+        children.first { $0.id == id }
     }
 }
 
 class SPNativeText: SPNativeUI {
+    enum CodingKeys: String, CodingKey {
+        case settings
+    }
+
     let settings: SPNativeUISettingsText
 
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         settings = try container.decode(SPNativeUISettingsText.self, forKey: .settings)
         try super.init(from: decoder)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case settings
     }
 }
 
 class SPNativeButton: SPNativeUI {
+    enum CodingKeys: String, CodingKey {
+        case settings
+    }
+
     let settings: SPNativeUISettingsText
 
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         settings = try container.decode(SPNativeUISettingsText.self, forKey: .settings)
         try super.init(from: decoder)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case settings
     }
 }
 
 class SPNativeImage: SPNativeUI {
     class Settings: SPNativeUISettings {
+        enum Keys: CodingKey {
+            case src, url
+        }
+
         let src: URL?
 
         required init(from decoder: Decoder) throws {
@@ -168,10 +178,10 @@ class SPNativeImage: SPNativeUI {
             src = try? container.decodeIfPresent(URL.self, forKey: .url) ?? (try? container.decodeIfPresent(URL.self, forKey: .src))
             try super.init(from: decoder)
         }
+    }
 
-        enum Keys: CodingKey {
-            case src, url
-        }
+    enum CodingKeys: String, CodingKey {
+        case settings
     }
 
     let settings: Settings
@@ -180,10 +190,6 @@ class SPNativeImage: SPNativeUI {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         settings = try container.decode(Settings.self, forKey: .settings)
         try super.init(from: decoder)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case settings
     }
 }
 
@@ -206,6 +212,10 @@ class SPNativeLongButton: SPNativeUI {
         }
     }
 
+    enum CodingKeys: String, CodingKey {
+        case settings
+    }
+
     let settings: Settings
 
     required init(from decoder: Decoder) throws {
@@ -213,14 +223,14 @@ class SPNativeLongButton: SPNativeUI {
         settings = try container.decode(Settings.self, forKey: .settings)
         try super.init(from: decoder)
     }
-
-    enum CodingKeys: String, CodingKey {
-        case settings
-    }
 }
 
 class SPNativeSlider: SPNativeUI {
     class Settings: SPNativeUISettings {
+        enum Keys: CodingKey {
+            case leftText, rightText
+        }
+
         let rightText, leftText: String
 
         required init(from decoder: Decoder) throws {
@@ -229,10 +239,10 @@ class SPNativeSlider: SPNativeUI {
             rightText = try container.decode(String.self, forKey: .rightText)
             try super.init(from: decoder)
         }
+    }
 
-        enum Keys: CodingKey {
-            case leftText, rightText
-        }
+    enum CodingKeys: String, CodingKey {
+        case settings
     }
 
     let settings: Settings
@@ -241,9 +251,5 @@ class SPNativeSlider: SPNativeUI {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         settings = try container.decode(Settings.self, forKey: .settings)
         try super.init(from: decoder)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case settings
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/SPPrivacyManagerRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SPPrivacyManagerRequestResponse.swift
@@ -38,9 +38,9 @@ import Foundation
     let requiringConsentVendors: [Vendor]?
     var uniqueVendorIds: [String] {
         Array(Set<String>(
-            (legIntVendors?.filter { $0.vendorId != nil }.map { $0.vendorId! } ?? []) +
-                (requiringConsentVendors?.filter { $0.vendorId != nil }.map { $0.vendorId! } ?? [])
-        ))
+            ((legIntVendors ?? []).compactMap { $0.vendorId } +
+             ((requiringConsentVendors ?? []).compactMap { $0.vendorId })
+        )))
     }
 }
 

--- a/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
@@ -22,7 +22,7 @@ protocol SPDispatchQueue {
 
 extension URLSession: SPURLSession {
     func dataTask(_ request: URLRequest, completionHandler: @escaping DataTaskResult) -> SPURLSessionDataTask {
-        return dataTask(with: request, completionHandler: completionHandler)
+        dataTask(with: request, completionHandler: completionHandler)
     }
 }
 
@@ -48,24 +48,7 @@ class SimpleClient: HttpClient {
     let session: SPURLSession
     let dispatchQueue: SPDispatchQueue
 
-    let logCalls: Bool = false
-
-    func logRequest(_ type: String, _ request: URLRequest, _ body: Data?) {
-        if logCalls, let method = request.httpMethod, let url = request.url {
-            logger.debug("\(type) \(method) \(url)")
-            if let body = body, let bodyString = String(data: body, encoding: .utf8) {
-                logger.debug(bodyString)
-            }
-        }
-    }
-
-    func logRequest(_ request: URLRequest, _ body: Data?) {
-        logRequest("REQUEST", request, body)
-    }
-
-    func logResponse(_ request: URLRequest, _ response: Data?) {
-        logRequest("RESPONSE", request, response)
-    }
+    let logCalls = false
 
     init(connectivityManager: Connectivity, logger: SPLogger, urlSession: SPURLSession, dispatchQueue: SPDispatchQueue) {
         self.connectivityManager = connectivityManager
@@ -85,6 +68,23 @@ class SimpleClient: HttpClient {
         )
     }
 
+    func logRequest(_ type: String, _ request: URLRequest, _ body: Data?) {
+        if logCalls, let method = request.httpMethod, let url = request.url {
+            logger.debug("\(type) \(method) \(url)")
+            if let body = body, let bodyString = String(data: body, encoding: .utf8) {
+                logger.debug(bodyString)
+            }
+        }
+    }
+
+    func logRequest(_ request: URLRequest, _ body: Data?) {
+        logRequest("REQUEST", request, body)
+    }
+
+    func logResponse(_ request: URLRequest, _ response: Data?) {
+        logRequest("RESPONSE", request, response)
+    }
+
     func request(_ urlRequest: URLRequest, _ handler: @escaping ResponseHandler) {
         logRequest(urlRequest, urlRequest.httpBody)
         guard connectivityManager.isConnectedToNetwork() else {
@@ -102,8 +102,10 @@ class SimpleClient: HttpClient {
                         switch response.statusCode {
                         case 400...499:
                             spError = ResourceNotFoundError(request: urlRequest, response: response)
+
                         case 500...599:
                             spError = InternalServerError(request: urlRequest, response: response)
+
                         default:
                             spError = GenericNetworkError(request: urlRequest, response: response)
                         }

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -12,8 +12,12 @@ extension Result where Success == Data? {
     func decoded<T: Decodable>(
         using decoder: JSONDecoder = .init()
     ) throws -> T {
-        let data = try get()
-        return try decoder.decode(T.self, from: data!)
+        let result = try get()
+        if let data = result {
+            return try decoder.decode(T.self, from: data)
+        } else {
+            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Failed converting Result into Data"))
+        }
     }
 }
 
@@ -199,7 +203,7 @@ class SourcePointClient: SourcePointProtocol {
             "propertyId": propertyId,
             "messageId": messageId,
             "includeData": "{\"categories\": {\"type\": \"RecordString\"}}"
-        ])!
+        ])! // swiftlint:disable:this force_unwrapping
         client.get(urlString: url.absoluteString) { result in
             handler(Result {
                 (try result.decoded() as MessageResponse).message
@@ -220,7 +224,7 @@ class SourcePointClient: SourcePointProtocol {
             "consentLanguage": consentLanguage.rawValue,
             "propertyId": propertyId,
             "messageId": messageId
-        ])!
+        ])! // swiftlint:disable:this force_unwrapping
         client.get(urlString: url.absoluteString) { result in
             handler(Result {
                 (try result.decoded() as MessageResponse).message
@@ -234,7 +238,7 @@ class SourcePointClient: SourcePointProtocol {
         let url = Constants.Urls.GDPR_PRIVACY_MANAGER_VIEW_URL.appendQueryItems([
             "siteId": String(propertyId),
             "consentLanguage": consentLanguage.rawValue
-        ])!
+        ])! // swiftlint:disable:this force_unwrapping
         client.get(urlString: url.absoluteString) { result in
             handler(Result {
                 try result.decoded() as GDPRPrivacyManagerViewResponse
@@ -248,7 +252,7 @@ class SourcePointClient: SourcePointProtocol {
         let url = Constants.Urls.CCPA_PRIVACY_MANAGER_VIEW_URL.appendQueryItems([
                 "siteId": String(propertyId),
                 "consentLanguage": consentLanguage.rawValue
-        ])!
+        ])! // swiftlint:disable:this force_unwrapping
             client.get(urlString: url.absoluteString) { result in
                 handler(Result {
                     try result.decoded() as CCPAPrivacyManagerViewResponse
@@ -259,6 +263,7 @@ class SourcePointClient: SourcePointProtocol {
     }
 
     func consentUrl(_ baseUrl: URL, _ actionType: SPActionType) -> URL {
+        // swiftlint:disable:next force_unwrapping
         URL(string: "./\(actionType.rawValue)?env=\(Constants.Urls.envParam)", relativeTo: baseUrl)!
     }
 
@@ -335,7 +340,7 @@ class SourcePointClient: SourcePointProtocol {
                 categories: categories,
                 legIntCategories: legIntCategories
             )).map { body in
-                client.delete(urlString: deleteCustomConsentUrl(Constants.Urls.DELETE_CUSTOM_CONSENT_URL, propertyId, consentUUID)!.absoluteString, body: body) { result in
+                client.delete(urlString: deleteCustomConsentUrl(Constants.Urls.DELETE_CUSTOM_CONSENT_URL, propertyId, consentUUID).absoluteString, body: body) { result in
                     handler(Result {
                         try result.decoded() as AddOrDeleteCustomConsentResponse
                     }.mapError {
@@ -345,12 +350,14 @@ class SourcePointClient: SourcePointProtocol {
             }
         }
 
-    func deleteCustomConsentUrl(_ baseUrl: URL, _ propertyId: Int, _ consentUUID: String) -> URL? {
+    func deleteCustomConsentUrl(_ baseUrl: URL, _ propertyId: Int, _ consentUUID: String) -> URL {
         let propertyIdString = String(propertyId)
         let urlWithPath = baseUrl.appendingPathComponent(propertyIdString)
-        var components = URLComponents(url: urlWithPath, resolvingAgainstBaseURL: true)
-        components?.queryItems = [URLQueryItem(name: "consentUUID", value: consentUUID)]
-        return components?.url(relativeTo: baseUrl)
+        // swiftlint:disable:next force_unwrapping
+        var components = URLComponents(url: urlWithPath, resolvingAgainstBaseURL: true)!
+        components.queryItems = [URLQueryItem(name: "consentUUID", value: consentUUID)]
+        // swiftlint:disable:next force_unwrapping
+        return components.url(relativeTo: baseUrl)!
     }
 
     func errorMetrics(
@@ -368,7 +375,7 @@ class SourcePointClient: SourcePointProtocol {
             sdkVersion: sdkVersion,
             OSVersion: OSVersion,
             deviceFamily: deviceFamily,
-            propertyId: propertyId != nil ? String(propertyId!) : "",
+            propertyId: propertyId != nil ? String(propertyId!) : "", // swiftlint:disable:this force_unwrapping
             propertyName: propertyName,
             campaignType: campaignType
         )).map {

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -248,7 +248,7 @@ class SourcePointClient: SourcePointProtocol {
         let url = Constants.Urls.CCPA_PRIVACY_MANAGER_VIEW_URL.appendQueryItems([
                 "siteId": String(propertyId),
                 "consentLanguage": consentLanguage.rawValue
-            ])!
+        ])!
             client.get(urlString: url.absoluteString) { result in
                 handler(Result {
                     try result.decoded() as CCPAPrivacyManagerViewResponse

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -580,6 +580,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 vendorListId: postPayloadFromGetCall?.vendorListId,
                 pubData: action.publisherData,
                 pmSaveAndExitVariables: action.pmPayload,
+                sendPVData: state.gdprMetaData?.wasSampled ?? false,
                 propertyId: propertyId,
                 sampleRate: state.gdprMetaData?.sampleRate,
                 idfaStatus: idfaStatus,
@@ -600,6 +601,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 messageId: String(state.ccpa?.lastMessage?.id ?? 0),
                 pubData: action.publisherData,
                 pmSaveAndExitVariables: action.pmPayload,
+                sendPVData: state.ccpaMetaData?.wasSampled ?? false,
                 propertyId: propertyId,
                 sampleRate: state.ccpaMetaData?.sampleRate
             )

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -267,22 +267,6 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         )
     }
 
-    static func setupState(from localStorage: SPLocalStorage, campaigns localCampaigns: SPCampaigns) -> State {
-        var localState = localStorage.spState ?? .init()
-        if localCampaigns.gdpr != nil, localState.gdpr == nil {
-            localState.gdpr = .empty()
-            localState.gdprMetaData = .init()
-        }
-        if localCampaigns.ccpa != nil, localState.ccpa == nil {
-            localState.ccpa = .empty()
-            localState.ccpaMetaData = .init()
-        }
-        if localCampaigns.ios14 != nil, localState.ios14 == nil {
-            localState.ios14 = .init()
-        }
-        return localState
-    }
-
     init(
         accountId: Int,
         propertyName: SPPropertyName,
@@ -307,8 +291,24 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             timeout: SPConsentManager.DefaultTimeout
         )
 
-        self.state = SourcepointClientCoordinator.setupState(from: storage, campaigns: campaigns)
+        self.state = Self.setupState(from: storage, campaigns: campaigns)
         self.storage.spState = self.state
+    }
+
+    static func setupState(from localStorage: SPLocalStorage, campaigns localCampaigns: SPCampaigns) -> State {
+        var localState = localStorage.spState ?? .init()
+        if localCampaigns.gdpr != nil, localState.gdpr == nil {
+            localState.gdpr = .empty()
+            localState.gdprMetaData = .init()
+        }
+        if localCampaigns.ccpa != nil, localState.ccpa == nil {
+            localState.ccpa = .empty()
+            localState.ccpaMetaData = .init()
+        }
+        if localCampaigns.ios14 != nil, localState.ios14 == nil {
+            localState.ios14 = .init()
+        }
+        return localState
     }
 
     func resetStateIfAuthIdChanged(_ authId: String?) {
@@ -360,6 +360,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             switch result {
                 case .success(let response):
                     self.handleMetaDataResponse(response)
+
                 case .failure(let error):
                     print(error)
             }
@@ -417,6 +418,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 switch result {
                     case .success(let response):
                         self.handleConsentStatusResponse(response)
+
                     case .failure(let error):
                         print(error)
                 }
@@ -479,6 +481,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 switch result {
                     case .success(let response):
                         handler(Result.success(self.handleMessagesResponse(response)))
+
                     case .failure(let error):
                         handler(Result.failure(error))
                 }
@@ -552,6 +555,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                     case .success(let response):
                         self.handleGetChoices(response, from: action.campaignType)
                         handler(Result.success(response))
+
                     case .failure(let error):
                         handler(Result.failure(error))
                 }
@@ -620,6 +624,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                                     self.state.gdpr?.vendorGrants = response.grants ?? getResponse?.gdpr?.grants ?? SPGDPRVendorGrants()
                                     self.storage.spState = self.state
                                     handler(Result.success(self.userData))
+
                                 case .failure(let error):
                                     // flag to sync again later
                                     handler(Result.failure(error))
@@ -637,12 +642,14 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                                     self.state.ccpa?.uspstring = response.uspstring ?? getResponse?.ccpa?.uspstring ?? ""
                                     self.storage.spState = self.state
                                     handler(Result.success(self.userData))
+
                                 case .failure(let error):
                                     // flag to sync again later
                                     handler(Result.failure(error))
                             }
                         }
                     }
+
                 case .failure(let error):
                     handler(Result.failure(error))
             }
@@ -691,6 +698,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 state.gdpr?.vendorGrants = consents.grants
                 storage.spState = state
                 handler(Result.success(state.gdpr ?? .empty()))
+
             case .failure(let error):
                 handler(Result.failure((error)))
         }

--- a/ConsentViewController/Classes/Views/iOS/SPWebViewExtensions.swift
+++ b/ConsentViewController/Classes/Views/iOS/SPWebViewExtensions.swift
@@ -46,7 +46,7 @@ import WebKit
                 handler(cookies
                     .components(separatedBy: "; ")
                     .compactMap { $0.components(separatedBy: "=") }
-                    .reduce(into: [String: String]()) { (all, pair) in
+                    .reduce(into: [String: String]()) { all, pair in
                         all[pair[0]] = pair[1]
                     }, nil)
             } else {

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPACategoryDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPACategoryDetailsViewController.swift
@@ -102,7 +102,7 @@ extension SPCCPACategoryDetailsViewController: UITableViewDataSource, UITableVie
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell = (categoryDetailsTableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) as UITableViewCell?)!
+        let cell: UITableViewCell = (categoryDetailsTableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) as UITableViewCell?) ?? UITableViewCell()
         cell.selectionStyle = .none
         cell.textLabel?.text = partners[indexPath.row]
         return cell

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPACategoryDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPACategoryDetailsViewController.swift
@@ -5,18 +5,10 @@
 //  Created by Vilas on 11/05/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 class SPCCPACategoryDetailsViewController: SPNativeScreenViewController {
-    @IBOutlet weak var header: SPPMHeader!
-    @IBOutlet weak var descriptionTextView: UITextView!
-    @IBOutlet weak var logoImageView: UIImageView!
-    @IBOutlet weak var onButton: SPAppleTVButton!
-    @IBOutlet weak var offButton: SPAppleTVButton!
-    @IBOutlet weak var actionsContainer: UIStackView!
-    @IBOutlet weak var categoryDetailsTableView: UITableView!
-
     weak var categoryManagerDelegate: CCPAPMConsentSnaptshot?
 
     var category: CCPACategory?
@@ -30,18 +22,13 @@ class SPCCPACategoryDetailsViewController: SPNativeScreenViewController {
     }
     let cellReuseIdentifier = "cell"
 
-    func setHeader() {
-        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
-        header.spTitleText = viewData.byId("Header") as? SPNativeText
-        header.titleLabel.text = category?.name
-        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
-    }
-
-    override func setFocusGuides() {
-        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
-        addFocusGuide(from: header.backButton, to: categoryDetailsTableView, direction: .right)
-        addFocusGuide(from: actionsContainer, to: categoryDetailsTableView, direction: .rightLeft)
-    }
+    @IBOutlet var header: SPPMHeader!
+    @IBOutlet var descriptionTextView: UITextView!
+    @IBOutlet var logoImageView: UIImageView!
+    @IBOutlet var onButton: SPAppleTVButton!
+    @IBOutlet var offButton: SPAppleTVButton!
+    @IBOutlet var actionsContainer: UIStackView!
+    @IBOutlet var categoryDetailsTableView: UITableView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -73,6 +60,19 @@ class SPCCPACategoryDetailsViewController: SPNativeScreenViewController {
         }
         dismiss(animated: true)
     }
+
+    func setHeader() {
+        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
+        header.spTitleText = viewData.byId("Header") as? SPNativeText
+        header.titleLabel.text = category?.name
+        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
+    }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
+        addFocusGuide(from: header.backButton, to: categoryDetailsTableView, direction: .right)
+        addFocusGuide(from: actionsContainer, to: categoryDetailsTableView, direction: .rightLeft)
+    }
 }
 
 // MARK: UITableViewDataSource
@@ -82,7 +82,7 @@ extension SPCCPACategoryDetailsViewController: UITableViewDataSource, UITableVie
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let label = UILabel(frame: CGRect.init(x: 0, y: 0, width: tableView.frame.width, height: 50))
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
         label.text = "\(sections[section]?.settings.text ?? "Partners") (\(partners.count))"
         label.font = UIFont(from: sections[section]?.settings.style?.font)
         label.textColor = UIColor(hexString: sections[section]?.settings.style?.font?.color)

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAManagePreferenceViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAManagePreferenceViewController.swift
@@ -14,9 +14,9 @@ class SPCCPAManagePreferenceViewController: SPNativeScreenViewController {
         let content: [CCPACategory]
 
         init? (header: SPNativeText?, content: [CCPACategory]?) {
-            if content == nil || content!.isEmpty { return nil }
+            if content == nil || content?.isEmpty == true { return nil }
             self.header = header
-            self.content = content!
+            self.content = content! // swiftlint:disable:this force_unwrapping
         }
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAManagePreferenceViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAManagePreferenceViewController.swift
@@ -5,8 +5,8 @@
 //  Created by Vilas on 03/05/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 class SPCCPAManagePreferenceViewController: SPNativeScreenViewController {
     struct Section {
@@ -20,16 +20,9 @@ class SPCCPAManagePreferenceViewController: SPNativeScreenViewController {
         }
     }
 
-    @IBOutlet weak var descriptionTextView: UITextView!
-    @IBOutlet weak var logoImageView: UIImageView!
-    @IBOutlet weak var acceptButton: SPAppleTVButton!
-    @IBOutlet weak var saveAndExit: SPAppleTVButton!
-    @IBOutlet weak var categoriesTableView: UITableView!
-    @IBOutlet weak var header: SPPMHeader!
-    @IBOutlet weak var actionsContainer: UIStackView!
     var nativeLongButton: SPNativeLongButton?
 
-    var consentsSnapshot: CCPAPMConsentSnaptshot = CCPAPMConsentSnaptshot()
+    var consentsSnapshot = CCPAPMConsentSnaptshot()
 
     var categories: [CCPACategory] = []
     var userConsentCategories: [CCPACategory] { categories.filter { $0.requiringConsentVendors.isNotEmpty() } }
@@ -41,17 +34,13 @@ class SPCCPAManagePreferenceViewController: SPNativeScreenViewController {
 
     let cellReuseIdentifier = "cell"
 
-    override func setFocusGuides() {
-        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
-        addFocusGuide(from: actionsContainer, to: categoriesTableView, direction: .rightLeft)
-        categoriesTableView.remembersLastFocusedIndexPath = true
-    }
-
-    func setHeader() {
-        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
-        header.spTitleText = viewData.byId("Header") as? SPNativeText
-        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
-    }
+    @IBOutlet var descriptionTextView: UITextView!
+    @IBOutlet var logoImageView: UIImageView!
+    @IBOutlet var acceptButton: SPAppleTVButton!
+    @IBOutlet var saveAndExit: SPAppleTVButton!
+    @IBOutlet var categoriesTableView: UITableView!
+    @IBOutlet var header: SPPMHeader!
+    @IBOutlet var actionsContainer: UIStackView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -83,6 +72,18 @@ class SPCCPAManagePreferenceViewController: SPNativeScreenViewController {
             pmPayload: consentsSnapshot.toPayload(language: .English, pmId: messageId).json()!
         ), from: self)
     }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
+        addFocusGuide(from: actionsContainer, to: categoriesTableView, direction: .rightLeft)
+        categoriesTableView.remembersLastFocusedIndexPath = true
+    }
+
+    func setHeader() {
+        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
+        header.spTitleText = viewData.byId("Header") as? SPNativeText
+        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
+    }
 }
 
 // MARK: UITableViewDataSource
@@ -100,7 +101,7 @@ extension SPCCPAManagePreferenceViewController: UITableViewDataSource, UITableVi
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let label = UILabel(frame: CGRect.init(x: 0, y: 0, width: tableView.frame.width, height: 50))
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
         label.text = sections[section].header?.settings.text
         label.font = UIFont(from: sections[section].header?.settings.style?.font)
         label.textColor = UIColor(hexString: sections[section].header?.settings.style?.font?.color)
@@ -144,7 +145,7 @@ extension SPCCPAManagePreferenceViewController: UITableViewDataSource, UITableVi
     }
 
     public func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
-        return true
+        true
     }
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAManagePreferenceViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAManagePreferenceViewController.swift
@@ -66,10 +66,14 @@ class SPCCPAManagePreferenceViewController: SPNativeScreenViewController {
     }
 
     @IBAction func onSaveAndExitTap(_ sender: Any) {
+        guard let pmPayload = consentsSnapshot.toPayload(language: .English, pmId: messageId).json() else {
+            messageUIDelegate?.onError(UnableToConvertConsentSnapshotIntoJsonError(campaignType: .ccpa))
+            return
+        }
         messageUIDelegate?.action(SPAction(
             type: .SaveAndExit,
             campaignType: campaignType,
-            pmPayload: consentsSnapshot.toPayload(language: .English, pmId: messageId).json()!
+            pmPayload: pmPayload
         ), from: self)
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPANativePrivacyManagerViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPANativePrivacyManagerViewController.swift
@@ -5,29 +5,16 @@
 //  Created by Vilas on 01/04/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 @objcMembers class SPCCPANativePrivacyManagerViewController: SPNativeScreenViewController, SPNativePrivacyManagerHome {
     weak var delegate: SPNativePMDelegate?
-
-    @IBOutlet weak var descriptionTextView: SPFocusableTextView!
-    @IBOutlet weak var logoImageView: UIImageView!
-    @IBOutlet weak var ourPartners: SPAppleTVButton!
-    @IBOutlet weak var managePreferenceButton: SPAppleTVButton!
-    @IBOutlet weak var acceptButton: SPAppleTVButton!
-    @IBOutlet weak var rejectButton: SPAppleTVButton!
-    @IBOutlet weak var saveAndExitButton: SPAppleTVButton!
-    @IBOutlet weak var privacyPolicyButton: SPAppleTVButton!
-    @IBOutlet weak var doNotSellTableView: UITableView!
-    @IBOutlet weak var actionsContainer: UIStackView!
 
     var doNotSellButton: SPNativeLongButton?
 
     var ccpaConsents: SPCCPAConsent?
     private var snapshot: CCPAPMConsentSnaptshot!
-
-    @IBOutlet weak var header: SPPMHeader!
 
     var secondLayerData: CCPAPrivacyManagerViewResponse?
 
@@ -35,47 +22,17 @@ import Foundation
 
     override var preferredFocusedView: UIView? { acceptButton }
 
-    override func setFocusGuides() {
-        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
-        addFocusGuide(from: actionsContainer, to: doNotSellTableView, direction: .rightLeft)
-    }
-
-    func setHeader () {
-        header.spBackButton = viewData.byId("CloseButton") as? SPNativeButton
-        header.spTitleText = viewData.byId("Header") as? SPNativeText
-        header.onBackButtonTapped = { [weak self] in
-            if let this = self {
-                self?.messageUIDelegate?.action(SPAction(type: .Dismiss), from: this)
-            }
-        }
-    }
-
-    override func loadMessage() {
-        loaded(self)
-    }
-
-    func setDoNotSellButton() {
-        doNotSellButton = viewData.byId("DoNotSellButton") as? SPNativeLongButton
-        doNotSellTableView.register(
-            UINib(nibName: "LongButtonViewCell", bundle: Bundle.framework),
-            forCellReuseIdentifier: cellReuseIdentifier
-        )
-        doNotSellTableView.allowsSelection = true
-        doNotSellTableView.delegate = self
-        doNotSellTableView.dataSource = self
-    }
-
-    func initConsentsSnapshot() {
-        snapshot = CCPAPMConsentSnaptshot(
-            vendors: [],
-            categories: [],
-            rejectedVendors: ccpaConsents?.rejectedVendors,
-            rejectedCategories: ccpaConsents?.rejectedCategories,
-            consentStatus: ccpaConsents?.status)
-        snapshot.onConsentsChange = { [weak self] in
-            self?.doNotSellTableView.reloadData()
-        }
-    }
+    @IBOutlet var header: SPPMHeader!
+    @IBOutlet var descriptionTextView: SPFocusableTextView!
+    @IBOutlet var logoImageView: UIImageView!
+    @IBOutlet var ourPartners: SPAppleTVButton!
+    @IBOutlet var managePreferenceButton: SPAppleTVButton!
+    @IBOutlet var acceptButton: SPAppleTVButton!
+    @IBOutlet var rejectButton: SPAppleTVButton!
+    @IBOutlet var saveAndExitButton: SPAppleTVButton!
+    @IBOutlet var privacyPolicyButton: SPAppleTVButton!
+    @IBOutlet var doNotSellTableView: UITableView!
+    @IBOutlet var actionsContainer: UIStackView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -93,27 +50,6 @@ import Foundation
         setDoNotSellButton()
         setFocusGuidesForButtons()
         disableMenuButton()
-    }
-
-    func disableMenuButton() {
-        let menuPressRecognizer = UITapGestureRecognizer()
-        menuPressRecognizer.addTarget(self, action: #selector(menuButtonAction))
-        menuPressRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.menu.rawValue)]
-        view.addGestureRecognizer(menuPressRecognizer)
-    }
-
-    func menuButtonAction() {
-        // override in order to disable menu button closing the Privacy Manager
-    }
-
-    func setFocusGuidesForButtons() {
-        let visibleButtons: [UIView] = actionsContainer.arrangedSubviews.filter({!$0.isHidden})
-        if visibleButtons.count <= 1 {
-            return
-        }
-        for i in 0...visibleButtons.count-2 {
-            addFocusGuide(from: visibleButtons[i], to: visibleButtons[i+1], direction: .bottomTop)
-        }
     }
 
     @IBAction func onAcceptTap(_ sender: Any) {
@@ -155,6 +91,7 @@ import Foundation
                 switch result {
                 case .failure(let error):
                     self?.onError(error)
+
                 case .success(let data):
                     if let strongSelf = self {
                         strongSelf.secondLayerData = data
@@ -199,6 +136,7 @@ import Foundation
             switch result {
             case .failure(let error):
                 self?.onError(error)
+
             case .success(let data):
                 if let strongSelf = self {
                     self?.snapshot = CCPAPMConsentSnaptshot(
@@ -236,6 +174,69 @@ import Foundation
             delegate: self,
             nibName: "SPPrivacyPolicyViewController"
         ), animated: true)
+    }
+
+    func setHeader () {
+        header.spBackButton = viewData.byId("CloseButton") as? SPNativeButton
+        header.spTitleText = viewData.byId("Header") as? SPNativeText
+        header.onBackButtonTapped = { [weak self] in
+            if let this = self {
+                self?.messageUIDelegate?.action(SPAction(type: .Dismiss), from: this)
+            }
+        }
+    }
+
+    func setDoNotSellButton() {
+        doNotSellButton = viewData.byId("DoNotSellButton") as? SPNativeLongButton
+        doNotSellTableView.register(
+            UINib(nibName: "LongButtonViewCell", bundle: Bundle.framework),
+            forCellReuseIdentifier: cellReuseIdentifier
+        )
+        doNotSellTableView.allowsSelection = true
+        doNotSellTableView.delegate = self
+        doNotSellTableView.dataSource = self
+    }
+
+    func initConsentsSnapshot() {
+        snapshot = CCPAPMConsentSnaptshot(
+            vendors: [],
+            categories: [],
+            rejectedVendors: ccpaConsents?.rejectedVendors,
+            rejectedCategories: ccpaConsents?.rejectedCategories,
+            consentStatus: ccpaConsents?.status)
+        snapshot.onConsentsChange = { [weak self] in
+            self?.doNotSellTableView.reloadData()
+        }
+    }
+
+    func disableMenuButton() {
+        let menuPressRecognizer = UITapGestureRecognizer()
+        menuPressRecognizer.addTarget(self, action: #selector(menuButtonAction))
+        menuPressRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.menu.rawValue)]
+        view.addGestureRecognizer(menuPressRecognizer)
+    }
+
+    func menuButtonAction() {
+        // override in order to disable menu button closing the Privacy Manager
+    }
+
+    func setFocusGuidesForButtons() {
+        let visibleButtons: [UIView] = actionsContainer.arrangedSubviews.filter({ !$0.isHidden })
+        if visibleButtons.count <= 1 {
+            return
+        }
+        for i in 0...visibleButtons.count - 2 {
+            addFocusGuide(from: visibleButtons[i], to: visibleButtons[i + 1], direction: .bottomTop)
+        }
+    }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
+        addFocusGuide(from: actionsContainer, to: doNotSellTableView, direction: .rightLeft)
+    }
+
+    override func loadMessage() {
+        loaded(self)
     }
 }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPANativePrivacyManagerViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPANativePrivacyManagerViewController.swift
@@ -111,7 +111,7 @@ import UIKit
                             consentStatus: data.consentStatus
                         )
                         controller.categories = data.categories
-                        controller.consentsSnapshot = strongSelf.snapshot!
+                        controller.consentsSnapshot = strongSelf.snapshot! // swiftlint:disable:this force_unwrapping
                         self?.present(controller, animated: true)
                     }
                 }
@@ -127,7 +127,7 @@ import UIKit
             nibName: "SPManagePreferenceViewController"
         )
         controller.categories = secondLayerData.categories
-        controller.consentsSnapshot = snapshot!
+        controller.consentsSnapshot = snapshot! // swiftlint:disable:this force_unwrapping
         present(controller, animated: true)
     }
 
@@ -154,7 +154,7 @@ import UIKit
                         nibName: "SPPartnersViewController"
                     )
                     controller.vendors = data.vendors
-                    controller.consentsSnapshot = strongSelf.snapshot!
+                    controller.consentsSnapshot = strongSelf.snapshot! // swiftlint:disable:this force_unwrapping
                     self?.present(controller, animated: true)
                 }
             }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAPartnersViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAPartnersViewController.swift
@@ -56,10 +56,14 @@ class SPCCPAPartnersViewController: SPNativeScreenViewController {
     }
 
     @IBAction func onSaveAndExitTap(_ sender: Any) {
+        guard let pmPayload = consentsSnapshot.toPayload(language: .English, pmId: messageId).json() else {
+            messageUIDelegate?.onError(UnableToConvertConsentSnapshotIntoJsonError(campaignType: .ccpa))
+            return
+        }
         messageUIDelegate?.action(SPAction(
             type: .SaveAndExit,
             campaignType: campaignType,
-            pmPayload: consentsSnapshot.toPayload(language: .English, pmId: messageId).json()!
+            pmPayload: pmPayload
         ), from: self)
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAPartnersViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAPartnersViewController.swift
@@ -5,39 +5,29 @@
 //  Created by Vilas on 06/05/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 class SPCCPAPartnersViewController: SPNativeScreenViewController {
-    @IBOutlet weak var selectedVendorTextLabel: UILabel!
-    @IBOutlet weak var logoImageView: UIImageView!
-    @IBOutlet weak var acceptButton: SPAppleTVButton!
-    @IBOutlet weak var saveAndExit: SPAppleTVButton!
-    @IBOutlet weak var vendorsTableView: UITableView!
-    @IBOutlet weak var header: SPPMHeader!
-    @IBOutlet weak var actionsContainer: UIStackView!
     var nativeLongButton: SPNativeLongButton?
 
-    var consentsSnapshot: CCPAPMConsentSnaptshot = CCPAPMConsentSnaptshot()
+    var consentsSnapshot = CCPAPMConsentSnaptshot()
 
     var vendors: [CCPAVendor] = []
 
     var sections: [SPNativeText?] {
         [viewData.byId("VendorsHeader") as? SPNativeText]
     }
+
     let cellReuseIdentifier = "cell"
 
-    override func setFocusGuides() {
-        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
-        addFocusGuide(from: actionsContainer, to: vendorsTableView, direction: .rightLeft)
-        vendorsTableView.remembersLastFocusedIndexPath = true
-    }
-
-    func setHeader () {
-        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
-        header.spTitleText = viewData.byId("Header") as? SPNativeText
-        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
-    }
+    @IBOutlet var selectedVendorTextLabel: UILabel!
+    @IBOutlet var logoImageView: UIImageView!
+    @IBOutlet var acceptButton: SPAppleTVButton!
+    @IBOutlet var saveAndExit: SPAppleTVButton!
+    @IBOutlet var vendorsTableView: UITableView!
+    @IBOutlet var header: SPPMHeader!
+    @IBOutlet var actionsContainer: UIStackView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -72,6 +62,18 @@ class SPCCPAPartnersViewController: SPNativeScreenViewController {
             pmPayload: consentsSnapshot.toPayload(language: .English, pmId: messageId).json()!
         ), from: self)
     }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
+        addFocusGuide(from: actionsContainer, to: vendorsTableView, direction: .rightLeft)
+        vendorsTableView.remembersLastFocusedIndexPath = true
+    }
+
+    func setHeader () {
+        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
+        header.spTitleText = viewData.byId("Header") as? SPNativeText
+        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
+    }
 }
 
 // MARK: UITableViewDataSource
@@ -81,7 +83,7 @@ extension SPCCPAPartnersViewController: UITableViewDataSource, UITableViewDelega
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let label = UILabel(frame: CGRect.init(x: 0, y: 0, width: tableView.frame.width, height: 50))
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
         label.text = "\(sections[section]?.settings.text ?? "Partners")"
         label.font = UIFont(from: sections[section]?.settings.style?.font)
         label.textColor = UIColor(hexString: sections[section]?.settings.style?.font?.color)

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAVendorDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAVendorDetailsViewController.swift
@@ -5,8 +5,8 @@
 //  Created by Vilas on 11/05/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 class SPCCPAVendorDetailsViewController: SPNativeScreenViewController {
     struct Section {
@@ -20,14 +20,6 @@ class SPCCPAVendorDetailsViewController: SPNativeScreenViewController {
         }
     }
 
-    @IBOutlet weak var headerView: SPPMHeader!
-    @IBOutlet weak var qrCodeImageView: UIImageView!
-    @IBOutlet weak var descriptionTextView: UITextView!
-    @IBOutlet weak var onButton: SPAppleTVButton!
-    @IBOutlet weak var offButton: SPAppleTVButton!
-    @IBOutlet weak var vendorDetailsTableView: UITableView!
-    @IBOutlet weak var actionsContainer: UIStackView!
-
     weak var vendorManagerDelegate: CCPAPMConsentSnaptshot?
 
     let cellReuseIdentifier = "cell"
@@ -36,18 +28,13 @@ class SPCCPAVendorDetailsViewController: SPNativeScreenViewController {
         Section(header: viewData.byId("PurposesText") as? SPNativeText, content: vendor?.purposes)
     ].compactMap { $0 }}
 
-    func setHeader () {
-        headerView.spBackButton = viewData.byId("BackButton") as? SPNativeButton
-        headerView.spTitleText = viewData.byId("Header") as? SPNativeText
-        headerView.titleLabel.text = vendor?.name
-        headerView.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
-    }
-
-    override func setFocusGuides() {
-        addFocusGuide(from: headerView.backButton, to: actionsContainer, direction: .bottomTop)
-        addFocusGuide(from: headerView.backButton, to: vendorDetailsTableView, direction: .right)
-        addFocusGuide(from: actionsContainer, to: vendorDetailsTableView, direction: .rightLeft)
-    }
+    @IBOutlet var headerView: SPPMHeader!
+    @IBOutlet var qrCodeImageView: UIImageView!
+    @IBOutlet var descriptionTextView: UITextView!
+    @IBOutlet var onButton: SPAppleTVButton!
+    @IBOutlet var offButton: SPAppleTVButton!
+    @IBOutlet var vendorDetailsTableView: UITableView!
+    @IBOutlet var actionsContainer: UIStackView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -78,6 +65,19 @@ class SPCCPAVendorDetailsViewController: SPNativeScreenViewController {
         }
         dismiss(animated: true)
     }
+
+    func setHeader () {
+        headerView.spBackButton = viewData.byId("BackButton") as? SPNativeButton
+        headerView.spTitleText = viewData.byId("Header") as? SPNativeText
+        headerView.titleLabel.text = vendor?.name
+        headerView.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
+    }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: headerView.backButton, to: actionsContainer, direction: .bottomTop)
+        addFocusGuide(from: headerView.backButton, to: vendorDetailsTableView, direction: .right)
+        addFocusGuide(from: actionsContainer, to: vendorDetailsTableView, direction: .rightLeft)
+    }
 }
 
 // MARK: UITableViewDataSource
@@ -87,7 +87,7 @@ extension SPCCPAVendorDetailsViewController: UITableViewDataSource, UITableViewD
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let label = UILabel(frame: CGRect.init(x: 0, y: 0, width: tableView.frame.width, height: 50))
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
         label.text = sections[section].header?.settings.text
         label.font = UIFont(from: sections[section].header?.settings.style?.font)
         label.textColor = UIColor(hexString: sections[section].header?.settings.style?.font?.color)

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAVendorDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAVendorDetailsViewController.swift
@@ -14,9 +14,9 @@ class SPCCPAVendorDetailsViewController: SPNativeScreenViewController {
         let content: [String]
 
         init? (header: SPNativeText?, content: [String]?) {
-            if content == nil || content!.isEmpty { return nil }
+            if content == nil || content?.isEmpty == true { return nil }
             self.header = header
-            self.content = content!
+            self.content = content! // swiftlint:disable:this force_unwrapping
         }
     }
 
@@ -107,7 +107,7 @@ extension SPCCPAVendorDetailsViewController: UITableViewDataSource, UITableViewD
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell = (vendorDetailsTableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) as UITableViewCell?)!
+        let cell: UITableViewCell = (vendorDetailsTableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) as UITableViewCell?) ?? UITableViewCell()
         cell.textLabel?.text = sections[indexPath.section].content[indexPath.row]
         return cell
     }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/LongButtonViewCell.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/LongButtonViewCell.swift
@@ -10,15 +10,15 @@ import UIKit
 class LongButtonViewCell: UITableViewCell {
     var labelText: String?
     var isOn: Bool?
-    var isCustom: Bool = false
+    var isCustom = false
     var onText: String?
     var offText: String?
     var customText: String?
-    var selectable: Bool = false
+    var selectable = false
 
-    @IBOutlet weak var label: UILabel!
-    @IBOutlet weak var customLabel: UILabel!
-    @IBOutlet weak var stateLabel: UILabel!
+    @IBOutlet var label: UILabel!
+    @IBOutlet var customLabel: UILabel!
+    @IBOutlet var stateLabel: UILabel!
 
 //    override var isAccessibilityElement: Bool { set {} get { false }}
 //    override var accessibilityElements: [Any]? { set {} get {[

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPFocusableTextView.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPFocusableTextView.swift
@@ -10,9 +10,14 @@ import UIKit
 class SPFocusableTextView: UITextView, UITextViewDelegate {
     override var canBecomeFocused: Bool { isContentBig }
     var isContentBig: Bool { self.contentSize.height > self.frame.size.height }
-    public var contentFitsContainer: Bool = true
+    public var contentFitsContainer = true
 
-    open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.delegate = self
+    }
+
+    override open func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
         if isFocused {
             backgroundColor = .lightGray.withAlphaComponent(0.5)
             flashScrollIndicators()
@@ -22,11 +27,6 @@ class SPFocusableTextView: UITextView, UITextViewDelegate {
         } else {
             backgroundColor = .clear
         }
-    }
-
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        self.delegate = self
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
@@ -36,6 +36,7 @@ enum SPUIRectEdge {
         case .bottom: self = .bottom
         case .left: self = .left
         case .right: self = .right
+
         default:
             self = .all
         }
@@ -65,12 +66,14 @@ extension UIViewController {
                 addFocusGuide(from: destination, to: [origin], direction: .top, debug: debug)
             ]
         case .topBottom: return addFocusGuide(from: destination, to: origin, direction: .bottomTop, debug: debug)
+
         case .rightLeft:
             return [
                 addFocusGuide(from: origin, to: [destination], direction: .right, debug: debug),
                 addFocusGuide(from: destination, to: [origin], direction: .left, debug: debug)
             ]
         case .leftRight: return addFocusGuide(from: destination, to: origin, direction: .rightLeft, debug: debug)
+
         default:
             return [addFocusGuide(from: origin, to: [destination], direction: direction, debug: debug)]
         }
@@ -90,15 +93,19 @@ extension UIViewController {
             case .bottom:
                 focusGuide.topAnchor.constraint(equalTo: origin.bottomAnchor).isActive = true
                 focusGuide.leftAnchor.constraint(equalTo: origin.leftAnchor).isActive = true
+
             case .top:
                 focusGuide.bottomAnchor.constraint(equalTo: origin.topAnchor).isActive = true
                 focusGuide.leftAnchor.constraint(equalTo: origin.leftAnchor).isActive = true
+
             case .left:
                 focusGuide.topAnchor.constraint(equalTo: origin.topAnchor).isActive = true
                 focusGuide.rightAnchor.constraint(equalTo: origin.leftAnchor).isActive = true
+
             case .right:
                 focusGuide.topAnchor.constraint(equalTo: origin.topAnchor).isActive = true
                 focusGuide.leftAnchor.constraint(equalTo: origin.rightAnchor).isActive = true
+
             default:
                 // Not supported :(
                 break
@@ -123,7 +130,7 @@ class FocusGuideDebugView: UIView {
     }
 
     required init?(coder aDecoder: NSCoder) {
-        return nil
+        nil
     }
 }
 
@@ -131,8 +138,6 @@ class FocusGuideDebugView: UIView {
     var components: [SPNativeUI] { viewData.children }
     let viewData: SPNativeView
     let pmData: PrivacyManagerViewData
-
-    func setFocusGuides() { }
 
     init(messageId: String, campaignType: SPCampaignType, viewData: SPNativeView, pmData: PrivacyManagerViewData, delegate: SPMessageUIDelegate?, nibName: String? = nil) {
         self.viewData = viewData
@@ -146,6 +151,7 @@ class FocusGuideDebugView: UIView {
         modalPresentationStyle = .currentContext
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -156,6 +162,8 @@ class FocusGuideDebugView: UIView {
         view.tintColor = UIColor(hexString: viewData.settings.style?.backgroundColor)
         setFocusGuides()
     }
+
+    func setFocusGuides() { }
 
     @discardableResult
     func loadImage(forComponentId id: String, imageView: UIImageView) -> UIImageView {

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
@@ -46,7 +46,9 @@ enum SPUIRectEdge {
 extension UIFont {
     convenience init?(from spFont: SPNativeFont?) {
         let magicScalingFactor = CGFloat(1.8)
-        let fontSize = spFont?.fontSize != nil ? spFont!.fontSize * magicScalingFactor : UIFont.preferredFont(forTextStyle: .body).pointSize
+        let fontSize = spFont?.fontSize != nil ? // swiftlint:disable:next force_unwrapping
+            spFont!.fontSize * magicScalingFactor :
+            UIFont.preferredFont(forTextStyle: .body).pointSize
         let family = spFont?.fontFamily
             .split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
@@ -82,7 +82,7 @@ extension UIViewController {
     @discardableResult
     func addFocusGuide(from origin: UIView?, to maybeDestinations: [UIView?], direction: SPUIRectEdge, debug: Bool = false) -> UIFocusGuide? {
         if let origin = origin {
-            let destinations = maybeDestinations.filter { $0 != nil }.map { $0! }
+            let destinations = maybeDestinations.compactMap { $0 }
             let focusGuide = UIFocusGuide()
             view.addLayoutGuide(focusGuide)
             focusGuide.preferredFocusEnvironments = destinations

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPPMHeader.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPPMHeader.swift
@@ -34,15 +34,6 @@ extension UIButton {
 
 @IBDesignable
 class SPPMHeader: UIView {
-    @IBOutlet var contentView: UIView!
-    @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var backButton: UIButton!
-    @IBAction func onBackButtonPressed(_ sender: Any) {
-        if let callback = onBackButtonTapped {
-            callback()
-        }
-    }
-
     var spBackButton: SPNativeButton? {
         didSet {
             backButton.setup(from: spBackButton)
@@ -61,10 +52,15 @@ class SPPMHeader: UIView {
         get { false }
         set {}
     }
+
     override var accessibilityElements: [Any]? {
         get { [titleLabel as Any, backButton as Any] }
         set {}
     }
+
+    @IBOutlet var contentView: UIView!
+    @IBOutlet var titleLabel: UILabel!
+    @IBOutlet var backButton: UIButton!
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -74,6 +70,12 @@ class SPPMHeader: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         loadSubViews()
+    }
+
+    @IBAction func onBackButtonPressed(_ sender: Any) {
+        if let callback = onBackButtonTapped {
+            callback()
+        }
     }
 
     func loadSubViews() {

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPPrivacyPolicyViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPPrivacyPolicyViewController.swift
@@ -5,22 +5,16 @@
 //  Created by Vilas on 03/05/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 @objcMembers class SPPrivacyPolicyViewController: SPNativeScreenViewController {
-    @IBOutlet weak var descriptionTextView: UITextView!
-    @IBOutlet weak var logoImageView: UIImageView!
-    @IBOutlet weak var closeButton: SPAppleTVButton!
-    @IBOutlet weak var header: SPPMHeader!
+    @IBOutlet var descriptionTextView: UITextView!
+    @IBOutlet var logoImageView: UIImageView!
+    @IBOutlet var closeButton: SPAppleTVButton!
+    @IBOutlet var header: SPPMHeader!
 
-    func setHeader () {
-        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
-        header.spTitleText = viewData.byId("Header") as? SPNativeText
-        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
-    }
-
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         setHeader()
         loadTextView(forComponentId: "Body", textView: descriptionTextView)
@@ -31,5 +25,11 @@ import Foundation
 
     @IBAction func onCloseTap(_ sender: Any) {
         dismiss(animated: true)
+    }
+
+    func setHeader () {
+        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
+        header.spTitleText = viewData.byId("Header") as? SPNativeText
+        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
     }
 }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRCategoryDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRCategoryDetailsViewController.swift
@@ -5,18 +5,10 @@
 //  Created by Vilas on 11/05/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 class SPGDPRCategoryDetailsViewController: SPNativeScreenViewController {
-    @IBOutlet weak var header: SPPMHeader!
-    @IBOutlet weak var descriptionTextView: UITextView!
-    @IBOutlet weak var logoImageView: UIImageView!
-    @IBOutlet weak var onButton: SPAppleTVButton!
-    @IBOutlet weak var offButton: SPAppleTVButton!
-    @IBOutlet weak var actionsContainer: UIStackView!
-    @IBOutlet weak var categoryDetailsTableView: UITableView!
-
     weak var categoryManagerDelegate: GDPRPMConsentSnaptshot?
 
     var category: GDPRCategory?
@@ -30,18 +22,13 @@ class SPGDPRCategoryDetailsViewController: SPNativeScreenViewController {
     }
     let cellReuseIdentifier = "cell"
 
-    func setHeader() {
-        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
-        header.spTitleText = viewData.byId("Header") as? SPNativeText
-        header.titleLabel.text = category?.name
-        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
-    }
-
-    override func setFocusGuides() {
-        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
-        addFocusGuide(from: header.backButton, to: categoryDetailsTableView, direction: .right)
-        addFocusGuide(from: actionsContainer, to: categoryDetailsTableView, direction: .rightLeft)
-    }
+    @IBOutlet var header: SPPMHeader!
+    @IBOutlet var descriptionTextView: UITextView!
+    @IBOutlet var logoImageView: UIImageView!
+    @IBOutlet var onButton: SPAppleTVButton!
+    @IBOutlet var offButton: SPAppleTVButton!
+    @IBOutlet var actionsContainer: UIStackView!
+    @IBOutlet var categoryDetailsTableView: UITableView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -73,6 +60,19 @@ class SPGDPRCategoryDetailsViewController: SPNativeScreenViewController {
         }
         dismiss(animated: true)
     }
+
+    func setHeader() {
+        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
+        header.spTitleText = viewData.byId("Header") as? SPNativeText
+        header.titleLabel.text = category?.name
+        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
+    }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
+        addFocusGuide(from: header.backButton, to: categoryDetailsTableView, direction: .right)
+        addFocusGuide(from: actionsContainer, to: categoryDetailsTableView, direction: .rightLeft)
+    }
 }
 
 // MARK: UITableViewDataSource
@@ -82,7 +82,7 @@ extension SPGDPRCategoryDetailsViewController: UITableViewDataSource, UITableVie
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let label = UILabel(frame: CGRect.init(x: 0, y: 0, width: tableView.frame.width, height: 50))
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
         label.text = "\(sections[section]?.settings.text ?? "Partners") (\(partners.count))"
         label.font = UIFont(from: sections[section]?.settings.style?.font)
         label.textColor = UIColor(hexString: sections[section]?.settings.style?.font?.color)

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRCategoryDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRCategoryDetailsViewController.swift
@@ -102,7 +102,7 @@ extension SPGDPRCategoryDetailsViewController: UITableViewDataSource, UITableVie
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell = (categoryDetailsTableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) as UITableViewCell?)!
+        let cell: UITableViewCell = (categoryDetailsTableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) as UITableViewCell?) ?? UITableViewCell()
         cell.selectionStyle = .none
         cell.textLabel?.text = partners[indexPath.row]
         cell.textLabel?.setDefaultTextColorForDarkMode()

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRManagePreferenceViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRManagePreferenceViewController.swift
@@ -76,10 +76,14 @@ class SPGDPRManagePreferenceViewController: SPNativeScreenViewController {
     }
 
     @IBAction func onSaveAndExitTap(_ sender: Any) {
+        guard let pmPayload = consentsSnapshot.toPayload(language: .English, pmId: messageId).json() else {
+            messageUIDelegate?.onError(UnableToConvertConsentSnapshotIntoJsonError(campaignType: .gdpr))
+            return
+        }
         messageUIDelegate?.action(SPAction(
             type: .SaveAndExit,
             campaignType: campaignType,
-            pmPayload: consentsSnapshot.toPayload(language: .English, pmId: messageId).json()!
+            pmPayload: pmPayload
         ), from: self)
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRManagePreferenceViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRManagePreferenceViewController.swift
@@ -5,8 +5,8 @@
 //  Created by Vilas on 03/05/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 class SPGDPRManagePreferenceViewController: SPNativeScreenViewController {
     struct Section {
@@ -20,17 +20,9 @@ class SPGDPRManagePreferenceViewController: SPNativeScreenViewController {
         }
     }
 
-    @IBOutlet weak var descriptionTextView: UITextView!
-    @IBOutlet weak var logoImageView: UIImageView!
-    @IBOutlet weak var acceptButton: SPAppleTVButton!
-    @IBOutlet weak var saveAndExit: SPAppleTVButton!
-    @IBOutlet weak var categorySlider: UISegmentedControl!
-    @IBOutlet weak var categoriesTableView: UITableView!
-    @IBOutlet weak var header: SPPMHeader!
-    @IBOutlet weak var actionsContainer: UIStackView!
     var nativeLongButton: SPNativeLongButton?
 
-    var consentsSnapshot: GDPRPMConsentSnaptshot = GDPRPMConsentSnaptshot()
+    var consentsSnapshot = GDPRPMConsentSnaptshot()
     var displayingLegIntCategories: Bool { categorySlider.selectedSegmentIndex == 1 }
 
     var categories: [GDPRCategory] = []
@@ -46,19 +38,14 @@ class SPGDPRManagePreferenceViewController: SPNativeScreenViewController {
 
     let cellReuseIdentifier = "cell"
 
-    override func setFocusGuides() {
-        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
-        addFocusGuide(from: categorySlider, to: categoriesTableView, direction: .bottomTop)
-        addFocusGuide(from: categorySlider, to: header.backButton, direction: .left)
-        addFocusGuide(from: actionsContainer, to: categoriesTableView, direction: .rightLeft)
-        categoriesTableView.remembersLastFocusedIndexPath = true
-    }
-
-    func setHeader() {
-        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
-        header.spTitleText = viewData.byId("Header") as? SPNativeText
-        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
-    }
+    @IBOutlet var descriptionTextView: UITextView!
+    @IBOutlet var logoImageView: UIImageView!
+    @IBOutlet var acceptButton: SPAppleTVButton!
+    @IBOutlet var saveAndExit: SPAppleTVButton!
+    @IBOutlet var categorySlider: UISegmentedControl!
+    @IBOutlet var categoriesTableView: UITableView!
+    @IBOutlet var header: SPPMHeader!
+    @IBOutlet var actionsContainer: UIStackView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -95,6 +82,20 @@ class SPGDPRManagePreferenceViewController: SPNativeScreenViewController {
             pmPayload: consentsSnapshot.toPayload(language: .English, pmId: messageId).json()!
         ), from: self)
     }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
+        addFocusGuide(from: categorySlider, to: categoriesTableView, direction: .bottomTop)
+        addFocusGuide(from: categorySlider, to: header.backButton, direction: .left)
+        addFocusGuide(from: actionsContainer, to: categoriesTableView, direction: .rightLeft)
+        categoriesTableView.remembersLastFocusedIndexPath = true
+    }
+
+    func setHeader() {
+        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
+        header.spTitleText = viewData.byId("Header") as? SPNativeText
+        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
+    }
 }
 
 // MARK: UITableViewDataSource
@@ -114,7 +115,7 @@ extension SPGDPRManagePreferenceViewController: UITableViewDataSource, UITableVi
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let label = UILabel(frame: CGRect.init(x: 0, y: 0, width: tableView.frame.width, height: 50))
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
         label.text = sections[section].header?.settings.text
         label.font = UIFont(from: sections[section].header?.settings.style?.font)
         label.textColor = UIColor(hexString: sections[section].header?.settings.style?.font?.color)
@@ -156,7 +157,7 @@ extension SPGDPRManagePreferenceViewController: UITableViewDataSource, UITableVi
     }
 
     public func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
-        return true
+        true
     }
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRManagePreferenceViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRManagePreferenceViewController.swift
@@ -14,9 +14,9 @@ class SPGDPRManagePreferenceViewController: SPNativeScreenViewController {
         let content: [GDPRCategory]
 
         init? (header: SPNativeText?, content: [GDPRCategory]?) {
-            if content == nil || content!.isEmpty { return nil }
+            if content == nil || content?.isEmpty == true { return nil }
             self.header = header
-            self.content = content!
+            self.content = content! // swiftlint:disable:this force_unwrapping
         }
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
@@ -5,8 +5,8 @@
 //  Created by Vilas on 01/04/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 // swiftlint:disable function_body_length
 
@@ -16,19 +16,6 @@ protocol SPNativePrivacyManagerHome {
 
 @objcMembers class SPGDPRNativePrivacyManagerViewController: SPNativeScreenViewController, SPNativePrivacyManagerHome {
     weak var delegate: SPNativePMDelegate?
-
-    @IBOutlet weak var categoriesExplainerLabel: UILabel!
-    @IBOutlet weak var descriptionTextView: SPFocusableTextView!
-    @IBOutlet weak var logoImageView: UIImageView!
-    @IBOutlet weak var ourPartners: SPAppleTVButton!
-    @IBOutlet weak var managePreferenceButton: SPAppleTVButton!
-    @IBOutlet weak var acceptButton: SPAppleTVButton!
-    @IBOutlet weak var rejectButton: SPAppleTVButton!
-    @IBOutlet weak var saveAndExitButton: SPAppleTVButton!
-    @IBOutlet weak var privacyPolicyButton: SPAppleTVButton!
-    @IBOutlet weak var categoryTableView: UITableView!
-    @IBOutlet weak var header: SPPMHeader!
-    @IBOutlet weak var buttonsStack: UIStackView!
 
     var secondLayerData: GDPRPrivacyManagerViewResponse?
 
@@ -40,19 +27,18 @@ protocol SPNativePrivacyManagerHome {
 
     override var preferredFocusedView: UIView? { acceptButton }
 
-    func setHeader () {
-        header.spBackButton = viewData.byId("CloseButton") as? SPNativeButton
-        header.spTitleText = viewData.byId("Header") as? SPNativeText
-        header.onBackButtonTapped = { [weak self] in
-            if let this = self {
-                self?.messageUIDelegate?.action(SPAction(type: .Dismiss), from: this)
-            }
-        }
-    }
-
-    override func loadMessage() {
-        loaded(self)
-    }
+    @IBOutlet var categoriesExplainerLabel: UILabel!
+    @IBOutlet var descriptionTextView: SPFocusableTextView!
+    @IBOutlet var logoImageView: UIImageView!
+    @IBOutlet var ourPartners: SPAppleTVButton!
+    @IBOutlet var managePreferenceButton: SPAppleTVButton!
+    @IBOutlet var acceptButton: SPAppleTVButton!
+    @IBOutlet var rejectButton: SPAppleTVButton!
+    @IBOutlet var saveAndExitButton: SPAppleTVButton!
+    @IBOutlet var privacyPolicyButton: SPAppleTVButton!
+    @IBOutlet var categoryTableView: UITableView!
+    @IBOutlet var header: SPPMHeader!
+    @IBOutlet var buttonsStack: UIStackView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -72,28 +58,6 @@ protocol SPNativePrivacyManagerHome {
         categoryTableView.delegate = self
         categoryTableView.dataSource = self
         disableMenuButton()
-    }
-
-    override func setFocusGuides() {
-        addFocusGuide(from: descriptionTextView, to: categoryTableView, direction: .bottomTop)
-    }
-
-    func setFocusGuidesForButtons() {
-        let visibleButtons: [UIView] = buttonsStack.arrangedSubviews.filter({!$0.isHidden})
-        for i in 0...visibleButtons.count-2 {
-            addFocusGuide(from: visibleButtons[i], to: visibleButtons[i+1], direction: .bottomTop)
-        }
-    }
-
-    func disableMenuButton() {
-        let menuPressRecognizer = UITapGestureRecognizer()
-        menuPressRecognizer.addTarget(self, action: #selector(menuButtonAction))
-        menuPressRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.menu.rawValue)]
-        view.addGestureRecognizer(menuPressRecognizer)
-    }
-
-    func menuButtonAction() {
-        // override in order to disable menu button closing the Privacy Manager
     }
 
     @IBAction func onAcceptTap(_ sender: Any) {
@@ -124,6 +88,7 @@ protocol SPNativePrivacyManagerHome {
                 switch result {
                 case .failure(let error):
                     self?.onError(error)
+
                 case .success(let data):
                     if let strongSelf = self {
                         strongSelf.secondLayerData = data
@@ -181,6 +146,7 @@ protocol SPNativePrivacyManagerHome {
             switch result {
             case .failure(let error):
                 self?.onError(error)
+
             case .success(let data):
                 if let strongSelf = self {
                     if self?.snapshot == nil {
@@ -222,6 +188,42 @@ protocol SPNativePrivacyManagerHome {
             delegate: self,
             nibName: "SPPrivacyPolicyViewController"
         ), animated: true)
+    }
+
+    func setHeader () {
+        header.spBackButton = viewData.byId("CloseButton") as? SPNativeButton
+        header.spTitleText = viewData.byId("Header") as? SPNativeText
+        header.onBackButtonTapped = { [weak self] in
+            if let this = self {
+                self?.messageUIDelegate?.action(SPAction(type: .Dismiss), from: this)
+            }
+        }
+    }
+
+    override func loadMessage() {
+        loaded(self)
+    }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: descriptionTextView, to: categoryTableView, direction: .bottomTop)
+    }
+
+    func setFocusGuidesForButtons() {
+        let visibleButtons: [UIView] = buttonsStack.arrangedSubviews.filter({ !$0.isHidden })
+        for i in 0...visibleButtons.count - 2 {
+            addFocusGuide(from: visibleButtons[i], to: visibleButtons[i + 1], direction: .bottomTop)
+        }
+    }
+
+    func disableMenuButton() {
+        let menuPressRecognizer = UITapGestureRecognizer()
+        menuPressRecognizer.addTarget(self, action: #selector(menuButtonAction))
+        menuPressRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.menu.rawValue)]
+        view.addGestureRecognizer(menuPressRecognizer)
+    }
+
+    func menuButtonAction() {
+        // override in order to disable menu button closing the Privacy Manager
     }
 }
 
@@ -282,16 +284,16 @@ extension SPGDPRNativePrivacyManagerViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate
 extension SPGDPRNativePrivacyManagerViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
-        return true
+        true
     }
 
     func tableView(_ tableView: UITableView, shouldUpdateFocusIn context: UITableViewFocusUpdateContext) -> Bool {
-        return true
+        true
     }
 }
 
 class FocusableScrollView: UIScrollView {
     override var canBecomeFocused: Bool {
-        return true
+        true
     }
 }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
@@ -111,7 +111,7 @@ protocol SPNativePrivacyManagerHome {
                             )
                         }
                         controller.categories = data.categories
-                        controller.consentsSnapshot = strongSelf.snapshot!
+                        controller.consentsSnapshot = strongSelf.snapshot! // swiftlint:disable:this force_unwrapping
                         self?.present(controller, animated: true)
                     }
                 }
@@ -137,7 +137,7 @@ protocol SPNativePrivacyManagerHome {
             )
         }
         controller.categories = secondLayerData.categories
-        controller.consentsSnapshot = snapshot!
+        controller.consentsSnapshot = snapshot! // swiftlint:disable:this force_unwrapping
         present(controller, animated: true)
     }
 
@@ -168,7 +168,7 @@ protocol SPNativePrivacyManagerHome {
                         nibName: "SPGDPRPartnersViewController"
                     )
                     controller.vendors = data.vendors
-                    controller.consentsSnapshot = strongSelf.snapshot!
+                    controller.consentsSnapshot = strongSelf.snapshot! // swiftlint:disable:this force_unwrapping
                     self?.present(controller, animated: true)
                 }
             }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRPartnersViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRPartnersViewController.swift
@@ -5,26 +5,19 @@
 //  Created by Vilas on 06/05/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 class SPGDPRPartnersViewController: SPNativeScreenViewController {
-    @IBOutlet weak var selectedVendorTextLabel: UILabel!
-    @IBOutlet weak var logoImageView: UIImageView!
-    @IBOutlet weak var acceptButton: SPAppleTVButton!
-    @IBOutlet weak var saveAndExit: SPAppleTVButton!
-    @IBOutlet weak var vendorsSlider: UISegmentedControl!
-    @IBOutlet weak var vendorsTableView: UITableView!
-    @IBOutlet weak var header: SPPMHeader!
-    @IBOutlet weak var actionsContainer: UIStackView!
     var nativeLongButton: SPNativeLongButton?
 
     var displayingLegIntVendors: Bool { vendorsSlider.selectedSegmentIndex == 1 }
+
     var currentVendors: [GDPRVendor] {
         displayingLegIntVendors ? legitimateInterestVendorList : userConsentVendors
     }
 
-    var consentsSnapshot: GDPRPMConsentSnaptshot = GDPRPMConsentSnaptshot()
+    var consentsSnapshot = GDPRPMConsentSnaptshot()
 
     var vendors: [GDPRVendor] = []
     var userConsentVendors: [GDPRVendor] { vendors.filter { !$0.consentCategories.isEmpty } }
@@ -35,19 +28,14 @@ class SPGDPRPartnersViewController: SPNativeScreenViewController {
     }
     let cellReuseIdentifier = "cell"
 
-    override func setFocusGuides() {
-        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
-        addFocusGuide(from: vendorsSlider, to: vendorsTableView, direction: .bottomTop)
-        addFocusGuide(from: vendorsSlider, to: header.backButton, direction: .left)
-        addFocusGuide(from: actionsContainer, to: vendorsTableView, direction: .rightLeft)
-        vendorsTableView.remembersLastFocusedIndexPath = true
-    }
-
-    func setHeader () {
-        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
-        header.spTitleText = viewData.byId("Header") as? SPNativeText
-        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
-    }
+    @IBOutlet var selectedVendorTextLabel: UILabel!
+    @IBOutlet var logoImageView: UIImageView!
+    @IBOutlet var acceptButton: SPAppleTVButton!
+    @IBOutlet var saveAndExit: SPAppleTVButton!
+    @IBOutlet var vendorsSlider: UISegmentedControl!
+    @IBOutlet var vendorsTableView: UITableView!
+    @IBOutlet var header: SPPMHeader!
+    @IBOutlet var actionsContainer: UIStackView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -87,6 +75,20 @@ class SPGDPRPartnersViewController: SPNativeScreenViewController {
             pmPayload: consentsSnapshot.toPayload(language: .English, pmId: messageId).json()!
         ), from: self)
     }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: header.backButton, to: actionsContainer, direction: .bottomTop)
+        addFocusGuide(from: vendorsSlider, to: vendorsTableView, direction: .bottomTop)
+        addFocusGuide(from: vendorsSlider, to: header.backButton, direction: .left)
+        addFocusGuide(from: actionsContainer, to: vendorsTableView, direction: .rightLeft)
+        vendorsTableView.remembersLastFocusedIndexPath = true
+    }
+
+    func setHeader () {
+        header.spBackButton = viewData.byId("BackButton") as? SPNativeButton
+        header.spTitleText = viewData.byId("Header") as? SPNativeText
+        header.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
+    }
 }
 
 // MARK: UITableViewDataSource
@@ -96,7 +98,7 @@ extension SPGDPRPartnersViewController: UITableViewDataSource, UITableViewDelega
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let label = UILabel(frame: CGRect.init(x: 0, y: 0, width: tableView.frame.width, height: 50))
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
         label.text = "\(sections[section]?.settings.text.stripOutHtml() ?? "Partners")"
         label.font = UIFont(from: sections[section]?.settings.style?.font)
         label.textColor = UIColor(hexString: sections[section]?.settings.style?.font?.color)

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRPartnersViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRPartnersViewController.swift
@@ -69,10 +69,14 @@ class SPGDPRPartnersViewController: SPNativeScreenViewController {
     }
 
     @IBAction func onSaveAndExitTap(_ sender: Any) {
+        guard let pmPayload = consentsSnapshot.toPayload(language: .English, pmId: messageId).json() else {
+            messageUIDelegate?.onError(UnableToConvertConsentSnapshotIntoJsonError(campaignType: .gdpr))
+            return
+        }
         messageUIDelegate?.action(SPAction(
             type: .SaveAndExit,
             campaignType: campaignType,
-            pmPayload: consentsSnapshot.toPayload(language: .English, pmId: messageId).json()!
+            pmPayload: pmPayload
         ), from: self)
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
@@ -14,9 +14,9 @@ class SPGDPRVendorDetailsViewController: SPNativeScreenViewController {
         let content: [String]
 
         init? (header: SPNativeText?, content: [String]?) {
-            if content == nil || content!.isEmpty { return nil }
+            if content == nil || content?.isEmpty == true { return nil }
             self.header = header
-            self.content = content!
+            self.content = content! // swiftlint:disable:this force_unwrapping
         }
     }
 
@@ -110,7 +110,7 @@ extension SPGDPRVendorDetailsViewController: UITableViewDataSource, UITableViewD
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell = (vendorDetailsTableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) as UITableViewCell?)!
+        let cell: UITableViewCell = (vendorDetailsTableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier) as UITableViewCell?) ?? UITableViewCell()
         cell.textLabel?.text = sections[indexPath.section].content[indexPath.row]
         cell.textLabel?.setDefaultTextColorForDarkMode()
         return cell

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
@@ -5,8 +5,8 @@
 //  Created by Vilas on 11/05/21.
 //
 
-import UIKit
 import Foundation
+import UIKit
 
 class SPGDPRVendorDetailsViewController: SPNativeScreenViewController {
     struct Section {
@@ -20,14 +20,6 @@ class SPGDPRVendorDetailsViewController: SPNativeScreenViewController {
         }
     }
 
-    @IBOutlet weak var headerView: SPPMHeader!
-    @IBOutlet weak var qrCodeImageView: UIImageView!
-    @IBOutlet weak var descriptionTextView: UITextView!
-    @IBOutlet weak var onButton: SPAppleTVButton!
-    @IBOutlet weak var offButton: SPAppleTVButton!
-    @IBOutlet weak var vendorDetailsTableView: UITableView!
-    @IBOutlet weak var actionsContainer: UIStackView!
-
     weak var vendorManagerDelegate: GDPRPMConsentSnaptshot?
 
     let cellReuseIdentifier = "cell"
@@ -39,18 +31,13 @@ class SPGDPRVendorDetailsViewController: SPNativeScreenViewController {
         Section(header: viewData.byId("SpecialFeaturesText") as? SPNativeText, content: vendor?.iabSpecialFeatures)
     ].compactMap { $0 }}
 
-    func setHeader () {
-        headerView.spBackButton = viewData.byId("BackButton") as? SPNativeButton
-        headerView.spTitleText = viewData.byId("Header") as? SPNativeText
-        headerView.titleLabel.text = vendor?.name
-        headerView.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
-    }
-
-    override func setFocusGuides() {
-        addFocusGuide(from: headerView.backButton, to: actionsContainer, direction: .bottomTop)
-        addFocusGuide(from: headerView.backButton, to: vendorDetailsTableView, direction: .right)
-        addFocusGuide(from: actionsContainer, to: vendorDetailsTableView, direction: .rightLeft)
-    }
+    @IBOutlet var headerView: SPPMHeader!
+    @IBOutlet var qrCodeImageView: UIImageView!
+    @IBOutlet var descriptionTextView: UITextView!
+    @IBOutlet var onButton: SPAppleTVButton!
+    @IBOutlet var offButton: SPAppleTVButton!
+    @IBOutlet var vendorDetailsTableView: UITableView!
+    @IBOutlet var actionsContainer: UIStackView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -81,6 +68,19 @@ class SPGDPRVendorDetailsViewController: SPNativeScreenViewController {
         }
         dismiss(animated: true)
     }
+
+    func setHeader () {
+        headerView.spBackButton = viewData.byId("BackButton") as? SPNativeButton
+        headerView.spTitleText = viewData.byId("Header") as? SPNativeText
+        headerView.titleLabel.text = vendor?.name
+        headerView.onBackButtonTapped = { [weak self] in self?.dismiss(animated: true) }
+    }
+
+    override func setFocusGuides() {
+        addFocusGuide(from: headerView.backButton, to: actionsContainer, direction: .bottomTop)
+        addFocusGuide(from: headerView.backButton, to: vendorDetailsTableView, direction: .right)
+        addFocusGuide(from: actionsContainer, to: vendorDetailsTableView, direction: .rightLeft)
+    }
 }
 
 // MARK: UITableViewDataSource
@@ -90,7 +90,7 @@ extension SPGDPRVendorDetailsViewController: UITableViewDataSource, UITableViewD
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let label = UILabel(frame: CGRect.init(x: 0, y: 0, width: tableView.frame.width, height: 50))
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
         label.text = sections[section].header?.settings.text
         label.font = UIFont(from: sections[section].header?.settings.style?.font)
         label.textColor = UIColor(hexString: sections[section].header?.settings.style?.font?.color)

--- a/Example/.swiftlint.yml
+++ b/Example/.swiftlint.yml
@@ -1,14 +1,49 @@
 # This Config is used when running swiftlint from within XCode
 # It needs to be called from the Example folder "xcode" reporter.
 # Make sure the rules are always in sync with the one from ../.swiftlint.yml
-
 disabled_rules:
   - switch_case_alignment
+  - void_function_in_ternary
+opt_in_rules:
+  - force_unwrapping
+  - trailing_semicolon
+  - trailing_whitespace
+  - type_body_length
+  - type_contents_order
+  - type_name
+  - unavailable_function
+  - unneeded_break_in_switch
+  - unneeded_parentheses_in_closure_argument
+  - unowned_variable_capture
+  - untyped_error_in_catch
+  - unused_capture_list
+  - unused_closure_parameter
+  - unused_control_flow_label
+  - unused_declaration
+  - unused_enumerated
+  - unused_import
+  - unused_optional_binding
+  - unused_setter_value
+  - valid_ibinspectable
+  - vertical_parameter_alignment
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace
+  - vertical_whitespace_between_cases
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - void_return
+  - weak_delegate
+  - xct_specific_matcher
+  - xctfail_message
+  - yoda_condition
 included: # paths to include during linting. `--path` is ignored if present.
  - ../ConsentViewController/Classes
- - ConsentViewController_ExampleTests
+ - ./
 excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - AuthExample
   - Pods
+  - SourcePointMetaAppUITests
+  - SourcePointMetaApp
 identifier_name:
   min_length:
     - 1

--- a/Example/AuthExampleUITests/AuthExampleUITests.swift
+++ b/Example/AuthExampleUITests/AuthExampleUITests.swift
@@ -9,7 +9,7 @@
 import XCTest
 
 class AuthExampleUITests: XCTestCase {
-    var app: XCUIApplication!
+    private var app: XCUIApplication!
 
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/Example/ConsentViewController/AppDelegate.swift
+++ b/Example/ConsentViewController/AppDelegate.swift
@@ -6,14 +6,13 @@
 //  Copyright (c) 2019 SourcePoint. All rights reserved.
 //
 
-import UIKit
+// swiftlint:disable line_length
+
 import ConsentViewController
-
-
+import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
 
     func resetStoredConfig() {
@@ -40,7 +39,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-
         if CommandLine.arguments.contains("-cleanAppsData") {
             SPConsentManager.clearAllData()
             SPConsentManager.shouldCallErrorMetrics = false
@@ -52,7 +50,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         if let scheme = url.scheme,
            scheme.localizedCaseInsensitiveCompare("exampleapp") == .orderedSame,
            let host = url.host, host.localizedCaseInsensitiveCompare("network") == .orderedSame {
@@ -83,5 +81,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
 }

--- a/Example/ConsentViewController/Config.swift
+++ b/Example/ConsentViewController/Config.swift
@@ -6,10 +6,14 @@
 //  Copyright © 2023 CocoaPods. All rights reserved.
 //
 
-import Foundation
 import ConsentViewController
+import Foundation
 
 struct Config {
+    enum Keys: String, CaseIterable {
+        case accountId, propertyId, propertyName, gdpr, ccpa, att, language, gdprPmId, ccpaPmId
+    }
+
     let accountId, propertyId: Int
     let propertyName: String
     let gdpr, ccpa, att: Bool
@@ -18,10 +22,6 @@ struct Config {
 
     let myVendorId = "5ff4d000a228633ac048be41"
     let myPurposesId = ["608bad95d08d3112188e0e36", "608bad95d08d3112188e0e2f"]
-
-    enum Keys: String, CaseIterable {
-        case accountId, propertyId, propertyName, gdpr, ccpa, att, language, gdprPmId, ccpaPmId
-    }
 }
 
 extension Config {
@@ -38,4 +38,3 @@ extension Config {
         ccpaPmId = defaults.ccpaPmId
     }
 }
-

--- a/Example/ConsentViewController/JSONLocalDataViewController.swift
+++ b/Example/ConsentViewController/JSONLocalDataViewController.swift
@@ -7,14 +7,13 @@
 //
 
 import Foundation
-import UIKit
 import JSONView
 import SwiftUI
+import UIKit
 
 func toHashable(_ data: Any) -> AnyHashable {
     if let data = data as? Data,
-       let jsonData = try? JSONSerialization.jsonObject(with: data, options: []) as? AnyHashable
-    {
+       let jsonData = try? JSONSerialization.jsonObject(with: data, options: []) as? AnyHashable {
         return jsonData
     } else {
         return String(describing: data)
@@ -22,12 +21,12 @@ func toHashable(_ data: Any) -> AnyHashable {
 }
 
 class JSONLocalDataViewController: UIViewController {
-    @IBOutlet weak var containerView: UIView!
-    
+    @IBOutlet var containerView: UIView!
+
     override func viewDidLoad() {
         let data: [String: AnyHashable] = UserDefaults.standard.dictionaryRepresentation()
             .filter { $0.key.starts(with: "sp_") || $0.key.starts(with: "IAB") }
-            .reduce(into: [String: AnyHashable]()) { (acc, element) in
+            .reduce(into: [String: AnyHashable]()) { acc, element in
                 if let newValue = element.value as? AnyHashable {
                     acc[element.key] = toHashable(newValue)
                 }

--- a/Example/ConsentViewController/Statuses.swift
+++ b/Example/ConsentViewController/Statuses.swift
@@ -30,4 +30,3 @@ enum SDKStatus: String {
     case finished = "Finished"
     case errored = "Errored"
 }
-

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2019 sourcepoint. All rights reserved.
 //
 
+// swiftlint:disable force_unwrapping
+
 import ConsentViewController
 import UIKit
 

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -6,21 +6,55 @@
 //  Copyright © 2019 sourcepoint. All rights reserved.
 //
 
-import UIKit
 import ConsentViewController
+import UIKit
 
 class ViewController: UIViewController {
     var sdkStatus: SDKStatus = .notStarted
     var idfaStatus: SPIDFAStatus { SPIDFAStatus.current() }
     var myVendorAccepted: VendorStatus = .Unknown
+    lazy var config = { Config(fromStorageWithDefaults: Config(
+        accountId: 22,
+        propertyId: 16893,
+        propertyName: "mobile.multicampaign.demo",
+        gdpr: true,
+        ccpa: true,
+        att: true,
+        language: .BrowserDefault,
+        gdprPmId: "488393",
+        ccpaPmId: "509688"
+    ))}()
 
-    @IBOutlet weak var sdkStatusLabel: UILabel!
-    @IBOutlet weak var idfaStatusLabel: UILabel!
-    @IBOutlet weak var myVendorAcceptedLabel: UILabel!
-    @IBOutlet weak var acceptMyVendorButton: UIButton!
-    @IBOutlet weak var deleteMyVendorButton: UIButton!
-    @IBOutlet weak var gdprPMButton: UIButton!
-    @IBOutlet weak var ccpaPMButton: UIButton!
+    lazy var consentManager: SPSDK = { SPConsentManager(
+        accountId: config.accountId,
+        propertyId: config.propertyId,
+        // swiftlint:disable:next force_try
+        propertyName: try! SPPropertyName(config.propertyName),
+        campaigns: SPCampaigns(
+            gdpr: config.gdpr ? SPCampaign() : nil,
+            ccpa: config.ccpa ? SPCampaign() : nil,
+            ios14: config.att ? SPCampaign() : nil
+        ),
+        language: config.language,
+        delegate: self
+    )}()
+
+    @IBOutlet var sdkStatusLabel: UILabel!
+    @IBOutlet var idfaStatusLabel: UILabel!
+    @IBOutlet var myVendorAcceptedLabel: UILabel!
+    @IBOutlet var acceptMyVendorButton: UIButton!
+    @IBOutlet var deleteMyVendorButton: UIButton!
+    @IBOutlet var gdprPMButton: UIButton!
+    @IBOutlet var ccpaPMButton: UIButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        sdkStatus = .running
+        sdkStatusLabel.accessibilityIdentifier = "sdkStatusLabel"
+        myVendorAcceptedLabel.accessibilityIdentifier = "customVendorLabel"
+        consentManager.loadMessage(forAuthId: nil, publisherData: ["foo": "load message"])
+        updateUI()
+    }
 
     @IBAction func onNetworkCallsTap(_ sender: Any) {
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: "wormholy_fire"), object: nil)
@@ -47,7 +81,7 @@ class ViewController: UIViewController {
             legIntCategories: []) { consents in
                 self.myVendorAccepted = VendorStatus(fromBool: consents.vendorGrants[self.config.myVendorId]?.granted)
                 self.updateUI()
-        }
+            }
     }
 
     @IBAction func onDeleteMyVendorTap(_ sender: Any) {
@@ -57,41 +91,7 @@ class ViewController: UIViewController {
             legIntCategories: []) { consents in
                 self.myVendorAccepted = VendorStatus(fromBool: consents.vendorGrants[self.config.myVendorId]?.granted)
                 self.updateUI()
-        }
-    }
-
-    lazy var config = { Config(fromStorageWithDefaults: Config(
-        accountId: 22,
-        propertyId: 16893,
-        propertyName: "mobile.multicampaign.demo",
-        gdpr: true,
-        ccpa: true,
-        att: true,
-        language: .BrowserDefault,
-        gdprPmId: "488393",
-        ccpaPmId: "509688"
-    ))}()
-
-    lazy var consentManager: SPSDK = { SPConsentManager(
-        accountId: config.accountId,
-        propertyId: config.propertyId,
-        propertyName: try! SPPropertyName(config.propertyName),
-        campaigns: SPCampaigns(
-            gdpr: config.gdpr ? SPCampaign() : nil,
-            ccpa: config.ccpa ? SPCampaign() : nil,
-            ios14: config.att ? SPCampaign() : nil
-        ),
-        language: config.language,
-        delegate: self
-    )}()
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        sdkStatus = .running
-        sdkStatusLabel.accessibilityIdentifier = "sdkStatusLabel"
-        myVendorAcceptedLabel.accessibilityIdentifier = "customVendorLabel"
-        consentManager.loadMessage(forAuthId: nil, publisherData: ["foo": "load message"])
-        updateUI()
+            }
     }
 }
 
@@ -159,10 +159,12 @@ extension ViewController {
                 myVendorAcceptedLabel.textColor = .systemGray
                 acceptMyVendorButton.isEnabled = false
                 deleteMyVendorButton.isEnabled = false
+
             case .Accepted:
                 myVendorAcceptedLabel.textColor = .systemGreen
                 acceptMyVendorButton.isEnabled = false
                 deleteMyVendorButton.isEnabled = true
+
             case .Rejected:
                 myVendorAcceptedLabel.textColor = .systemRed
                 acceptMyVendorButton.isEnabled = true

--- a/Example/ConsentViewController_ExampleTests/CCPAConsentStatusSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/CCPAConsentStatusSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2023 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 // swiftlint:disable colon
 

--- a/Example/ConsentViewController_ExampleTests/CCPAConsentStatusSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/CCPAConsentStatusSpec.swift
@@ -11,7 +11,7 @@ import Foundation
 import Nimble
 import Quick
 
-// swiftlint:disable colon
+// swiftlint:disable colon force_unwrapping
 
 class CCPAConsentStatusSpec: QuickSpec {
     override func spec() {

--- a/Example/ConsentViewController_ExampleTests/ConsentsProfileSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/ConsentsProfileSpec.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 class ConsentsProfileSpec: QuickSpec {
     let ccpaConsents = """

--- a/Example/ConsentViewController_ExampleTests/Extensions/GDPRURLExtensionsSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/Extensions/GDPRURLExtensionsSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class SPURLExtensions: QuickSpec {
     override func spec() {
@@ -17,7 +17,7 @@ class SPURLExtensions: QuickSpec {
             it("should append a query param at the end of the URL while keeping the URL intact") {
                 var url = URL(string: "https://example.com?foo=bar")
                 url = url?.appendQueryItems(["a": "b", "c": "d"])
-                expect(url).to(equal(URL(string: "https://example.com?foo=bar&a=b&c=d")))
+                expect(url) == URL(string: "https://example.com?foo=bar&a=b&c=d")
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/Extensions/GDPRWebViewExtensionsSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/Extensions/GDPRWebViewExtensionsSpec.swift
@@ -28,6 +28,7 @@ class TestWebView: WKWebView, WKNavigationDelegate {
                 forMainFrameOnly: true
             ))
         }
+        // swiftlint:disable:next force_unwrapping
         loadHTMLString("", baseURL: URL(string: "https://sourcepoint.com")!)
     }
 

--- a/Example/ConsentViewController_ExampleTests/Extensions/GDPRWebViewExtensionsSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/Extensions/GDPRWebViewExtensionsSpec.swift
@@ -6,11 +6,11 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
-import WebKit
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
+import WebKit
 
 class TestWebView: WKWebView, WKNavigationDelegate {
     let authIdToInject: String?
@@ -31,6 +31,7 @@ class TestWebView: WKWebView, WKNavigationDelegate {
         loadHTMLString("", baseURL: URL(string: "https://sourcepoint.com")!)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("not implemented") }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -68,7 +69,8 @@ class GDPRWebViewExtensionsSpec: QuickSpec {
                     self.webView = TestWebView(authIdToInject: "foo") { $0.getAuthId { authId, error in
                         expect(authId).to(equal("foo"), description: error.debugDescription)
                         done()
-                    }}
+                    }
+                    }
                 }
             }
 
@@ -79,7 +81,8 @@ class GDPRWebViewExtensionsSpec: QuickSpec {
                             $0.getAuthId { authId, error in
                                 expect(authId).to(beEmpty(), description: error.debugDescription)
                                 done()
-                            }}
+                            }
+                        }
                     }
                 }
             }
@@ -91,7 +94,8 @@ class GDPRWebViewExtensionsSpec: QuickSpec {
                             $0.getAuthId { authId, error in
                                 expect(authId).to(beEmpty(), description: error.debugDescription)
                                 done()
-                            }}
+                            }
+                        }
                     }
                 }
             }
@@ -103,7 +107,8 @@ class GDPRWebViewExtensionsSpec: QuickSpec {
                     self.webView = TestWebView { $0.getAuthId { authId, error in
                         expect(authId).to(equal("another foo"), description: error.debugDescription)
                         done()
-                    }}
+                    }
+                    }
                     self.webView.setConsentFor(authId: "another foo")
                 }
             }

--- a/Example/ConsentViewController_ExampleTests/Extensions/SPStringExtensionsSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/Extensions/SPStringExtensionsSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class SPStringExtensionsSpec: QuickSpec {
     override func spec() {
@@ -28,7 +28,7 @@ class SPStringExtensionsSpec: QuickSpec {
                 </head>
                 """
                 let stripped = cssHtml.stripOutHtml()
-                expect(stripped).to(equal("\nHTML - head tag\nstrongbolditalic\n\n\n\n\n\nYour browser does not support javascript.\n"))
+                expect(stripped) == "\nHTML - head tag\nstrongbolditalic\n\n\n\n\n\nYour browser does not support javascript.\n"
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/GDPRMessageSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRMessageSpec.swift
@@ -6,14 +6,12 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 class GDPRMessageSpec: QuickSpec {
-
     override func spec() {
-
         describe("Test GDPRMessage") {
             var attributeStyle: SPNativeMessage.AttributeStyle?
             var messageAttribute: SPNativeMessage.Attribute?
@@ -29,19 +27,19 @@ class GDPRMessageSpec: QuickSpec {
             }
 
             it("Test AttributeStyle method") {
-                expect(attributeStyle?.backgroundColor).to(equal("#944488"))
+                expect(attributeStyle?.backgroundColor) == "#944488"
             }
 
             it("Test MessageAction method") {
-                expect(messageAttribute?.style.backgroundColor).to(equal("#944488"))
+                expect(messageAttribute?.style.backgroundColor) == "#944488"
             }
 
             it("Test MessageAction method") {
-                expect(messageAction?.choiceType).to(equal(SPActionType.AcceptAll))
+                expect(messageAction?.choiceType) == SPActionType.AcceptAll
             }
 
             it("Test GDPRMessage method") {
-                expect(gdprMessage?.title.style.color).to(equal("#00FA9A"))
+                expect(gdprMessage?.title.style.color) == "#00FA9A"
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/GDPRMessageSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRMessageSpec.swift
@@ -13,33 +13,33 @@ import Quick
 class GDPRMessageSpec: QuickSpec {
     override func spec() {
         describe("Test GDPRMessage") {
-            var attributeStyle: SPNativeMessage.AttributeStyle?
-            var messageAttribute: SPNativeMessage.Attribute?
-            var messageAction: SPNativeMessage.Action?
-            var gdprMessage: SPNativeMessage?
+            var attributeStyle: SPNativeMessage.AttributeStyle!
+            var messageAttribute: SPNativeMessage.Attribute!
+            var messageAction: SPNativeMessage.Action!
+            var gdprMessage: SPNativeMessage!
             let customFileds = ["Custom": "Fileds"]
 
             beforeEach {
                 attributeStyle = SPNativeMessage.AttributeStyle(fontFamily: "System-Font", fontSize: 14, color: "#00FA9A", backgroundColor: "#944488")
-                messageAttribute = SPNativeMessage.Attribute(text: "Test GDPR Message", style: attributeStyle!, customFields: customFileds)
-                messageAction = SPNativeMessage.Action(text: "Test GDPR Message", style: attributeStyle!, customFields: customFileds, choiceType: SPActionType.AcceptAll, url: nil)
-                gdprMessage = SPNativeMessage(title: messageAttribute!, body: messageAttribute!, actions: [messageAction!], customFields: customFileds)
+                messageAttribute = SPNativeMessage.Attribute(text: "Test GDPR Message", style: attributeStyle, customFields: customFileds)
+                messageAction = SPNativeMessage.Action(text: "Test GDPR Message", style: attributeStyle, customFields: customFileds, choiceType: SPActionType.AcceptAll, url: nil)
+                gdprMessage = SPNativeMessage(title: messageAttribute, body: messageAttribute, actions: [messageAction], customFields: customFileds)
             }
 
             it("Test AttributeStyle method") {
-                expect(attributeStyle?.backgroundColor) == "#944488"
+                expect(attributeStyle.backgroundColor) == "#944488"
             }
 
             it("Test MessageAction method") {
-                expect(messageAttribute?.style.backgroundColor) == "#944488"
+                expect(messageAttribute.style.backgroundColor) == "#944488"
             }
 
             it("Test MessageAction method") {
-                expect(messageAction?.choiceType) == SPActionType.AcceptAll
+                expect(messageAction.choiceType) == SPActionType.AcceptAll
             }
 
             it("Test GDPRMessage method") {
-                expect(gdprMessage?.title.style.color) == "#00FA9A"
+                expect(gdprMessage.title.style.color) == "#00FA9A"
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/GDPRUserConsentsSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GDPRUserConsentsSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class SPGDPRConsentsSpec: QuickSpec {
     override func spec() {
@@ -30,10 +30,11 @@ class SPGDPRConsentsSpec: QuickSpec {
                     "childPmId": null,
                     "consentStatus": {}
                 }
-                """.data(using: .utf8) }
+                """.data(using: .utf8)
+            }
             let consent = try gdprCampaign.decoded() as SPGDPRConsent
-            expect(consent.euconsent).to(equal("ABCD"))
-            expect(consent.vendorGrants).to(equal(SPGDPRVendorGrants()))
+            expect(consent.euconsent) == "ABCD"
+            expect(consent.vendorGrants) == SPGDPRVendorGrants()
             expect(consent.childPmId).to(beNil())
         }
 
@@ -56,7 +57,7 @@ class SPGDPRConsentsSpec: QuickSpec {
                 )
                 expect(consent.acceptedCategories).to(contain(["purpose1", "purpose3"]))
                 expect(consent.acceptedCategories).notTo(contain(["purpose2"]))
-                expect(consent.childPmId).to(equal("yes"))
+                expect(consent.childPmId) == "yes"
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/Helpers/ConnectivityMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/ConnectivityMock.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
 @testable import ConsentViewController
+import Foundation
 
 class ConnectivityMock: Connectivity {
     let isConnected: Bool
@@ -15,6 +15,6 @@ class ConnectivityMock: Connectivity {
         isConnected = connected
     }
     func isConnectedToNetwork() -> Bool {
-        return isConnected
+        isConnected
     }
 }

--- a/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
@@ -14,7 +14,7 @@ extension URL {
         guard
             let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
             let queryItems = components.queryItems else { return nil }
-        return queryItems.reduce(into: [String: String]()) { (result, item) in
+        return queryItems.reduce(into: [String: String]()) { result, item in
             result[item.name] = item.value
         }
     }

--- a/Example/ConsentViewController_ExampleTests/Helpers/GDPRLocalStorageMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/GDPRLocalStorageMock.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
 @testable import ConsentViewController
+import Foundation
 
 class GDPRLocalStorageMock: SPLocalStorage {
     var gdprChildPmId: String?
@@ -23,12 +23,12 @@ class GDPRLocalStorageMock: SPLocalStorage {
 
     var clearWasCalled = false
 
+    required init(storage: Storage = InMemoryStorageMock()) {
+        self.storage = storage
+    }
+
     func clear() {
         clearWasCalled = true
         storage = InMemoryStorageMock()
-    }
-
-    required init(storage: Storage = InMemoryStorageMock()) {
-        self.storage = storage
     }
 }

--- a/Example/ConsentViewController_ExampleTests/Helpers/GDPRUIiDelegateMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/GDPRUIiDelegateMock.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
 @testable import ConsentViewController
+import Foundation
 
 //  class GDPRUIDelegateMock: SPMessageUIDelegate {
 //    weak var consentDelegate: SPDelegate?

--- a/Example/ConsentViewController_ExampleTests/Helpers/HttpMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/HttpMock.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
 @testable import ConsentViewController
+import Foundation
 
 class MockHttp: HttpClient {
     var postWasCalledWithUrl: String!

--- a/Example/ConsentViewController_ExampleTests/Helpers/HttpMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/HttpMock.swift
@@ -31,6 +31,7 @@ class MockHttp: HttpClient {
             if self.success != nil {
                 handler(.success(self.success))
             } else {
+                // swiftlint:disable:next force_unwrapping
                 handler(.failure(SPError(error: self.error!)))
             }
         }

--- a/Example/ConsentViewController_ExampleTests/Helpers/InMemoryStorageMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/InMemoryStorageMock.swift
@@ -6,16 +6,16 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
 @testable import ConsentViewController
+import Foundation
 
 /// A class that uses [String: Any] as its storage
 class InMemoryStorageMock: Storage {
+    var storage = [String: Any]()
+
     func integer(forKey defaultName: String) -> Int {
         storage[defaultName] as? Int ?? 0
     }
-
-    var storage = [String: Any]()
 
     func string(forKey defaultName: String) -> String? {
         storage[defaultName] as? String

--- a/Example/ConsentViewController_ExampleTests/Helpers/MessageMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/MessageMock.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
+@testable import ConsentViewController
 import Foundation
 import WebKit
-@testable import ConsentViewController
 
 class WebViewMock: WKWebView {
     var loadCalledWith: URLRequest!
@@ -23,7 +23,7 @@ class MessageMock: WKScriptMessage {
     var _body: Any
     override var body: Any {
         get {
-            return _body
+            _body
         }
         set {
             _body = newValue

--- a/Example/ConsentViewController_ExampleTests/Helpers/MockConsentDelegate.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/MockConsentDelegate.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
+@testable import ConsentViewController
 import Foundation
 import UIKit
-@testable import ConsentViewController
 
 class MockConsentDelegate: SPDelegate {
     var isOnSPUIFinishedCalled = false

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -6,16 +6,20 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
 @testable import ConsentViewController
+import Foundation
 
 // swiftlint:disable function_parameter_count
 
 class SourcePointClientMock: SourcePointProtocol {
+    var customConsentResponse: AddOrDeleteCustomConsentResponse?
+    var error: SPError?
+    var postActionCalled = false, getMessageCalled = false, customConsentCalled = false
+    var customConsentWasCalledWith: [String: Any?]!
+    var errorMetricsCalledWith: [String: Any?]!
+
     required init(accountId: Int, propertyName: SPPropertyName, campaignEnv: SPCampaignEnv, timeout: TimeInterval) {
     }
-
-    var customConsentResponse: AddOrDeleteCustomConsentResponse?
 
     static func getCampaign(_ type: SPCampaignType) -> Campaign {
         Campaign(
@@ -49,13 +53,7 @@ class SourcePointClientMock: SourcePointProtocol {
         )
     }
 
-    var error: SPError?
-    var postActionCalled = false, getMessageCalled = false, customConsentCalled = false
-    var customConsentWasCalledWith: [String: Any?]!
-    var errorMetricsCalledWith: [String: Any?]!
-
     func consentStatus(propertyId: Int, metadata: ConsentStatusMetaData, authId: String?, handler: @escaping ConsentStatusHandler) {
-
     }
 
     func getMessages(_ params: MessagesRequest, handler: @escaping MessagesHandler) {
@@ -66,47 +64,36 @@ class SourcePointClientMock: SourcePointProtocol {
     }
 
     func getGDPRMessage(propertyId: String, consentLanguage: SPMessageLanguage, messageId: String, handler: @escaping MessageHandler) {
-
     }
 
     func getCCPAMessage(propertyId: String, consentLanguage: SPMessageLanguage, messageId: String, handler: @escaping MessageHandler) {
-
     }
 
     func gdprPrivacyManagerView(propertyId: Int, consentLanguage: SPMessageLanguage, handler: @escaping GDPRPrivacyManagerViewHandler) {
-
     }
 
     func ccpaPrivacyManagerView(propertyId: Int, consentLanguage: SPMessageLanguage, handler: @escaping CCPAPrivacyManagerViewHandler) {
-
     }
 
     func postCCPAAction(actionType: SPActionType, body: CCPAChoiceBody, handler: @escaping CCPAConsentHandler) {
-
     }
 
     func postGDPRAction(authId: String?, action: SPAction, localState: SPJson, handler: @escaping GDPRConsentHandler) {
-
     }
 
     func getMessages(campaigns: SPCampaigns, authId: String?, localState: SPJson, idfaStaus: SPIDFAStatus, consentLanguage: SPMessageLanguage, handler: @escaping MessagesHandler) {
-
     }
 
     func postCCPAAction(authId: String?, action: SPAction, localState: SPJson, idfaStatus: SPIDFAStatus, handler: @escaping CCPAConsentHandler) {
-
     }
 
     func postGDPRAction(actionType: ConsentViewController.SPActionType, body: ConsentViewController.GDPRChoiceBody, handler: @escaping ConsentViewController.GDPRConsentHandler) {
-
     }
 
     func pvData(pvDataRequestBody: ConsentViewController.PvDataRequestBody, handler: @escaping ConsentViewController.PvDataHandler) {
-
     }
 
     func reportIdfaStatus(propertyId: Int?, uuid: String?, uuidType: SPCampaignType?, messageId: Int?, idfaStatus: SPIDFAStatus, iosVersion: String, partitionUUID: String?) {
-
     }
 
     func customConsentGDPR(
@@ -116,11 +103,9 @@ class SourcePointClientMock: SourcePointProtocol {
         legIntCategories: [String],
         propertyId: Int,
         handler: @escaping AddOrDeleteCustomConsentHandler) {
-
     }
 
     func errorMetrics(_ error: SPError, propertyId: Int?, sdkVersion: String, OSVersion: String, deviceFamily: String, campaignType: SPCampaignType) {
-
     }
 
     func deleteCustomConsentGDPR(toConsentUUID consentUUID: String,

--- a/Example/ConsentViewController_ExampleTests/LocalStorage/GDPRLocalStorageSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/LocalStorage/GDPRLocalStorageSpec.swift
@@ -6,17 +6,17 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 class CodableMock: Codable, Equatable {
-    static func == (lhs: CodableMock, rhs: CodableMock) -> Bool {
-        return lhs.attribute == rhs.attribute
-    }
     let attribute: Int
     init(_ attr: Int) {
         attribute = attr
+    }
+    static func == (lhs: CodableMock, rhs: CodableMock) -> Bool {
+        lhs.attribute == rhs.attribute
     }
 }
 
@@ -27,7 +27,7 @@ class GDPRLocalStorageSpec: QuickSpec {
                 let original = CodableMock(42)
                 UserDefaults.standard.setObject(original, forKey: "a_codable")
                 let stored = UserDefaults.standard.object(ofType: CodableMock.self, forKey: "a_codable")
-                expect(stored).to(equal(original))
+                expect(stored) == original
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/LocalStorage/GDPRUserDefaultsSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/LocalStorage/GDPRUserDefaultsSpec.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 // swiftlint:disable force_cast function_body_length
 
@@ -34,28 +34,28 @@ class GDPRUserDefaultsSpec: QuickSpec {
                 it("gets its value from the local storage") {
                     localStorage.storage = [SPUserDefaults.IAB_CMP_SDK_ID_KEY: 99]
                     let userDefaults = SPUserDefaults(storage: localStorage)
-                    expect(userDefaults.tcfData?[SPUserDefaults.IAB_CMP_SDK_ID_KEY] as? Int).to(equal(99))
+                    expect(userDefaults.tcfData?[SPUserDefaults.IAB_CMP_SDK_ID_KEY] as? Int) == 99
                 }
 
                 it("persists the value in the local storage") {
                     let userDefaults = SPUserDefaults(storage: localStorage)
                     userDefaults.tcfData = [SPUserDefaults.IAB_CMP_SDK_ID_KEY: 99]
                     let stored = localStorage.storage[SPUserDefaults.IAB_CMP_SDK_ID_KEY] as! Int
-                    expect(stored).to(equal(99))
+                    expect(stored) == 99
                 }
             }
 
             describe("userData") {
                 it("is empty SPUserData by default") {
                     let userDefaults = SPUserDefaults(storage: localStorage)
-                    expect(userDefaults.userData).to(equal(SPUserData()))
+                    expect(userDefaults.userData) == SPUserData()
                 }
 
                 it("gets its value from the local storage") {
                     let userData = SPUserData()
                     localStorage.storage = [SPUserDefaults.USER_DATA_KEY: userData]
                     let userDefaults = SPUserDefaults(storage: localStorage)
-                    expect(userDefaults.userData).to(equal(userData))
+                    expect(userDefaults.userData) == userData
                 }
 
                 it("persists the value in the local storage") {
@@ -63,7 +63,7 @@ class GDPRUserDefaultsSpec: QuickSpec {
                     let userDefaults = SPUserDefaults(storage: localStorage)
                     userDefaults.userData = userData
                     let stored = localStorage.storage[SPUserDefaults.USER_DATA_KEY] as! SPUserData
-                    expect(stored).to(equal(userData))
+                    expect(stored) == userData
                 }
             }
 
@@ -75,8 +75,8 @@ class GDPRUserDefaultsSpec: QuickSpec {
                     userDefaults.userData = userData
                     userDefaults.tcfData = tcfData
                     let dict = userDefaults.dictionaryRepresentation()
-                    expect((dict[SPUserDefaults.USER_DATA_KEY] as? SPUserData)).to(equal(userData))
-                    expect((dict["\(SPUserDefaults.IAB_KEY_PREFIX)foo"] as? String)).to(equal("bar"))
+                    expect((dict[SPUserDefaults.USER_DATA_KEY] as? SPUserData)) == userData
+                    expect((dict["\(SPUserDefaults.IAB_KEY_PREFIX)foo"] as? String)) == "bar"
                 }
 
                 it("returns a dictionary containing only its attributes") {
@@ -96,7 +96,7 @@ class GDPRUserDefaultsSpec: QuickSpec {
                     let userDefaults = SPUserDefaults(storage: localStorage)
                     userDefaults.userData = self.randomUserConsents()
                     userDefaults.clear()
-                    expect(userDefaults.userData).to(equal(SPUserData()))
+                    expect(userDefaults.userData) == SPUserData()
                 }
 
                 it("sets tcfData back to its default value") {
@@ -111,13 +111,13 @@ class GDPRUserDefaultsSpec: QuickSpec {
                 it("sets gdprChildPMId and checks it") {
                     let userDefaults = SPUserDefaults(storage: localStorage)
                     userDefaults.gdprChildPmId = "yo"
-                    expect(userDefaults.gdprChildPmId).to(equal("yo"))
+                    expect(userDefaults.gdprChildPmId) == "yo"
                 }
 
                 it("sets ccpaChildPMId and checks it") {
                     let userDefaults = SPUserDefaults(storage: localStorage)
                     userDefaults.ccpaChildPmId = "yo"
-                    expect(userDefaults.ccpaChildPmId).to(equal("yo"))
+                    expect(userDefaults.ccpaChildPmId) == "yo"
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SPActionSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPActionSpec.swift
@@ -8,17 +8,16 @@
 
 // swiftlint:disable function_body_length
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class SPActionSpec: QuickSpec {
     override func spec() {
-
         describe("SPAction") {
             it("publisherData is set to empty dictionary by default") {
-                expect(SPAction(type: .AcceptAll).publisherData).to(equal([:]))
+                expect(SPAction(type: .AcceptAll).publisherData) == [:]
             }
 
             describe("init") {
@@ -28,14 +27,14 @@ class SPActionSpec: QuickSpec {
                     let consentLanguage = "EN"
                     let action = SPAction(type: .AcceptAll, consentLanguage: "EN", pmPayload: payload)
 
-                    expect(action.type).to(equal(type))
-                    expect(action.pmPayload).to(equal(payload))
-                    expect(action.consentLanguage).to(equal(consentLanguage))
+                    expect(action.type) == type
+                    expect(action.pmPayload) == payload
+                    expect(action.consentLanguage) == consentLanguage
                 }
 
                 it("initialises data to data encoded \"{}\" by default") {
                     let action = SPAction(type: .AcceptAll)
-                    expect(action.pmPayload).to(equal(SPJson()))
+                    expect(action.pmPayload) == SPJson()
                 }
 
                 it("initialises consentLanguage to nil by default") {
@@ -48,61 +47,61 @@ class SPActionSpec: QuickSpec {
         describe("SPActionType") {
             describe("SaveAndExit") {
                 it("has the raw value of 1") {
-                    expect(SPActionType.SaveAndExit.rawValue).to(equal(1))
+                    expect(SPActionType.SaveAndExit.rawValue) == 1
                 }
 
                 it("has its description as 'SaveAndExit'") {
-                    expect(SPActionType.SaveAndExit.description).to(equal("SaveAndExit"))
+                    expect(SPActionType.SaveAndExit.description) == "SaveAndExit"
                 }
             }
 
             describe("PMCancel") {
                 it("has the raw value of 2") {
-                    expect(SPActionType.PMCancel.rawValue).to(equal(2))
+                    expect(SPActionType.PMCancel.rawValue) == 2
                 }
 
                 it("has its description as 'PMCancel'") {
-                    expect(SPActionType.PMCancel.description).to(equal("PMCancel"))
+                    expect(SPActionType.PMCancel.description) == "PMCancel"
                 }
             }
 
             describe("AcceptAll") {
                 it("has the raw value of 11") {
-                    expect(SPActionType.AcceptAll.rawValue).to(equal(11))
+                    expect(SPActionType.AcceptAll.rawValue) == 11
                 }
 
                 it("has its description as 'AcceptAll'") {
-                    expect(SPActionType.AcceptAll.description).to(equal("AcceptAll"))
+                    expect(SPActionType.AcceptAll.description) == "AcceptAll"
                 }
             }
 
             describe("ShowPrivacyManager") {
                 it("has the raw value of 12") {
-                    expect(SPActionType.ShowPrivacyManager.rawValue).to(equal(12))
+                    expect(SPActionType.ShowPrivacyManager.rawValue) == 12
                 }
 
                 it("has its description as 'ShowPrivacyManager'") {
-                    expect(SPActionType.ShowPrivacyManager.description).to(equal("ShowPrivacyManager"))
+                    expect(SPActionType.ShowPrivacyManager.description) == "ShowPrivacyManager"
                 }
             }
 
             describe("RejectAll") {
                 it("has the raw value of 13") {
-                    expect(SPActionType.RejectAll.rawValue).to(equal(13))
+                    expect(SPActionType.RejectAll.rawValue) == 13
                 }
 
                 it("has its description as 'RejectAll'") {
-                    expect(SPActionType.RejectAll.description).to(equal("RejectAll"))
+                    expect(SPActionType.RejectAll.description) == "RejectAll"
                 }
             }
 
             describe("Dismiss") {
                 it("has the raw value of 15") {
-                    expect(SPActionType.Dismiss.rawValue).to(equal(15))
+                    expect(SPActionType.Dismiss.rawValue) == 15
                 }
 
                 it("has its description as 'Dismiss'") {
-                    expect(SPActionType.Dismiss.description).to(equal("Dismiss"))
+                    expect(SPActionType.Dismiss.description) == "Dismiss"
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SPCampaignEnvSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPCampaignEnvSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 // swiftlint:disable force_try
 
@@ -18,29 +18,29 @@ class SPCampaignEnvSpec: QuickSpec {
         describe("SPCampaignEnv") {
             describe("Stage") {
                 it("has the raw value of 0") {
-                    expect(SPCampaignEnv.Stage.rawValue).to(equal(0))
+                    expect(SPCampaignEnv.Stage.rawValue) == 0
                 }
 
                 it("has its description as 'stage'") {
-                    expect(SPCampaignEnv.Stage.description).to(equal("SPCampaignEnv.stage"))
+                    expect(SPCampaignEnv.Stage.description) == "SPCampaignEnv.stage"
                 }
 
                 it("can be created with a string") {
-                    expect(SPCampaignEnv(stringValue: "stage")).to(equal(SPCampaignEnv.Stage))
+                    expect(SPCampaignEnv(stringValue: "stage")) == SPCampaignEnv.Stage
                 }
             }
 
             describe("Public") {
                 it("has the raw value of 1") {
-                    expect(SPCampaignEnv.Public.rawValue).to(equal(1))
+                    expect(SPCampaignEnv.Public.rawValue) == 1
                 }
 
                 it("has its description as 'prod'") {
-                    expect(SPCampaignEnv.Public.description).to(equal("SPCampaignEnv.prod"))
+                    expect(SPCampaignEnv.Public.description) == "SPCampaignEnv.prod"
                 }
 
                 it("can be created with a string") {
-                    expect(SPCampaignEnv(stringValue: "prod")).to(equal(SPCampaignEnv.Public))
+                    expect(SPCampaignEnv(stringValue: "prod")) == SPCampaignEnv.Public
                 }
             }
 
@@ -50,9 +50,9 @@ class SPCampaignEnvSpec: QuickSpec {
                         let encoded = try! JSONEncoder().encodeResult(SPCampaignEnv.Stage).get()
                         let encodedString = String(data: encoded, encoding: .utf8)
                         if #available(iOS 11, *) {
-                            expect(encodedString).to(equal("\"stage\""))
+                            expect(encodedString) == "\"stage\""
                         } else {
-                            expect(encodedString).to(equal("[\"stage\"]"))
+                            expect(encodedString) == "[\"stage\"]"
                         }
                     }
                 }
@@ -64,7 +64,7 @@ class SPCampaignEnvSpec: QuickSpec {
                     } else {
                         decoded = try? JSONDecoder().decode(SPCampaignEnv.self, from: "[\"stage\"]".data(using: .utf8)!)
                     }
-                    expect(decoded).to(equal(.Stage))
+                    expect(decoded) == .Stage
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SPCampaignEnvSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPCampaignEnvSpec.swift
@@ -60,8 +60,10 @@ class SPCampaignEnvSpec: QuickSpec {
                 it("can be decoded from JSON") {
                     var decoded: SPCampaignEnv?
                     if #available(iOS 11, *) {
+                        // swiftlint:disable:next force_unwrapping
                         decoded = try? JSONDecoder().decode(SPCampaignEnv.self, from: "\"stage\"".data(using: .utf8)!)
                     } else {
+                        // swiftlint:disable:next force_unwrapping
                         decoded = try? JSONDecoder().decode(SPCampaignEnv.self, from: "[\"stage\"]".data(using: .utf8)!)
                     }
                     expect(decoded) == .Stage

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -15,21 +15,19 @@ import Quick
 
 class SPClientCoordinatorSpec: QuickSpec {
     override func spec() {
-        describe("a property with GDPR and CCPA campaigns") {
-            SPConsentManager.clearAllData()
+        SPConsentManager.clearAllData()
 
-            let coordinator: SPClientCoordinator = SourcepointClientCoordinator(
-                accountId: 22,
-                propertyName: try! SPPropertyName("mobile.multicampaign.demo"),
-                propertyId: 16_893,
-                campaigns: SPCampaigns(
-                    gdpr: SPCampaign(),
-                    ccpa: SPCampaign()
-                )
+        let coordinator: SPClientCoordinator = SourcepointClientCoordinator(
+            accountId: 22,
+            propertyName: try! SPPropertyName("mobile.multicampaign.demo"),
+            propertyId: 16_893,
+            campaigns: SPCampaigns(
+                gdpr: SPCampaign(),
+                ccpa: SPCampaign()
             )
+        )
 
-            let defaults = UserDefaults.standard
-
+        describe("a property with GDPR and CCPA campaigns") {
             describe("loadMessage") {
                 it("should return 2 messages and consents") {
                     waitUntil { done in
@@ -41,8 +39,6 @@ class SPClientCoordinatorSpec: QuickSpec {
                                     expect(consents.gdpr?.consents?.euconsent).notTo(beEmpty())
                                     expect(consents.gdpr?.consents?.vendorGrants).notTo(beEmpty())
                                     expect(consents.ccpa?.consents?.uspstring) == "1YNN"
-                                    expect(defaults.integer(forKey: "IABTCF_gdprApplies")) == 1
-                                    expect(defaults.string(forKey: "IABUSPrivacy_String")) == "1YNN"
                                 case .failure(let error):
                                     fail(error.failureReason)
                             }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2023 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 // swiftlint:disable force_try
 
@@ -21,7 +21,7 @@ class SPClientCoordinatorSpec: QuickSpec {
             let coordinator: SPClientCoordinator = SourcepointClientCoordinator(
                 accountId: 22,
                 propertyName: try! SPPropertyName("mobile.multicampaign.demo"),
-                propertyId: 16893,
+                propertyId: 16_893,
                 campaigns: SPCampaigns(
                     gdpr: SPCampaign(),
                     ccpa: SPCampaign()
@@ -36,12 +36,12 @@ class SPClientCoordinatorSpec: QuickSpec {
                         coordinator.loadMessages(forAuthId: nil) { result in
                             switch result {
                                 case .success(let (messages, consents)):
-                                    expect(messages.count).to(equal(2))
+                                    expect(messages.count) == 2
                                     expect(consents.gdpr?.consents?.euconsent).notTo(beEmpty())
                                     expect(consents.gdpr?.consents?.vendorGrants).notTo(beEmpty())
-                                    expect(consents.ccpa?.consents?.uspstring).to(equal("1YNN"))
-                                    expect(defaults.integer(forKey: "IABTCF_gdprApplies")).to(equal(1))
-                                    expect(defaults.string(forKey: "IABUSPrivacy_String")).to(equal("1YNN"))
+                                    expect(consents.ccpa?.consents?.uspstring) == "1YNN"
+                                    expect(defaults.integer(forKey: "IABTCF_gdprApplies")) == 1
+                                    expect(defaults.string(forKey: "IABUSPrivacy_String")) == "1YNN"
                                 case .failure(let error):
                                     fail(error.failureReason)
                             }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -15,7 +15,7 @@ import Quick
 
 class SPClientCoordinatorSpec: QuickSpec {
     override func spec() {
-        describe("a property without campaigns") {
+        describe("a property with GDPR and CCPA campaigns") {
             SPConsentManager.clearAllData()
 
             let coordinator: SPClientCoordinator = SourcepointClientCoordinator(
@@ -37,6 +37,7 @@ class SPClientCoordinatorSpec: QuickSpec {
                             switch result {
                                 case .success(let (messages, consents)):
                                     expect(messages.count) == 2
+                                    expect(consents.gdpr?.consents?.applies).to(beTrue())
                                     expect(consents.gdpr?.consents?.euconsent).notTo(beEmpty())
                                     expect(consents.gdpr?.consents?.vendorGrants).notTo(beEmpty())
                                     expect(consents.ccpa?.consents?.uspstring) == "1YNN"

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/ActionRequestSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/ActionRequestSpec.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 // swiftlint:disable force_try
 class ActionRequestSpec: QuickSpec {
@@ -45,7 +45,7 @@ class ActionRequestSpec: QuickSpec {
 
         it("can be encoded to JSON") {
             let actionEncoded = String(data: try! JSONEncoder().encode(request), encoding: .utf8)
-            expect(actionString).to(equal(actionEncoded))
+            expect(actionString) == actionEncoded
         }
     }
 }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/CampaignSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/CampaignSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2022 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 // swiftlint:disable force_try function_body_length
 
@@ -49,18 +49,18 @@ class CampaignSpec: QuickSpec {
         """.data(using: .utf8)!).get()
 
         it("can be decoded with keyed consentStatus") {
-            expect(campaignWithKeydConsentStatus.consentStatus?.rejectedAny).to(beTrue())
-            expect(campaignWithKeydConsentStatus.consentStatus?.rejectedLI).to(beFalse())
-            expect(campaignWithKeydConsentStatus.consentStatus?.consentedAll).to(beFalse())
-            expect(campaignWithKeydConsentStatus.consentStatus?.hasConsentData).to(beFalse())
-            expect(campaignWithKeydConsentStatus.consentStatus?.consentedToAny).to(beFalse())
+            expect(campaignWithKeydConsentStatus.consentStatus?.rejectedAny) == true
+            expect(campaignWithKeydConsentStatus.consentStatus?.rejectedLI) == false
+            expect(campaignWithKeydConsentStatus.consentStatus?.consentedAll) == false
+            expect(campaignWithKeydConsentStatus.consentStatus?.hasConsentData) == false
+            expect(campaignWithKeydConsentStatus.consentStatus?.consentedToAny) == false
         }
 
         it("can be decoded with non keyed consentStatus") {
-            expect(campaignWithNonKeyedConsentStatus.consentStatus?.consentedAll).to(beFalse())
-            expect(campaignWithNonKeyedConsentStatus.consentStatus?.rejectedAll).to(beFalse())
-            expect(campaignWithNonKeyedConsentStatus.consentStatus?.rejectedVendors).to(equal([]))
-            expect(campaignWithNonKeyedConsentStatus.consentStatus?.rejectedCategories).to(equal([]))
+            expect(campaignWithNonKeyedConsentStatus.consentStatus?.consentedAll) == false
+            expect(campaignWithNonKeyedConsentStatus.consentStatus?.rejectedAll) == false
+            expect(campaignWithNonKeyedConsentStatus.consentStatus?.rejectedVendors) == []
+            expect(campaignWithNonKeyedConsentStatus.consentStatus?.rejectedCategories) == []
         }
 
         it("ccpa campaign can be decoded into SPCCPAConsent") {

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/CampaignSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/CampaignSpec.swift
@@ -11,7 +11,7 @@ import Foundation
 import Nimble
 import Quick
 
-// swiftlint:disable force_try function_body_length
+// swiftlint:disable force_try function_body_length force_unwrapping
 
 class CampaignSpec: QuickSpec {
     override func spec() {

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/ConnectivityManagerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/ConnectivityManagerSpec.swift
@@ -6,16 +6,14 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 class ConnectivityManagerSpec: QuickSpec {
-
     override func spec() {
         let connectivityManager = ConnectivityManager()
         describe("Test ConnectivityManager") {
-
             it("Test isConnectedToNetwork method") {
                 let networkStatus = connectivityManager.isConnectedToNetwork()
                 if networkStatus == true {

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/MessageRequestSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/MessageRequestSpec.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 // swiftlint:disable force_try
 
@@ -69,7 +69,7 @@ class MessageRequestSpec: QuickSpec {
             let encoder = JSONEncoder()
             if #available(iOS 11.0, *) { encoder.outputFormatting = .sortedKeys }
             let messageEncoded = String(data: try! encoder.encode(message), encoding: .utf8)
-            expect(messageString).to(equal(messageEncoded))
+            expect(messageString) == messageEncoded
         }
     }
 }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/MessageResponseSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/MessageResponseSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class MessageResponseSpec: QuickSpec {
     override func spec() {

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/MessagesResponseSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/MessagesResponseSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2022 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 // swiftlint:disable function_body_length
 class MessagesResponseSpec: QuickSpec {

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/QueryParamEncodableSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/QueryParamEncodableSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2022 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class QueryParamEncodableSpec: QuickSpec {
     struct MockMetaData: QueryParamEncodable {
@@ -19,7 +19,7 @@ class QueryParamEncodableSpec: QuickSpec {
     override func spec() {
         it("should encode to a stringified json object") {
             let mockData = MockMetaData()
-            expect(mockData.stringified).to(equal("{\"foo\":\"bar\"}"))
+            expect(mockData.stringified) == "{\"foo\":\"bar\"}"
         }
     }
 }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SimpleClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SimpleClientSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 // swiftlint:disable force_cast function_body_length
 
@@ -28,12 +28,6 @@ class URLSessionMock: SPURLSession {
     let error: Error?
     var dataTaskCalledWith: URLRequest?
 
-    func dataTask(_ request: URLRequest, completionHandler: @escaping DataTaskResult) -> SPURLSessionDataTask {
-        dataTaskCalledWith = request
-        completionHandler(result, URLResponse(), error)
-        return dataTaskResult
-    }
-
     init(
         configuration: URLSessionConfiguration = URLSessionConfiguration.default,
         dataTaskResult: SPURLSessionDataTask = URLSessionDataTaskMock(),
@@ -44,6 +38,12 @@ class URLSessionMock: SPURLSession {
         self.error = error
         self.dataTaskResult = dataTaskResult
         result = data
+    }
+
+    func dataTask(_ request: URLRequest, completionHandler: @escaping DataTaskResult) -> SPURLSessionDataTask {
+        dataTaskCalledWith = request
+        completionHandler(result, URLResponse(), error)
+        return dataTaskResult
     }
 }
 
@@ -63,12 +63,12 @@ class SimpleClientSpec: QuickSpec {
         describe("init(timeoutAfter: TimeInterval)") {
             it("sets the dispatchQueue to DispatchQueue.main") {
                 let dispatchQueue = SimpleClient(timeoutAfter: 1).dispatchQueue as! DispatchQueue
-                expect(dispatchQueue).to(equal(DispatchQueue.main))
+                expect(dispatchQueue) == DispatchQueue.main
             }
 
             it("sets the timeout in its URLSession") {
                 let session = SimpleClient(timeoutAfter: 10.0).session as! URLSession
-                expect(session.configuration.timeoutIntervalForResource).to(equal(10.0))
+                expect(session.configuration.timeoutIntervalForResource) == 10.0
             }
         }
 
@@ -82,7 +82,7 @@ class SimpleClientSpec: QuickSpec {
                     dispatchQueue: DispatchQueue.main
                 )
                 client.request(self.exampleRequest) { _ in }
-                expect(session.dataTaskCalledWith).to(equal(self.exampleRequest))
+                expect(session.dataTaskCalledWith) == self.exampleRequest
             }
 
             it("calls requestCachePolicy on its urlSession configuration") {
@@ -95,7 +95,7 @@ class SimpleClientSpec: QuickSpec {
                     dispatchQueue: DispatchQueue.main
                 )
                 client.request(self.exampleRequest) { _ in }
-                expect(session.configuration.requestCachePolicy).to(equal(.reloadIgnoringLocalCacheData))
+                expect(session.configuration.requestCachePolicy) == .reloadIgnoringLocalCacheData
             }
 
             it("calls async on its dispatchQueue with the result of the dataTask") {
@@ -108,7 +108,7 @@ class SimpleClientSpec: QuickSpec {
                 )
                 waitUntil { done in
                     client.request(self.exampleRequest) { _ in
-                        expect(queue.asyncCalled).to(beTrue())
+                        expect(queue.asyncCalled) == true
                         done()
                     }
                 }
@@ -127,7 +127,7 @@ class SimpleClientSpec: QuickSpec {
                     dispatchQueue: DispatchQueue.main
                 )
                 client.request(self.exampleRequest) { _ in }
-                expect(dataTaskResult.resumeWasCalled).to(beTrue())
+                expect(dataTaskResult.resumeWasCalled) == true
             }
 
             describe("when the result data from the call is different than nil") {
@@ -165,6 +165,7 @@ class SimpleClientSpec: QuickSpec {
                     client.request(self.exampleRequest) { result in
                         switch result {
                         case .success: fail("call should fail")
+
                         case .failure(let e):
                             expect(e).toEventuallyNot(beNil())
                         }
@@ -184,6 +185,7 @@ class SimpleClientSpec: QuickSpec {
                 client.request(self.exampleRequest) { result in
                     switch result {
                     case .success: fail("call should fail")
+
                     case .failure(let e):
                         expect(e).toEventually(beAKindOf(NoInternetConnection.self))
                     }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SimpleClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SimpleClientSpec.swift
@@ -57,6 +57,7 @@ class DispatchQueueMock: SPDispatchQueue {
 }
 
 class SimpleClientSpec: QuickSpec {
+    // swiftlint:disable:next force_unwrapping
     let exampleRequest = URLRequest(url: URL(string: "http://example")!)
 
     override func spec() {
@@ -154,6 +155,7 @@ class SimpleClientSpec: QuickSpec {
                     let session = URLSessionMock(
                         configuration: URLSessionConfiguration.default,
                         data: nil,
+                        // swiftlint:disable:next force_unwrapping
                         error: GenericNetworkError(request: URLRequest(url: URL(string: "/")!), response: nil)
                     )
                     let client = SimpleClient(

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
@@ -119,6 +119,7 @@ class SourcePointClientSpec: QuickSpec {
                                 vendorListId: nil,
                                 pubData: [:],
                                 pmSaveAndExitVariables: nil,
+                                sendPVData: true,
                                 propertyId: 0,
                                 sampleRate: 1,
                                 idfaStatus: nil,
@@ -137,6 +138,7 @@ class SourcePointClientSpec: QuickSpec {
                             vendorListId: nil,
                             pubData: [:],
                             pmSaveAndExitVariables: nil,
+                            sendPVData: true,
                             propertyId: 0,
                             sampleRate: 1,
                             idfaStatus: nil,
@@ -161,6 +163,7 @@ class SourcePointClientSpec: QuickSpec {
                                 messageId: "",
                                 pubData: [:],
                                 pmSaveAndExitVariables: nil,
+                                sendPVData: true,
                                 propertyId: 1,
                                 sampleRate: 1
                             )
@@ -175,6 +178,7 @@ class SourcePointClientSpec: QuickSpec {
                             messageId: "",
                             pubData: [:],
                             pmSaveAndExitVariables: nil,
+                            sendPVData: true,
                             propertyId: 1,
                             sampleRate: 1
                         )

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-// swiftlint:disable force_try function_body_length type_body_length
+// swiftlint:disable force_try function_body_length type_body_length force_unwrapping
 
 @testable import ConsentViewController
 import Nimble
@@ -292,7 +292,7 @@ class SourcePointClientSpec: QuickSpec {
 
             describe("deleteCustomConsent") {
                 it("constructsCorrectURL") {
-                    expect(client.deleteCustomConsentUrl(Constants.Urls.DELETE_CUSTOM_CONSENT_URL, self.propertyId, "yo")!.absoluteString).to(
+                    expect(client.deleteCustomConsentUrl(Constants.Urls.DELETE_CUSTOM_CONSENT_URL, self.propertyId, "yo").absoluteString).to(
                         equal("https://cdn.privacy-mgmt.com/consent/tcfv2/consent/v3/custom/\(self.propertyId)?consentUUID=yo"))
                 }
 

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
@@ -8,19 +8,15 @@
 
 // swiftlint:disable force_try function_body_length type_body_length
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 class SourcePointClientSpec: QuickSpec {
     let propertyId = 123
     let accountId = 1
     let propertyName = try! SPPropertyName("test")
     let authID = "auth id"
-
-    func getClient(_ client: MockHttp) -> SourcePointClient {
-        SourcePointClient(accountId: accountId, propertyName: propertyName, campaignEnv: .Public, client: client)
-    }
     var campaign: SPCampaign { SPCampaign(targetingParams: [:]) }
     var campaigns: SPCampaigns { SPCampaigns(gdpr: campaign) }
     var gdprProfile: SPConsent<SPGDPRConsent> { SPConsent<SPGDPRConsent>(
@@ -28,6 +24,10 @@ class SourcePointClientSpec: QuickSpec {
         applies: true
     )}
     var profile: SPUserData { SPUserData(gdpr: gdprProfile) }
+
+    func getClient(_ client: MockHttp) -> SourcePointClient {
+        SourcePointClient(accountId: accountId, propertyName: propertyName, campaignEnv: .Public, client: client)
+    }
 
     func getMessageRequest(_ client: SourcePointClient, _ targetingParams: SPTargetingParams = [:]) -> Data {
         try! JSONEncoder().encode(
@@ -76,7 +76,7 @@ class SourcePointClientSpec: QuickSpec {
             }
 
             it("DELETE_CUSTOM_CONSENT_URL") {
-                expect(Constants.Urls.DELETE_CUSTOM_CONSENT_URL.absoluteURL).to(equal(URL(string: "https://cdn.privacy-mgmt.com/consent/tcfv2/consent/v3/custom/")!.absoluteURL))
+                expect(Constants.Urls.DELETE_CUSTOM_CONSENT_URL.absoluteURL) == URL(string: "https://cdn.privacy-mgmt.com/consent/tcfv2/consent/v3/custom/")!.absoluteURL
             }
         }
 
@@ -125,7 +125,7 @@ class SourcePointClientSpec: QuickSpec {
                                 granularStatus: .init()
                             )
                         ) { _ in }
-                        expect(httpClient.postWasCalledWithUrl).to(equal("https://cdn.privacy-mgmt.com/wrapper/v2/choice/gdpr/11?env=prod"))
+                        expect(httpClient.postWasCalledWithUrl) == "https://cdn.privacy-mgmt.com/wrapper/v2/choice/gdpr/11?env=prod"
                     }
 
                     it("calls POST on the http client with the right body") {
@@ -146,7 +146,8 @@ class SourcePointClientSpec: QuickSpec {
                             actionType: .AcceptAll,
                             body: body
                         ) { _ in }
-                        expect(httpClient.postWasCalledWithBody!).to(equal(try JSONEncoder().encode(body)))
+                        let encoded = try JSONEncoder().encode(body)
+                        expect(httpClient.postWasCalledWithBody!).to(equal(encoded))
                     }
                 }
 
@@ -164,7 +165,7 @@ class SourcePointClientSpec: QuickSpec {
                                 sampleRate: 1
                             )
                         ) { _ in }
-                        expect(httpClient.postWasCalledWithUrl).to(equal("https://cdn.privacy-mgmt.com/wrapper/v2/choice/ccpa/11?env=prod"))
+                        expect(httpClient.postWasCalledWithUrl) == "https://cdn.privacy-mgmt.com/wrapper/v2/choice/ccpa/11?env=prod"
                     }
 
                     it("calls POST on the http client with the right body") {
@@ -181,7 +182,8 @@ class SourcePointClientSpec: QuickSpec {
                             actionType: .AcceptAll,
                             body: body
                         ) { _ in }
-                        expect(httpClient.postWasCalledWithBody!).to(equal(try JSONEncoder().encode(body)))
+                        let encoded = try JSONEncoder().encode(body)
+                        expect(httpClient.postWasCalledWithBody!).to(equal(encoded))
                     }
                 }
             }
@@ -197,11 +199,11 @@ class SourcePointClientSpec: QuickSpec {
                     let http = MockHttp()
                     self.getClient(http).customConsentGDPR(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: [], propertyId: self.propertyId) { _ in }
                     let parsedRequest = try? JSONSerialization.jsonObject(with: http.postWasCalledWithBody!) as? [String: Any]
-                    expect((parsedRequest?["consentUUID"] as? String)).to(equal("uuid"))
-                    expect((parsedRequest?["vendors"] as? [String])).to(equal([]))
-                    expect((parsedRequest?["categories"] as? [String])).to(equal([]))
-                    expect((parsedRequest?["legIntCategories"] as? [String])).to(equal([]))
-                    expect((parsedRequest?["propertyId"] as? Int)).to(equal(self.propertyId))
+                    expect((parsedRequest?["consentUUID"] as? String)) == "uuid"
+                    expect((parsedRequest?["vendors"] as? [String])) == []
+                    expect((parsedRequest?["categories"] as? [String])) == []
+                    expect((parsedRequest?["legIntCategories"] as? [String])) == []
+                    expect((parsedRequest?["propertyId"] as? Int)) == self.propertyId
                 }
 
                 context("on success") {
@@ -229,11 +231,10 @@ class SourcePointClientSpec: QuickSpec {
                             client.customConsentGDPR(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: [], propertyId: self.propertyId) { result in
                                 switch result {
                                 case .success(let response):
-                                    expect(response).to(equal(AddOrDeleteCustomConsentResponse(
+                                    expect(response) == AddOrDeleteCustomConsentResponse(
                                         grants: [
                                             "vendorId": SPGDPRVendorGrant(granted: true, purposeGrants: ["purposeId": true])
-                                        ]
-                                    )))
+                                        ])
                                     done()
                                 case .failure(let error): fail(error.debugDescription)
                                 }
@@ -252,6 +253,7 @@ class SourcePointClientSpec: QuickSpec {
                             client.customConsentGDPR(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: [], propertyId: self.propertyId) { result in
                                 switch result {
                                 case .success: fail("expected to fail but it succeeded")
+
                                 case .failure(let error):
                                     expect(error).to(beAKindOf(SPError.self))
                                     done()
@@ -274,16 +276,16 @@ class SourcePointClientSpec: QuickSpec {
                             campaignType: .gdpr
                         )
                         let parsedRequest = try? JSONSerialization.jsonObject(with: http.postWasCalledWithBody!) as? [String: Any]
-                        expect(http.postWasCalledWithUrl).to(equal("https://cdn.privacy-mgmt.com/wrapper/metrics/v1/custom-metrics"))
-                        expect((parsedRequest?["code"] as? String)).to(equal(error.spCode))
-                        expect((parsedRequest?["accountId"] as? String)).to(equal("\(self.accountId)"))
-                        expect((parsedRequest?["propertyId"] as? String)).to(equal("\(self.propertyId)"))
-                        expect((parsedRequest?["propertyHref"] as? String)).to(equal("https://test"))
-                        expect((parsedRequest?["description"] as? String)).to(equal(error.description))
-                        expect((parsedRequest?["scriptVersion"] as? String)).to(equal("1.2.3"))
-                        expect((parsedRequest?["sdkOSVersion"] as? String)).to(equal("11.0"))
-                        expect((parsedRequest?["deviceFamily"] as? String)).to(equal("iPhone 11 pro"))
-                        expect((parsedRequest?["legislation"] as? String)).to(equal("GDPR"))
+                        expect(http.postWasCalledWithUrl) == "https://cdn.privacy-mgmt.com/wrapper/metrics/v1/custom-metrics"
+                        expect((parsedRequest?["code"] as? String)) == error.spCode
+                        expect((parsedRequest?["accountId"] as? String)) == "\(self.accountId)"
+                        expect((parsedRequest?["propertyId"] as? String)) == "\(self.propertyId)"
+                        expect((parsedRequest?["propertyHref"] as? String)) == "https://test"
+                        expect((parsedRequest?["description"] as? String)) == error.description
+                        expect((parsedRequest?["scriptVersion"] as? String)) == "1.2.3"
+                        expect((parsedRequest?["sdkOSVersion"] as? String)) == "11.0"
+                        expect((parsedRequest?["deviceFamily"] as? String)) == "iPhone 11 pro"
+                        expect((parsedRequest?["legislation"] as? String)) == "GDPR"
                     }
                 }
             }
@@ -298,9 +300,9 @@ class SourcePointClientSpec: QuickSpec {
                     let http = MockHttp()
                     self.getClient(http).deleteCustomConsentGDPR(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: [], propertyId: self.propertyId) { _ in }
                     let parsedRequest = try? JSONSerialization.jsonObject(with: http.deleteWasCalledWithBody!) as? [String: Any]
-                    expect((parsedRequest?["vendors"] as? [String])).to(equal([]))
-                    expect((parsedRequest?["categories"] as? [String])).to(equal([]))
-                    expect((parsedRequest?["legIntCategories"] as? [String])).to(equal([]))
+                    expect((parsedRequest?["vendors"] as? [String])) == []
+                    expect((parsedRequest?["categories"] as? [String])) == []
+                    expect((parsedRequest?["legIntCategories"] as? [String])) == []
                 }
 
                 context("on success") {
@@ -328,13 +330,12 @@ class SourcePointClientSpec: QuickSpec {
                             client.deleteCustomConsentGDPR(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: [], propertyId: self.propertyId) { result in
                                 switch result {
                                 case .success(let response):
-                                    expect(response).to(equal(
-                                        AddOrDeleteCustomConsentResponse(grants: [
+                                    expect(response) == AddOrDeleteCustomConsentResponse(grants: [
                                             "vendorId": SPGDPRVendorGrant(
                                                 granted: false,
                                                 purposeGrants: ["purposeId": false]
                                             )
-                                        ])))
+                                        ])
                                     done()
                                 case .failure: fail()
                                 }
@@ -353,6 +354,7 @@ class SourcePointClientSpec: QuickSpec {
                             client.deleteCustomConsentGDPR(toConsentUUID: "uuid", vendors: [], categories: [], legIntCategories: [], propertyId: self.propertyId) { result in
                                 switch result {
                                 case .success: fail("expected call to fail but it succeeded")
+
                                 case .failure(let error):
                                     expect(error).to(beAKindOf(
                                         InvalidResponseDeleteCustomError.self)

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2022 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 // swiftlint:disable force_try line_length function_body_length cyclomatic_complexity
 
@@ -18,7 +18,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
         let emptyMetaData = ConsentStatusMetaData(gdpr: nil, ccpa: nil)
         let propertyName = try! SPPropertyName("tests.unified-script.com")
         let accountId = 22
-        let propertyId = 17801
+        let propertyId = 17_801
 
         var client: SourcePointClient!
 
@@ -52,9 +52,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
             it("should contain all query params") {
                 let url = client.consentStatusURLWithParams(propertyId: propertyId, metadata: emptyMetaData, authId: nil)
                 let paramsRaw = "env=\(Constants.Urls.envParam)&hasCsp=true&includeData={\"TCData\":{\"type\":\"RecordString\"}}&metadata={}&propertyId=17801&withSiteActions=false"
-                expect(url?.query).to(equal(
-                    paramsRaw.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-                ))
+                expect(url?.query) == paramsRaw.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
             }
         }
 
@@ -70,11 +68,12 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                                 expect(response).to(beAnInstanceOf(ConsentStatusResponse.self))
                                 expect(response.consentStatusData.gdpr).notTo(beNil())
                                 expect(response.consentStatusData.ccpa).notTo(beNil())
+
                             case .failure(let error):
                                 fail(error.failureReason)
                             }
                             done()
-                        }
+                    }
                 }
             }
         }
@@ -113,15 +112,16 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                             switch $0 {
                             case .success(let response):
                                 expect(response).to(beAnInstanceOf(MessagesResponse.self))
-                                expect(response.campaigns.count).to(equal(2))
+                                expect(response.campaigns.count) == 2
                                 response.campaigns.forEach { campaign in
                                     expect(campaign.url).to(containQueryParam(("consentLanguage", "ES")))
                                 }
+
                             case .failure(let error):
                                 fail(error.failureReason)
                             }
                             done()
-                        }
+                    }
                 }
             }
         }
@@ -135,7 +135,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                                 applies: true,
                                 uuid: nil,
                                 accountId: accountId,
-                                siteId: 17801,
+                                siteId: 17_801,
                                 consentStatus: ConsentStatus(),
                                 pubData: nil,
                                 sampleRate: 5,
@@ -149,7 +149,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                                 applies: true,
                                 uuid: nil,
                                 accountId: accountId,
-                                siteId: 17801,
+                                siteId: 17_801,
                                 consentStatus: ConsentStatus(rejectedVendors: [], rejectedCategories: []),
                                 pubData: nil,
                                 messageId: nil,
@@ -161,6 +161,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                         case .success(let response):
                             expect(response).to(beAnInstanceOf(PvDataResponse.self))
                             expect(response.gdpr).notTo(beNil())
+
                         case .failure(let error):
                             fail(error.failureReason)
                         }
@@ -174,7 +175,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
             it("should call the endpoint and parse the response into MetaDataResponse") {
                 waitUntil { done in
                     client.metaData(accountId: accountId,
-                                    propertyId: 17801,
+                                    propertyId: 17_801,
                                     metadata: MetaDataBodyRequest(
                                         gdpr: MetaDataBodyRequest.Campaign(hasLocalData: true, dateCreated: nil, uuid: nil),
                                         ccpa: MetaDataBodyRequest.Campaign(hasLocalData: false, dateCreated: nil, uuid: nil))) {
@@ -185,11 +186,12 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                                 expect(response).to(beAnInstanceOf(MetaDataResponse.self))
                                 expect(GDPR).notTo(beNil())
                                 expect(CCPA).notTo(beNil())
+
                             case .failure(let error):
                                 fail(error.failureReason)
                             }
                             done()
-                        }
+                    }
                 }
             }
         }
@@ -211,6 +213,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                             expect(response).to(beAnInstanceOf(ChoiceAllResponse.self))
                             expect(response.gdpr).notTo(beNil())
                             expect(response.ccpa).notTo(beNil())
+
                         case .failure(let error):
                             fail(error.failureReason)
                         }
@@ -237,6 +240,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                             expect(response).to(beAnInstanceOf(ChoiceAllResponse.self))
                             expect(response.gdpr).notTo(beNil())
                             expect(response.ccpa).notTo(beNil())
+
                         case .failure(let error):
                             fail(error.failureReason)
                         }

--- a/Example/ConsentViewController_ExampleTests/SPDateCreatedSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPDateCreatedSpec.swift
@@ -12,14 +12,14 @@ import Foundation
 import Nimble
 import Quick
 
-// swiftlint:disable force_try
+// swiftlint:disable force_try force_unwrapping
 
 class SPDateCreatedSpec: QuickSpec {
     override func spec() {
-        func dateFromString(_ date: String) -> Date {
+        func dateFromString(_ date: String) -> Date? {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-            return formatter.date(from: date)!
+            return formatter.date(from: date)
         }
 
         describe("SPDateCreated") {

--- a/Example/ConsentViewController_ExampleTests/SPDateCreatedSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPDateCreatedSpec.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 // swiftlint:disable force_try
 
@@ -28,14 +28,14 @@ class SPDateCreatedSpec: QuickSpec {
                 let decoded: SPDateCreated = try! JSONDecoder().decode(SPDateCreated.self, from: dateString.data(using: .utf8)!)
                 let encoded = try! JSONEncoder().encode(decoded)
                 let encodedString = String(data: encoded, encoding: .utf8)!
-                expect(encodedString).to(equal(dateString))
+                expect(encodedString) == dateString
             }
 
             it("should decode from string") {
                 let dateString = "\"2022-08-25T20:56:38.551Z\""
                 let decoded: SPDateCreated = try! JSONDecoder().decode(SPDateCreated.self, from: dateString.data(using: .utf8)!)
                 let date = dateFromString(dateString.replacingOccurrences(of: "\"", with: ""))
-                expect(decoded.date).to(equal(date))
+                expect(decoded.date) == date
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/SPDeviceSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPDeviceSpec.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class SPDeviceSpec: QuickSpec {
     override func spec() {
@@ -31,7 +31,7 @@ class SPDeviceSpec: QuickSpec {
                 } else if  #available(iOS 10, *) {
                     expect(version).to(contain("10."))
                 } else {
-                    expect(version).to(equal("apple-unknown"))
+                    expect(version) == "apple-unknown"
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SPErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPErrorSpec.swift
@@ -6,16 +6,16 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 func emptyRequest() -> URLRequest {
-    return URLRequest(url: URL(string: "/")!)
+    URLRequest(url: URL(string: "/")!)
 }
 
 func aResponseWith(status: Int) -> HTTPURLResponse {
-    return HTTPURLResponse(url: URL(string: "/")!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    HTTPURLResponse(url: URL(string: "/")!, statusCode: status, httpVersion: nil, headerFields: nil)!
 }
 
 // swiftlint:disable function_body_length
@@ -27,156 +27,156 @@ class SPErrorSpec: QuickSpec {
                 context("when no response object is provided") {
                     it("has spCode: generic_network_request_999") {
                         let error = GenericNetworkError(request: emptyRequest(), response: nil)
-                        expect(error.spCode).to(equal("sp_metric_generic_network_request_999"))
+                        expect(error.spCode) == "sp_metric_generic_network_request_999"
                     }
                 }
 
                 context("when we know the response status") {
                     it("has spCode: generic_network_request_{response.status}") {
                         let error = GenericNetworkError(request: emptyRequest(), response: aResponseWith(status: 500))
-                        expect(error.spCode).to(equal("sp_metric_generic_network_request_500"))
+                        expect(error.spCode) == "sp_metric_generic_network_request_500"
                     }
                 }
             }
 
             describe("NoInternetConnection") {
                 it("has spCode: no_internet_connection") {
-                    expect(NoInternetConnection().spCode).to(equal("sp_metric_no_internet_connection"))
+                    expect(NoInternetConnection().spCode) == "sp_metric_no_internet_connection"
                 }
             }
 
             describe("InternalServerError") {
                 it("has spCode: internal_server_error_{response.statusCode}") {
                     let error = InternalServerError(request: emptyRequest(), response: aResponseWith(status: 502))
-                    expect(error.spCode).to(equal("sp_metric_internal_server_error_502"))
+                    expect(error.spCode) == "sp_metric_internal_server_error_502"
                 }
             }
 
             describe("ResourceNotFoundError") {
                 it("has spCode: resource_not_found_{response.statusCode}") {
                     let error = ResourceNotFoundError(request: emptyRequest(), response: aResponseWith(status: 404))
-                    expect(error.spCode).to(equal("sp_metric_resource_not_found_404"))
+                    expect(error.spCode) == "sp_metric_resource_not_found_404"
                 }
             }
 
             describe("ConnectionTimeOutError") {
                 it("has spCode: connection_timeout") {
-                    expect(ConnectionTimeOutError(url: nil, timeout: nil, campaignType: .unknown).spCode).to(equal("sp_metric_connection_timeout"))
+                    expect(ConnectionTimeOutError(url: nil, timeout: nil, campaignType: .unknown).spCode) == "sp_metric_connection_timeout"
                 }
             }
 
             describe("InvalidURLError") {
                 it("has spCode: invalid_url") {
-                    expect(InvalidURLError(urlString: "").spCode).to(equal("sp_metric_invalid_url"))
+                    expect(InvalidURLError(urlString: "").spCode) == "sp_metric_invalid_url"
                 }
             }
 
             describe("WebViewError") {
                 it("has spCode: web_view_error") {
-                    expect(WebViewError(campaignType: .gdpr).spCode).to(equal("sp_metric_web_view_error"))
+                    expect(WebViewError(campaignType: .gdpr).spCode) == "sp_metric_web_view_error"
                 }
             }
 
             describe("InvalidResponseWebMessageError") {
                 it("has spCode: invalid_response_web_message") {
-                    expect(InvalidResponseWebMessageError().spCode).to(equal("sp_metric_invalid_response_web_message"))
+                    expect(InvalidResponseWebMessageError().spCode) == "sp_metric_invalid_response_web_message"
                 }
             }
 
             describe("InvalidResponseNativeMessageError") {
                 it("has spCode: invalid_response_native_message") {
-                    expect(InvalidResponseNativeMessageError().spCode).to(equal("sp_metric_invalid_response_native_message"))
+                    expect(InvalidResponseNativeMessageError().spCode) == "sp_metric_invalid_response_native_message"
                 }
             }
 
             describe("InvalidResponseConsentError") {
                 it("has spCode: invalid_response_consent") {
-                    expect(InvalidResponseConsentError().spCode).to(equal("sp_metric_invalid_response_consent"))
+                    expect(InvalidResponseConsentError().spCode) == "sp_metric_invalid_response_consent"
                 }
             }
 
             describe("InvalidResponseCustomError") {
                 it("has spCode: invalid_response_custom_consent") {
-                    expect(InvalidResponseCustomError().spCode).to(equal("sp_metric_invalid_response_custom_consent"))
+                    expect(InvalidResponseCustomError().spCode) == "sp_metric_invalid_response_custom_consent"
                 }
             }
 
             describe("InvalidEventPayloadError") {
                 it("has spCode: invalid_event_payload") {
-                    expect(InvalidEventPayloadError(campaignType: .gdpr).spCode).to(equal("sp_metric_invalid_event_payload"))
+                    expect(InvalidEventPayloadError(campaignType: .gdpr).spCode) == "sp_metric_invalid_event_payload"
                 }
             }
 
             describe("InvalidOnActionEventPayloadError") {
                 it("has spCode: invalid_event_payload") {
-                    expect(InvalidOnActionEventPayloadError(campaignType: .gdpr).spCode).to(equal("sp_metric_invalid_onAction_event_payload"))
+                    expect(InvalidOnActionEventPayloadError(campaignType: .gdpr).spCode) == "sp_metric_invalid_onAction_event_payload"
                 }
             }
 
             describe("RenderingAppError") {
                 describe("if not code is provided") {
                     it("its spCode should be rendering_app_error") {
-                        expect(RenderingAppError(campaignType: .gdpr, nil).spCode).to(equal("sp_metric_rendering_app_error"))
+                        expect(RenderingAppError(campaignType: .gdpr, nil).spCode) == "sp_metric_rendering_app_error"
                     }
                 }
 
                 describe("if a code is provided") {
                     it("its spCode should be the same as the code provided") {
-                        expect(RenderingAppError(campaignType: .gdpr, "foo").spCode).to(equal("foo"))
+                        expect(RenderingAppError(campaignType: .gdpr, "foo").spCode) == "foo"
                     }
                 }
             }
 
             describe("InvalidRequestError") {
                 it("has spCode: invalid_request_error") {
-                    expect(InvalidRequestError().spCode).to(equal("sp_metric_invalid_request_error"))
+                    expect(InvalidRequestError().spCode) == "sp_metric_invalid_request_error"
                 }
             }
 
             describe("UnableToLoadJSReceiver") {
                 it("has spCode: unable_to_load_jsreceiver") {
-                    expect(UnableToLoadJSReceiver().spCode).to(equal("sp_metric_unable_to_load_jsreceiver"))
+                    expect(UnableToLoadJSReceiver().spCode) == "sp_metric_unable_to_load_jsreceiver"
                 }
             }
 
             it("Test InvalidArgumentError method") {
                 let errorObject = InvalidArgumentError(message: "The operation couldn't be completed")
-                expect(errorObject.description).to(equal("The operation couldn't be completed"))
+                expect(errorObject.description) == "The operation couldn't be completed"
             }
 
             describe("InvalidResponseGetMessagesEndpointError") {
                 it("has spCode: sp_metric_invalid_response_get_messages") {
-                    expect(InvalidResponseGetMessagesEndpointError().spCode).to(equal("sp_metric_invalid_response_get_messages"))
+                    expect(InvalidResponseGetMessagesEndpointError().spCode) == "sp_metric_invalid_response_get_messages"
                 }
             }
 
             describe("InvalidResponseMessageGDPREndpointError") {
                 it("has spCode: sp_metric_invalid_response_message_gdpr") {
-                    expect(InvalidResponseMessageGDPREndpointError().spCode).to(equal("sp_metric_invalid_response_message_gdpr"))
+                    expect(InvalidResponseMessageGDPREndpointError().spCode) == "sp_metric_invalid_response_message_gdpr"
                 }
             }
 
             describe("InvalidResponseMessageCCPAEndpointError") {
                 it("has spCode: sp_metric_invalid_response_message_ccpa") {
-                    expect(InvalidResponseMessageCCPAEndpointError().spCode).to(equal("sp_metric_invalid_response_message_ccpa"))
+                    expect(InvalidResponseMessageCCPAEndpointError().spCode) == "sp_metric_invalid_response_message_ccpa"
                 }
             }
 
             describe("InvalidResponseGDPRPMViewEndpointError") {
                 it("has spCode: sp_metric_invalid_response_privacy_manager_view_gdpr") {
-                    expect(InvalidResponseGDPRPMViewEndpointError().spCode).to(equal("sp_metric_invalid_response_privacy_manager_view_gdpr"))
+                    expect(InvalidResponseGDPRPMViewEndpointError().spCode) == "sp_metric_invalid_response_privacy_manager_view_gdpr"
                 }
             }
 
             describe("InvalidResponseCCPAPMViewEndpointError") {
                 it("has spCode: sp_metric_invalid_response_privacy_manager_view_ccpa") {
-                    expect(InvalidResponseCCPAPMViewEndpointError().spCode).to(equal("sp_metric_invalid_response_privacy_manager_view_ccpa"))
+                    expect(InvalidResponseCCPAPMViewEndpointError().spCode) == "sp_metric_invalid_response_privacy_manager_view_ccpa"
                 }
             }
 
             describe("MissingChildPmIdError") {
                 it("has spCode: sp_log_child_pm_id_custom_metrics") {
-                    expect(MissingChildPmIdError(usedId: "ololo").spCode).to(equal("sp_log_child_pm_id_custom_metrics"))
+                    expect(MissingChildPmIdError(usedId: "ololo").spCode) == "sp_log_child_pm_id_custom_metrics"
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SPErrorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPErrorSpec.swift
@@ -11,11 +11,11 @@ import Nimble
 import Quick
 
 func emptyRequest() -> URLRequest {
-    URLRequest(url: URL(string: "/")!)
+    URLRequest(url: URL(string: "/")!) // swiftlint:disable:this force_unwrapping
 }
 
 func aResponseWith(status: Int) -> HTTPURLResponse {
-    HTTPURLResponse(url: URL(string: "/")!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    HTTPURLResponse(url: URL(string: "/")!, statusCode: status, httpVersion: nil, headerFields: nil)! // swiftlint:disable:this force_unwrapping
 }
 
 // swiftlint:disable function_body_length

--- a/Example/ConsentViewController_ExampleTests/SPJsonSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPJsonSpec.swift
@@ -29,7 +29,7 @@ class SPJsonSpec: QuickSpec {
     }
     """
     var json: Any {
-        try! JSONSerialization.jsonObject(with: jsonSample.data(using: .utf8)!)
+        try! JSONSerialization.jsonObject(with: jsonSample.data(using: .utf8)!) // swiftlint:disable:this force_unwrapping
     }
 
     override func spec() {
@@ -63,8 +63,8 @@ class SPJsonSpec: QuickSpec {
             }
 
             it("empty constructor instantiates an equivalent to empty object") {
-                expect(SPJson().dictionaryValue!).to(beAKindOf([String: Any].self))
-                expect(SPJson().dictionaryValue!).to(beEmpty())
+                expect(SPJson().dictionaryValue).to(beAKindOf([String: Any].self))
+                expect(SPJson().dictionaryValue).to(beEmpty())
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/SPJsonSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPJsonSpec.swift
@@ -8,10 +8,10 @@
 
 // swiftlint:disable force_try
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class SPJsonSpec: QuickSpec {
     let jsonSample = """
@@ -29,20 +29,20 @@ class SPJsonSpec: QuickSpec {
     }
     """
     var json: Any {
-        return try! JSONSerialization.jsonObject(with: jsonSample.data(using: .utf8)!)
+        try! JSONSerialization.jsonObject(with: jsonSample.data(using: .utf8)!)
     }
 
     override func spec() {
         describe("SPJson") {
             it("parses all primitive types of data") {
                 let spJson = try! SPJson(self.json)
-                expect(spJson["string"]?.stringValue).to(equal("hello there"))
-                expect(spJson["fake int"]?.stringValue).to(equal("1"))
-                expect(spJson["double"]?.doubleValue).to(equal(1.01))
-                expect(spJson["bool"]?.boolValue).to(beTrue())
-                expect(spJson["obj"]?.objectValue?["foo"]?.stringValue).to(equal("bar"))
-                expect(spJson["arr"]?.arrayValue?[0].intValue).to(equal(1))
-                expect(spJson["arr"]?.arrayValue?[1].stringValue).to(equal("2"))
+                expect(spJson["string"]?.stringValue) == "hello there"
+                expect(spJson["fake int"]?.stringValue) == "1"
+                expect(spJson["double"]?.doubleValue) == 1.01
+                expect(spJson["bool"]?.boolValue) == true
+                expect(spJson["obj"]?.objectValue?["foo"]?.stringValue) == "bar"
+                expect(spJson["arr"]?.arrayValue?[0].intValue) == 1
+                expect(spJson["arr"]?.arrayValue?[1].stringValue) == "2"
                 expect(spJson["arr"]?.arrayValue?[2].nullValue).to(beNil())
                 expect(spJson["null"]?.nullValue).to(beNil())
             }
@@ -51,13 +51,13 @@ class SPJsonSpec: QuickSpec {
                 let spJson = try! SPJson(self.json)
                 let encoded = try! JSONEncoder().encodeResult(spJson).get()
                 let decoded = try! JSONDecoder().decode(SPJson.self, from: encoded).get()
-                expect(decoded["string"]?.stringValue).to(equal("hello there"))
-                expect(decoded["fake int"]?.stringValue).to(equal("1"))
-                expect(decoded["double"]?.doubleValue).to(equal(1.01))
-                expect(decoded["bool"]?.boolValue).to(beTrue())
-                expect(decoded["obj"]?.objectValue?["foo"]?.stringValue).to(equal("bar"))
-                expect(decoded["arr"]?.arrayValue?[0].intValue).to(equal(1))
-                expect(decoded["arr"]?.arrayValue?[1].stringValue).to(equal("2"))
+                expect(decoded["string"]?.stringValue) == "hello there"
+                expect(decoded["fake int"]?.stringValue) == "1"
+                expect(decoded["double"]?.doubleValue) == 1.01
+                expect(decoded["bool"]?.boolValue) == true
+                expect(decoded["obj"]?.objectValue?["foo"]?.stringValue) == "bar"
+                expect(decoded["arr"]?.arrayValue?[0].intValue) == 1
+                expect(decoded["arr"]?.arrayValue?[1].stringValue) == "2"
                 expect(decoded["arr"]?.arrayValue?[2].nullValue).to(beNil())
                 expect(decoded["null"]?.nullValue).to(beNil())
             }

--- a/Example/ConsentViewController_ExampleTests/SPMessageLanguageSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPMessageLanguageSpec.swift
@@ -7,210 +7,209 @@
 //
 // swiftlint:disable function_body_length
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class SPMessageLanguageSpec: QuickSpec {
     override func spec() {
-
         describe("SPMessageLanguage") {
             context("BrowserDefault") {
                 it("has the raw value language code empty") {
-                    expect(SPMessageLanguage.BrowserDefault.rawValue).to(equal(""))
+                    expect(SPMessageLanguage.BrowserDefault.rawValue) == ""
                 }
             }
 
             context("English") {
                 it("has the raw value language code is EN") {
-                    expect(SPMessageLanguage.English.rawValue).to(equal("EN"))
+                    expect(SPMessageLanguage.English.rawValue) == "EN"
                 }
             }
 
             context("Bulgarian") {
                 it("has the raw value language code is BG") {
-                    expect(SPMessageLanguage.Bulgarian.rawValue).to(equal("BG"))
+                    expect(SPMessageLanguage.Bulgarian.rawValue) == "BG"
                 }
             }
 
             context("Catalan") {
                 it("has the raw value language code is CA") {
-                    expect(SPMessageLanguage.Catalan.rawValue).to(equal("CA"))
+                    expect(SPMessageLanguage.Catalan.rawValue) == "CA"
                 }
             }
 
             context("Chinese") {
                 it("has the raw value language code is ZH") {
-                    expect(SPMessageLanguage.Chinese.rawValue).to(equal("ZH"))
+                    expect(SPMessageLanguage.Chinese.rawValue) == "ZH"
                 }
             }
 
             context("Croatian") {
                 it("has the raw value language code is HR") {
-                    expect(SPMessageLanguage.Croatian.rawValue).to(equal("HR"))
+                    expect(SPMessageLanguage.Croatian.rawValue) == "HR"
                 }
             }
 
             context("Czech") {
                 it("has the raw value language code is CS") {
-                    expect(SPMessageLanguage.Czech.rawValue).to(equal("CS"))
+                    expect(SPMessageLanguage.Czech.rawValue) == "CS"
                 }
             }
 
             context("Danish") {
                 it("has the raw value language code is DA") {
-                    expect(SPMessageLanguage.Danish.rawValue).to(equal("DA"))
+                    expect(SPMessageLanguage.Danish.rawValue) == "DA"
                 }
             }
 
             context("Dutch") {
                 it("has the raw value language code is NL") {
-                    expect(SPMessageLanguage.Dutch.rawValue).to(equal("NL"))
+                    expect(SPMessageLanguage.Dutch.rawValue) == "NL"
                 }
             }
 
             context("Estonian") {
                 it("has the raw value language code is ET") {
-                    expect(SPMessageLanguage.Estonian.rawValue).to(equal("ET"))
+                    expect(SPMessageLanguage.Estonian.rawValue) == "ET"
                 }
             }
 
             context("Finnish") {
                 it("has the raw value language code is FI") {
-                    expect(SPMessageLanguage.Finnish.rawValue).to(equal("FI"))
+                    expect(SPMessageLanguage.Finnish.rawValue) == "FI"
                 }
             }
 
             context("French") {
                 it("has the raw value language code is FR") {
-                    expect(SPMessageLanguage.French.rawValue).to(equal("FR"))
+                    expect(SPMessageLanguage.French.rawValue) == "FR"
                 }
             }
 
             context("Gaelic") {
                 it("has the raw value language code is GD") {
-                    expect(SPMessageLanguage.Gaelic.rawValue).to(equal("GD"))
+                    expect(SPMessageLanguage.Gaelic.rawValue) == "GD"
                 }
             }
 
             context("German") {
                 it("has the raw value language code is DE") {
-                    expect(SPMessageLanguage.German.rawValue).to(equal("DE"))
+                    expect(SPMessageLanguage.German.rawValue) == "DE"
                 }
             }
 
             context("Greek") {
                 it("has the raw value language code is EL") {
-                    expect(SPMessageLanguage.Greek.rawValue).to(equal("EL"))
+                    expect(SPMessageLanguage.Greek.rawValue) == "EL"
                 }
             }
 
             context("Hungarian") {
                 it("has the raw value language code is HU") {
-                    expect(SPMessageLanguage.Hungarian.rawValue).to(equal("HU"))
+                    expect(SPMessageLanguage.Hungarian.rawValue) == "HU"
                 }
             }
 
             context("Icelandic") {
                 it("has the raw value language code is IS") {
-                    expect(SPMessageLanguage.Icelandic.rawValue).to(equal("IS"))
+                    expect(SPMessageLanguage.Icelandic.rawValue) == "IS"
                 }
             }
 
             context("Italian") {
                 it("has the raw value language code is IT") {
-                    expect(SPMessageLanguage.Italian.rawValue).to(equal("IT"))
+                    expect(SPMessageLanguage.Italian.rawValue) == "IT"
                 }
             }
 
             context("Japanese") {
                 it("has the raw value language code is JA") {
-                    expect(SPMessageLanguage.Japanese.rawValue).to(equal("JA"))
+                    expect(SPMessageLanguage.Japanese.rawValue) == "JA"
                 }
             }
 
             context("Latvian") {
                 it("has the raw value language code is LV") {
-                    expect(SPMessageLanguage.Latvian.rawValue).to(equal("LV"))
+                    expect(SPMessageLanguage.Latvian.rawValue) == "LV"
                 }
             }
 
             context("Lithuanian") {
                 it("has the raw value language code is LT") {
-                    expect(SPMessageLanguage.Lithuanian.rawValue).to(equal("LT"))
+                    expect(SPMessageLanguage.Lithuanian.rawValue) == "LT"
                 }
             }
 
             context("Norwegian") {
                 it("has the raw value language code is NO") {
-                    expect(SPMessageLanguage.Norwegian.rawValue).to(equal("NO"))
+                    expect(SPMessageLanguage.Norwegian.rawValue) == "NO"
                 }
             }
 
             context("Polish") {
                 it("has the raw value language code is PL") {
-                    expect(SPMessageLanguage.Polish.rawValue).to(equal("PL"))
+                    expect(SPMessageLanguage.Polish.rawValue) == "PL"
                 }
             }
 
             context("Portuguese") {
                 it("has the raw value language code is PT") {
-                    expect(SPMessageLanguage.Portuguese.rawValue).to(equal("PT"))
+                    expect(SPMessageLanguage.Portuguese.rawValue) == "PT"
                 }
             }
 
             context("Romanian") {
                 it("has the raw value language code is RO") {
-                    expect(SPMessageLanguage.Romanian.rawValue).to(equal("RO"))
+                    expect(SPMessageLanguage.Romanian.rawValue) == "RO"
                 }
             }
 
             context("Russian") {
                 it("has the raw value language code is RU") {
-                    expect(SPMessageLanguage.Russian.rawValue).to(equal("RU"))
+                    expect(SPMessageLanguage.Russian.rawValue) == "RU"
                 }
             }
 
             context("Serbian_Cyrillic") {
                 it("has the raw value language code is SR-CYRL") {
-                    expect(SPMessageLanguage.Serbian_Cyrillic.rawValue).to(equal("SR-CYRL"))
+                    expect(SPMessageLanguage.Serbian_Cyrillic.rawValue) == "SR-CYRL"
                 }
             }
 
             context("Serbian_Latin") {
                 it("has the raw value language code is SR-LATN") {
-                    expect(SPMessageLanguage.Serbian_Latin.rawValue).to(equal("SR-LATN"))
+                    expect(SPMessageLanguage.Serbian_Latin.rawValue) == "SR-LATN"
                 }
             }
 
             context("Slovakian") {
                 it("has the raw value language code is SK") {
-                    expect(SPMessageLanguage.Slovakian.rawValue).to(equal("SK"))
+                    expect(SPMessageLanguage.Slovakian.rawValue) == "SK"
                 }
             }
 
             context("Slovenian") {
                 it("has the raw value language code is SL") {
-                    expect(SPMessageLanguage.Slovenian.rawValue).to(equal("SL"))
+                    expect(SPMessageLanguage.Slovenian.rawValue) == "SL"
                 }
             }
 
             context("Spanish") {
                 it("has the raw value language code is ES") {
-                    expect(SPMessageLanguage.Spanish.rawValue).to(equal("ES"))
+                    expect(SPMessageLanguage.Spanish.rawValue) == "ES"
                 }
             }
 
             context("Swedish") {
                 it("has the raw value language code is SV") {
-                    expect(SPMessageLanguage.Swedish.rawValue).to(equal("SV"))
+                    expect(SPMessageLanguage.Swedish.rawValue) == "SV"
                 }
             }
 
             context("Turkish") {
                 it("has the raw value language code is TR") {
-                    expect(SPMessageLanguage.Turkish.rawValue).to(equal("TR"))
+                    expect(SPMessageLanguage.Turkish.rawValue) == "TR"
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SPNativeMessageViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPNativeMessageViewControllerSpec.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 /// swiftlint:disable function_body_length
 

--- a/Example/ConsentViewController_ExampleTests/SPPrivacyManagerTabSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPPrivacyManagerTabSpec.swift
@@ -6,36 +6,35 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
 
 class SPPrivacyManagerTabSpec: QuickSpec {
     override func spec() {
-
         describe("SPPrivacyManagerTab") {
             context("Default") {
                 it("has the empty raw value") {
-                    expect(SPPrivacyManagerTab.Default.rawValue).to(equal(""))
+                    expect(SPPrivacyManagerTab.Default.rawValue) == ""
                 }
             }
 
             context("Purposes") {
                 it("has the raw value 'purposes'") {
-                    expect(SPPrivacyManagerTab.Purposes.rawValue).to(equal("purposes"))
+                    expect(SPPrivacyManagerTab.Purposes.rawValue) == "purposes"
                 }
             }
 
             context("Vendors") {
                 it("has the raw value 'vendors'") {
-                    expect(SPPrivacyManagerTab.Vendors.rawValue).to(equal("vendors"))
+                    expect(SPPrivacyManagerTab.Vendors.rawValue) == "vendors"
                 }
             }
 
             context("Features") {
                 it("has the raw value 'features'") {
-                    expect(SPPrivacyManagerTab.Features.rawValue).to(equal("features"))
+                    expect(SPPrivacyManagerTab.Features.rawValue) == "features"
                 }
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SPPropertyNameSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPPropertyNameSpec.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
 
 // swiftlint:disable force_try
 class SPPropertyNameSpec: QuickSpec {
@@ -18,19 +18,19 @@ class SPPropertyNameSpec: QuickSpec {
         it("http:// in property are not affected") {
             let property = "http://any"
             let spProperty = try! SPPropertyName(property)
-            expect(spProperty.rawValue).to(equal(property))
+            expect(spProperty.rawValue) == property
         }
 
         it("https:// in property are not affected") {
             let property = "https://any"
             let spProperty = try! SPPropertyName(property)
-            expect(spProperty.rawValue).to(equal(property))
+            expect(spProperty.rawValue) == property
         }
 
         it("https:// prefix is added to property name if not present") {
             let property = "any"
             let spProperty = try! SPPropertyName(property)
-            expect(spProperty.rawValue).to(equal("https://any"))
+            expect(spProperty.rawValue) == "https://any"
         }
     }
 }

--- a/Example/NativeMessageExample/AppDelegate.swift
+++ b/Example/NativeMessageExample/AppDelegate.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import UIKit
+// swiftlint:disable line_length
+
 import ConsentViewController
+import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -21,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         if let scheme = url.scheme,
            scheme.localizedCaseInsensitiveCompare("exampleapp") == .orderedSame,
            let host = url.host, host.localizedCaseInsensitiveCompare("network") == .orderedSame {

--- a/Example/NativeMessageExample/NativeMessageViewController.swift
+++ b/Example/NativeMessageExample/NativeMessageViewController.swift
@@ -6,27 +6,11 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import UIKit
-import Foundation
 import ConsentViewController
+import Foundation
+import UIKit
 
 @objcMembers public class NativeMessageViewController: UIViewController {
-    @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var descriptionTextView: UITextView!
-    @IBOutlet weak var showOptionsButton: UIButton!
-    @IBOutlet weak var rejectButton: UIButton!
-    @IBOutlet weak var acceptButton: UIButton!
-
-    @IBAction func onShowOptionsTap(_ sender: Any) {
-        onAction(SPAction(type: .ShowPrivacyManager, campaignType: message.campaignType), from: self)
-    }
-    @IBAction func onRejectTap(_ sender: Any) {
-        onAction(SPAction(type: .RejectAll, campaignType: message.campaignType), from: self)
-    }
-    @IBAction func onAcceptTap(_ sender: Any) {
-        onAction(SPAction(type: .AcceptAll, campaignType: message.campaignType), from: self)
-    }
-
     /// Holds the contents of the message. Title, body, actions, etc.
     let message: SPNativeMessage
 
@@ -37,6 +21,12 @@ import ConsentViewController
     /// Even though the native message only uses native components, the Privacy Manager is only available in a web form
     /// That's why we need to use the `SPConsentManager`, so we can display the PM whenever necessary
     var consentManager: SPConsentManager!
+
+    @IBOutlet var titleLabel: UILabel!
+    @IBOutlet var descriptionTextView: UITextView!
+    @IBOutlet var showOptionsButton: UIButton!
+    @IBOutlet var rejectButton: UIButton!
+    @IBOutlet var acceptButton: UIButton!
 
     public init(
         accountId: Int,
@@ -51,13 +41,14 @@ import ConsentViewController
         modalPresentationStyle = .overFullScreen
         consentManager = SPConsentManager(
             accountId: accountId,
-            propertyId: 21944,
+            propertyId: 21_944,
             propertyName: propertyName,
             campaigns: campaigns,
             delegate: self
         )
     }
 
+    @available(*, unavailable)
     public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -69,6 +60,16 @@ import ConsentViewController
         loadOrHideActionButton(actionType: .AcceptAll, button: acceptButton)
         loadOrHideActionButton(actionType: .RejectAll, button: rejectButton)
         loadOrHideActionButton(actionType: .ShowPrivacyManager, button: showOptionsButton)
+    }
+
+    @IBAction func onShowOptionsTap(_ sender: Any) {
+        onAction(SPAction(type: .ShowPrivacyManager, campaignType: message.campaignType), from: self)
+    }
+    @IBAction func onRejectTap(_ sender: Any) {
+        onAction(SPAction(type: .RejectAll, campaignType: message.campaignType), from: self)
+    }
+    @IBAction func onAcceptTap(_ sender: Any) {
+        onAction(SPAction(type: .AcceptAll, campaignType: message.campaignType), from: self)
     }
 }
 
@@ -84,7 +85,7 @@ extension NativeMessageViewController: SPDelegate {
     public func onAction(_ action: SPAction, from controller: UIViewController) {
         switch action.type {
         case .ShowPrivacyManager:
-            if let messageAction = message.actions.first(where: {$0.choiceType == action.type}),
+            if let messageAction = message.actions.first(where: { $0.choiceType == action.type }),
                let id = messageAction.pmId {
                 switch message.campaignType {
                     case .gdpr: consentManager.loadGDPRPrivacyManager(withId: id)
@@ -120,7 +121,7 @@ extension NativeMessageViewController: SPDelegate {
 // MARK: UI Related
 extension NativeMessageViewController {
     func loadOrHideActionButton(actionType: SPActionType, button: UIButton) {
-        if let action =  message.actions.first(where: { $0.choiceType == actionType }) {
+        if let action = message.actions.first(where: { $0.choiceType == actionType }) {
             button.setTitle(action.text, for: .normal)
             button.setTitleColor(UIColor(hexString: action.style.color), for: .normal)
             button.backgroundColor = UIColor(hexString: action.style.backgroundColor)

--- a/Example/NativeMessageExample/SpinnerExtension.swift
+++ b/Example/NativeMessageExample/SpinnerExtension.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-fileprivate var aiView: UIView?
+private var aiView: UIView?
 
 extension UIViewController {
     func showSpinner() {

--- a/Example/NativeMessageExample/SpinnerExtension.swift
+++ b/Example/NativeMessageExample/SpinnerExtension.swift
@@ -21,7 +21,7 @@ extension UIViewController {
         ai.color = .black
         aiView?.addSubview(ai)
         if aiView != nil {
-            view.addSubview(aiView!)
+            view.addSubview(aiView!) // swiftlint:disable:this force_unwrapping
         }
     }
 

--- a/Example/NativeMessageExample/SpinnerExtension.swift
+++ b/Example/NativeMessageExample/SpinnerExtension.swift
@@ -14,13 +14,15 @@ private var aiView: UIView?
 extension UIViewController {
     func showSpinner() {
         let ai = UIActivityIndicatorView(style: .gray)
-        aiView = UIView(frame: view.bounds)! // swiftlint:disable:this force_unwrapping
+        aiView = UIView(frame: view.bounds)
         aiView?.backgroundColor = UIColor(white: 0.5, alpha: 0.5)
-        ai.center = aiView.center
+        ai.center = aiView?.center ?? .zero
         ai.startAnimating()
         ai.color = .black
         aiView?.addSubview(ai)
-        view.addSubview(aiView)
+        if aiView != nil {
+            view.addSubview(aiView!)
+        }
     }
 
     func removeSpinner() {

--- a/Example/NativeMessageExample/SpinnerExtension.swift
+++ b/Example/NativeMessageExample/SpinnerExtension.swift
@@ -14,13 +14,13 @@ private var aiView: UIView?
 extension UIViewController {
     func showSpinner() {
         let ai = UIActivityIndicatorView(style: .gray)
-        aiView = UIView(frame: view.bounds)
+        aiView = UIView(frame: view.bounds)! // swiftlint:disable:this force_unwrapping
         aiView?.backgroundColor = UIColor(white: 0.5, alpha: 0.5)
-        ai.center = aiView!.center
+        ai.center = aiView.center
         ai.startAnimating()
         ai.color = .black
         aiView?.addSubview(ai)
-        view.addSubview(aiView!)
+        view.addSubview(aiView)
     }
 
     func removeSpinner() {

--- a/Example/NativeMessageExample/ViewController.swift
+++ b/Example/NativeMessageExample/ViewController.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import UIKit
-import Foundation
 import ConsentViewController
+import Foundation
+import UIKit
 
 class ViewController: UIViewController {
     var idfaStatus: SPIDFAStatus { SPIDFAStatus.current() }
@@ -20,6 +20,7 @@ class ViewController: UIViewController {
         "61767550ee493f0617946a71"  // Develop and improve products
     ]
     let accountId = 22
+    // swiftlint:disable:next force_try
     let propertyName = try! SPPropertyName("ios.native.demo")
     let campaigns = SPCampaigns(
         gdpr: SPCampaign(),
@@ -29,15 +30,30 @@ class ViewController: UIViewController {
     let gdprPMId = "566358"
     let ccpaPMId = "566360"
     var sdkStatus: SDKStatus = .notStarted
-
-    @IBOutlet weak var sdkStatusLabel: UILabel!
-    @IBOutlet weak var idfaStatusLabel: UILabel!
-    @IBOutlet weak var myVendorAcceptedLabel: UILabel!
-    @IBOutlet weak var acceptMyVendorButton: UIButton!
-    @IBOutlet weak var gdprPMButton: UIButton!
-    @IBOutlet weak var ccpaPMButton: UIButton!
-
     var messageController: NativeMessageViewController!
+
+    lazy var consentManager: SPConsentManager = { SPConsentManager(
+        accountId: accountId,
+        propertyId: 21_944,
+        propertyName: propertyName,
+        campaigns: campaigns,
+        delegate: self
+    )}()
+
+    @IBOutlet var sdkStatusLabel: UILabel!
+    @IBOutlet var idfaStatusLabel: UILabel!
+    @IBOutlet var myVendorAcceptedLabel: UILabel!
+    @IBOutlet var acceptMyVendorButton: UIButton!
+    @IBOutlet var gdprPMButton: UIButton!
+    @IBOutlet var ccpaPMButton: UIButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        sdkStatusLabel.accessibilityIdentifier = "sdkStatusLabel"
+        consentManager.loadMessage()
+        sdkStatus = .running
+        updateUI()
+    }
 
     @IBAction func onNetworkCallsTap(_ sender: Any) {
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: "wormholy_fire"), object: nil)
@@ -66,22 +82,6 @@ class ViewController: UIViewController {
                 let vendorAccepted = consents.vendorGrants[self?.myVendorId ?? ""]?.granted
                 self?.updateMyVendorUI(vendorAccepted)
             }
-    }
-
-    lazy var consentManager: SPConsentManager = { SPConsentManager(
-        accountId: accountId,
-        propertyId: 21944,
-        propertyName: propertyName,
-        campaigns: campaigns,
-        delegate: self
-    )}()
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        sdkStatusLabel.accessibilityIdentifier = "sdkStatusLabel"
-        consentManager.loadMessage()
-        sdkStatus = .running
-        updateUI()
     }
 }
 

--- a/Example/NativeMessageExampleUITests/Helpers/CustomMatchers.swift
+++ b/Example/NativeMessageExampleUITests/Helpers/CustomMatchers.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import XCTest
 import Nimble
 import Quick
+import XCTest
 
 extension DispatchTimeInterval {
     func toDouble() -> Double? {
@@ -16,12 +16,16 @@ extension DispatchTimeInterval {
         switch self {
         case .seconds(let value):
             result = Double(value)
+
         case .milliseconds(let value):
-            result = Double(value)*0.001
+            result = Double(value) * 0.001
+
         case .microseconds(let value):
-            result = Double(value)*0.000001
+            result = Double(value) * 0.000_001
+
         case .nanoseconds(let value):
-            result = Double(value)*0.000000001
+            result = Double(value) * 0.000_000_001
+
         case .never:
             result = nil
         @unknown default:
@@ -33,7 +37,7 @@ extension DispatchTimeInterval {
 
 /// A matcher that checks if a `XCUIElement` contains the given text
 public func containText(_ text: String) -> Predicate<XCUIElement> {
-    return Predicate.simple("contain text") { actualExpression in
+    Predicate.simple("contain text") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.label.contains(text))
     }
@@ -42,7 +46,7 @@ public func containText(_ text: String) -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
 /// a certain amount of time. 20 seconds by default
 public func showUp() -> Predicate<XCUIElement> {
-    return Predicate.simple("show up") { actualExpression in
+    Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.waitForExistence(timeout: Nimble.AsyncDefaults.timeout.toDouble() ?? 20.0))
     }
@@ -51,7 +55,7 @@ public func showUp() -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
 /// a certain amount of time.
 public func showUp(in timeout: TimeInterval) -> Predicate<XCUIElement> {
-    return Predicate.simple("show up") { actualExpression in
+    Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.waitForExistence(timeout: timeout))
     }
@@ -60,7 +64,7 @@ public func showUp(in timeout: TimeInterval) -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement no longer exists. Due to its async nature, it should
 /// be used together with `.toEventually`.
 public func disappear() -> Predicate<XCUIElement> {
-    return Predicate.simple("disappear") { actualExpression in
+    Predicate.simple("disappear") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         QuickSpec.current.expectation(for: NSPredicate(format: "exists == FALSE"), evaluatedWith: actual, handler: nil)
         QuickSpec.current.waitForExpectations(timeout: Double(Nimble.AsyncDefaults.timeout.toDouble() ?? 20.0))

--- a/Example/NativeMessageExampleUITests/Helpers/NativeExampleApp.swift
+++ b/Example/NativeMessageExampleUITests/Helpers/NativeExampleApp.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import XCTest
 import Nimble
+import XCTest
 
 protocol App {
     func launch()
@@ -37,7 +37,7 @@ class FirstLayerMessage: XCUIApplication {
 }
 
 class NativeExampleApp: XCUIApplication {
-    class CCPAPrivacyManager:XCUIApplication {
+    class CCPAPrivacyManager: XCUIApplication {
         private var container: XCUIElement {
             webViews.containing(NSPredicate(format: "label CONTAINS[cd] 'CCPA PM'")).firstMatch
         }
@@ -45,12 +45,12 @@ class NativeExampleApp: XCUIApplication {
         var messageTitle: XCUIElement {
             container
         }
-        
+
         var acceptAllButton: XCUIElement {
             container.buttons["Accept All"].firstMatch
         }
     }
-    
+
     class GDPRPrivacyManager: XCUIApplication {
         private var container: XCUIElement {
             webViews.containing(NSPredicate(format: "label CONTAINS[cd] 'GDPR Privacy Manager'")).firstMatch
@@ -126,10 +126,10 @@ class NativeExampleApp: XCUIApplication {
     var ccpaPrivacyManagerButton: XCUIElement {
         buttons["CCPA Privacy Manager"].firstMatch
     }
-    
+
     var shouldRunAttScenario: Bool {
-        /// Unfortunately querying for `ATTrackingManager.trackingAuthorizationStatus` during tests is not reliable.
-        /// So we rely on the app's IDFA status label in order to decide if the ATT scenario should be tested or not.
+        // Unfortunately querying for `ATTrackingManager.trackingAuthorizationStatus` during tests is not reliable.
+        // So we rely on the app's IDFA status label in order to decide if the ATT scenario should be tested or not.
         staticTexts["unknown"].exists
     }
 

--- a/Example/NativeMessageExampleUITests/NativeMessageExampleUITests.swift
+++ b/Example/NativeMessageExampleUITests/NativeMessageExampleUITests.swift
@@ -57,7 +57,7 @@ class NativeMessageExampleUITests: QuickSpec {
 
     /// The SDK stores data in the UserDefaults and it takes a while until it persists its in-memory data
     func waitForUserDefaultsToPersist(_ delay: Int = 3, execute: @escaping () -> Void) {
-        waitUntil(timeout: .seconds(delay * 2)) { done in
+        waitUntil(timeout: .seconds(delay + 3)) { done in
             DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(delay)) {
                 execute()
                 done()

--- a/Example/NativeMessageExampleUITests/NativeMessageExampleUITests.swift
+++ b/Example/NativeMessageExampleUITests/NativeMessageExampleUITests.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import XCTest
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
+import XCTest
 
 class NativeMessageExampleUITests: QuickSpec {
     var app: NativeExampleApp!
@@ -42,7 +42,7 @@ class NativeMessageExampleUITests: QuickSpec {
         self.app.ccpaMessage.showOptionsButton.tap()
         expect(self.app.ccpaPM.messageTitle).toEventually(showUp())
     }
-    
+
     // We are unable to reset ATT permissions on iOS < 15 so we need to make sure
     // the ATT expectations run only once per test suite.
     func runAttScenario() {

--- a/Example/NativePMExampleApp/AppDelegate.swift
+++ b/Example/NativePMExampleApp/AppDelegate.swift
@@ -6,12 +6,13 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import UIKit
+// swiftlint:disable line_length
+
 import ConsentViewController
+import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -40,7 +41,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
-
-
 }
-

--- a/Example/NativePMExampleApp/ViewController.swift
+++ b/Example/NativePMExampleApp/ViewController.swift
@@ -6,24 +6,11 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import UIKit
 import ConsentViewController
+import UIKit
 
 class ViewController: UIViewController {
     var activityIndicator = UIActivityIndicatorView(style: .white)
-
-    @IBOutlet weak var gdprButton: UIButton!
-    @IBOutlet weak var ccpaButton: UIButton!
-    @IBOutlet weak var sdkStatusLabel: UILabel!
-
-    @IBAction func onGDPRTap(_ sender: Any) {
-        consentManager.loadGDPRPrivacyManager(withId: "713324")
-    }
-
-    @IBAction func onCCPATap(_ sender: Any) {
-        consentManager.loadCCPAPrivacyManager(withId: "753814")
-    }
-
     var sdkStatus = SDKStatus.notStarted
 
     var campaigns: SPCampaigns {
@@ -38,14 +25,19 @@ class ViewController: UIViewController {
     }
 
     lazy var consentManager: SPSDK = {
-        return SPConsentManager(
+        SPConsentManager(
             accountId: 22,
             propertyId: 21927,
+            // swiftlint:disable:next force_try
             propertyName: try! SPPropertyName("appletv.demo"),
             campaigns: campaigns,
             delegate: self
         )
     }()
+
+    @IBOutlet var gdprButton: UIButton!
+    @IBOutlet var ccpaButton: UIButton!
+    @IBOutlet var sdkStatusLabel: UILabel!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -55,6 +47,14 @@ class ViewController: UIViewController {
         updateButtons()
         consentManager.loadMessage()
         updateSdkStatus(.running)
+    }
+
+    @IBAction func onGDPRTap(_ sender: Any) {
+        consentManager.loadGDPRPrivacyManager(withId: "713324")
+    }
+
+    @IBAction func onCCPATap(_ sender: Any) {
+        consentManager.loadCCPAPrivacyManager(withId: "753814")
     }
 }
 
@@ -126,4 +126,3 @@ enum SDKStatus: String {
     case done = "(SDK done)"
     case errored = "(SDK errored)"
 }
-

--- a/Example/NativePMExampleAppUITests/CustomMatchers.swift
+++ b/Example/NativePMExampleAppUITests/CustomMatchers.swift
@@ -11,7 +11,7 @@ import Quick
 import XCTest
 
 extension TimeInterval {
-    init?(dispatchTimeInterval: DispatchTimeInterval) {
+    init(dispatchTimeInterval: DispatchTimeInterval) {
         switch dispatchTimeInterval {
         case .seconds(let value):
             self = Double(value)
@@ -26,9 +26,9 @@ extension TimeInterval {
             self = Double(value) / 1_000_000_000
 
         case .never:
-            return nil
+            self = 1_000_000_000
         @unknown default:
-            return nil
+            self = 1_000_000_000
         }
     }
 }
@@ -46,7 +46,7 @@ public func containText(_ text: String) -> Predicate<XCUIElement> {
 public func showUp() -> Predicate<XCUIElement> {
     Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-        return PredicateStatus(bool: actual.waitForExistence(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)!
+        return PredicateStatus(bool: actual.waitForExistence(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)
         ))
     }
 }
@@ -66,7 +66,7 @@ public func disappear() -> Predicate<XCUIElement> {
     Predicate.simple("disappear") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         QuickSpec.current.expectation(for: NSPredicate(format: "exists == FALSE"), evaluatedWith: actual, handler: nil)
-        QuickSpec.current.waitForExpectations(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)!
+        QuickSpec.current.waitForExpectations(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)
         )
         return PredicateStatus(bool: !actual.exists)
     }

--- a/Example/NativePMExampleAppUITests/CustomMatchers.swift
+++ b/Example/NativePMExampleAppUITests/CustomMatchers.swift
@@ -6,21 +6,25 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import XCTest
 import Nimble
 import Quick
+import XCTest
 
 extension TimeInterval {
     init?(dispatchTimeInterval: DispatchTimeInterval) {
         switch dispatchTimeInterval {
         case .seconds(let value):
             self = Double(value)
+
         case .milliseconds(let value):
             self = Double(value) / 1_000
+
         case .microseconds(let value):
             self = Double(value) / 1_000_000
+
         case .nanoseconds(let value):
             self = Double(value) / 1_000_000_000
+
         case .never:
             return nil
         @unknown default:
@@ -31,17 +35,16 @@ extension TimeInterval {
 
 /// A matcher that checks if a `XCUIElement` contains the given text
 public func containText(_ text: String) -> Predicate<XCUIElement> {
-    return Predicate.simple("contain text") { actualExpression in
+    Predicate.simple("contain text") { actualExpression in
         guard let actual = try? actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.label.contains(text))
     }
 }
 
-
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
 /// a certain amount of time. 10 seconds by default
 public func showUp() -> Predicate<XCUIElement> {
-    return Predicate.simple("show up") { actualExpression in
+    Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.waitForExistence(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)!
         ))
@@ -51,7 +54,7 @@ public func showUp() -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
 /// a certain amount of time.
 public func showUp(in timeout: TimeInterval) -> Predicate<XCUIElement> {
-    return Predicate.simple("show up") { actualExpression in
+    Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.waitForExistence(timeout: timeout))
     }
@@ -60,7 +63,7 @@ public func showUp(in timeout: TimeInterval) -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement no longer exists. Due to its async nature, it should
 /// be used together with `.toEventually`.
 public func disappear() -> Predicate<XCUIElement> {
-    return Predicate.simple("disappear") { actualExpression in
+    Predicate.simple("disappear") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         QuickSpec.current.expectation(for: NSPredicate(format: "exists == FALSE"), evaluatedWith: actual, handler: nil)
         QuickSpec.current.waitForExpectations(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)!

--- a/Example/NativePMExampleAppUITests/NativePMApp.swift
+++ b/Example/NativePMExampleAppUITests/NativePMApp.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import XCTest
 import Nimble
+import XCTest
 
 protocol App {
     func launch()
@@ -248,7 +248,7 @@ extension NativePMApp {
 extension XCUIElement {
     func remotePressUntilFocus(direction: XCUIRemote.Button) {
         var counter = 0
-        while(!self.hasFocus && counter < 10) {
+        while !self.hasFocus && counter < 10 {
             remote.press(direction)
             counter += 1
         }
@@ -256,7 +256,7 @@ extension XCUIElement {
 
     func expectToHaveFocus() {
         expect(self).toEventually(showUp())
-        expect(self.hasFocus).to(beTrue())
+        expect(self.hasFocus) == true
     }
 
     func remotePress() {

--- a/Example/NativePMExampleAppUITests/NativePMUITests.swift
+++ b/Example/NativePMExampleAppUITests/NativePMUITests.swift
@@ -6,10 +6,12 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import XCTest
-import Quick
-import Nimble
+// swiftlint:disable function_body_length
+
 @testable import NativePMExampleApp
+import Nimble
+import Quick
+import XCTest
 
 extension QuickSpec {
     var remote: XCUIRemote { XCUIRemote.shared }

--- a/Example/ObjC-ExampleAppUITests/CustomMatchers.swift
+++ b/Example/ObjC-ExampleAppUITests/CustomMatchers.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import XCTest
 import Nimble
 import Quick
+import XCTest
 
 /// A matcher that checks if a `XCUIElement` contains the given text
 public func containText(_ text: String) -> Predicate<XCUIElement> {
-    return Predicate.simple("contain text") { actualExpression in
+    Predicate.simple("contain text") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.label.contains(text))
     }
@@ -21,7 +21,7 @@ public func containText(_ text: String) -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
 /// a certain amount of time. 20 seconds by default
 public func showUp() -> Predicate<XCUIElement> {
-    return Predicate.simple("show up") { actualExpression in
+    Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.waitForExistence(timeout: 25))
     }
@@ -30,7 +30,7 @@ public func showUp() -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
 /// a certain amount of time.
 public func showUp(in timeout: TimeInterval) -> Predicate<XCUIElement> {
-    return Predicate.simple("show up") { actualExpression in
+    Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.waitForExistence(timeout: timeout))
     }
@@ -39,7 +39,7 @@ public func showUp(in timeout: TimeInterval) -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement no longer exists. Due to its async nature, it should
 /// be used together with `.toEventually`.
 public func disappear() -> Predicate<XCUIElement> {
-    return Predicate.simple("disappear") { actualExpression in
+    Predicate.simple("disappear") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         QuickSpec.current.expectation(for: NSPredicate(format: "exists == FALSE"), evaluatedWith: actual, handler: nil)
         QuickSpec.current.waitForExpectations(timeout: 20)

--- a/Example/ObjC-ExampleAppUITests/ExampleApp.swift
+++ b/Example/ObjC-ExampleAppUITests/ExampleApp.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
-import XCTest
-import Quick
 import Nimble
+import Quick
+import XCTest
 
 protocol App {
     func launch()
@@ -25,8 +25,8 @@ extension XCUIApplication: App {
             resetAuthorizationStatus(for: .userTracking)
         }
         clean ?
-        launchArguments.append("-cleanAppsData") :
-        launchArguments.removeAll { $0 == "-cleanAppsData" }
+            launchArguments.append("-cleanAppsData") :
+            launchArguments.removeAll { $0 == "-cleanAppsData" }
         launch()
     }
 }
@@ -61,8 +61,8 @@ class ExampleApp: XCUIApplication {
     let attPrePrompt = ATTPrePrompt()
 
     var shouldRunAttScenario: Bool {
-        /// Unfortunately querying for `ATTrackingManager.trackingAuthorizationStatus` during tests is not reliable.
-        /// So we rely on the app's IDFA status label in order to decide if the ATT scenario should be tested or not.
+        // Unfortunately querying for `ATTrackingManager.trackingAuthorizationStatus` during tests is not reliable.
+        // So we rely on the app's IDFA status label in order to decide if the ATT scenario should be tested or not.
         staticTexts["unknown"].exists
     }
 

--- a/Example/ObjC-ExampleAppUITests/ObjC_ExampleAppUITests.swift
+++ b/Example/ObjC-ExampleAppUITests/ObjC_ExampleAppUITests.swift
@@ -6,12 +6,12 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import XCTest
-import Quick
-import Nimble
 @testable import ConsentViewController
+import Nimble
+import Quick
+import XCTest
 
-class ObjC_ExampleAppUITests: QuickSpec {
+class ObjCExampleAppUITests: QuickSpec {
     var app: ExampleApp!
 
     override func spec() {

--- a/Example/SPGDPRExampleAppUITests/ExampleApp.swift
+++ b/Example/SPGDPRExampleAppUITests/ExampleApp.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import XCTest
 import Nimble
+import XCTest
 
 protocol App {
     func launch()
@@ -20,7 +20,7 @@ extension XCUIApplication: App {
         clean: Bool = false,
         resetAtt: Bool = false,
         args: [String: Any] = [:]
-    ){
+    ) {
         UserDefaults.standard.synchronize()
         self.terminate()
         if #available(iOS 15.0, *), resetAtt {
@@ -128,8 +128,8 @@ class ExampleApp: XCUIApplication {
     }
 
     var shouldRunAttScenario: Bool {
-        /// Unfortunately querying for `ATTrackingManager.trackingAuthorizationStatus` during tests is not reliable.
-        /// So we rely on the app's IDFA status label in order to decide if the ATT scenario should be tested or not.
+        // Unfortunately querying for `ATTrackingManager.trackingAuthorizationStatus` during tests is not reliable.
+        // So we rely on the app's IDFA status label in order to decide if the ATT scenario should be tested or not.
         staticTexts["unknown"].exists
     }
 

--- a/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
+++ b/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
@@ -6,21 +6,25 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
-import XCTest
 import Nimble
 import Quick
+import XCTest
 
 extension TimeInterval {
     init?(dispatchTimeInterval: DispatchTimeInterval) {
         switch dispatchTimeInterval {
         case .seconds(let value):
             self = Double(value)
+
         case .milliseconds(let value):
             self = Double(value) / 1_000
+
         case .microseconds(let value):
             self = Double(value) / 1_000_000
+
         case .nanoseconds(let value):
             self = Double(value) / 1_000_000_000
+
         case .never:
             return nil
         @unknown default:
@@ -31,7 +35,7 @@ extension TimeInterval {
 
 /// A matcher that checks if a `XCUIElement` contains the given text
 public func containText(_ text: String) -> Predicate<XCUIElement> {
-    return Predicate.simple("contain text") { actualExpression in
+    Predicate.simple("contain text") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.label.contains(text))
     }
@@ -40,7 +44,7 @@ public func containText(_ text: String) -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
 /// a certain amount of time. 10 seconds by default
 public func showUp() -> Predicate<XCUIElement> {
-    return Predicate.simple("show up") { actualExpression in
+    Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.waitForExistence(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)!
         ))
@@ -50,7 +54,7 @@ public func showUp() -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement shows up after
 /// a certain amount of time.
 public func showUp(in timeout: TimeInterval) -> Predicate<XCUIElement> {
-    return Predicate.simple("show up") { actualExpression in
+    Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.waitForExistence(timeout: timeout))
     }
@@ -59,7 +63,7 @@ public func showUp(in timeout: TimeInterval) -> Predicate<XCUIElement> {
 /// A Nimble matcher that succeeds when an XCUIElement no longer exists. Due to its async nature, it should
 /// be used together with `.toEventually`.
 public func disappear() -> Predicate<XCUIElement> {
-    return Predicate.simple("disappear") { actualExpression in
+    Predicate.simple("disappear") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         QuickSpec.current.expectation(for: NSPredicate(format: "exists == FALSE"), evaluatedWith: actual)
         QuickSpec.current.waitForExpectations(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)!
@@ -70,7 +74,7 @@ public func disappear() -> Predicate<XCUIElement> {
 
 /// A Nimble matcher that succeeds when an XCUIElement is enable
 public func beEnabled() -> Predicate<XCUIElement> {
-    return Predicate.simple("beEnabled") { actualExpression in
+    Predicate.simple("beEnabled") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: actual.isEnabled)
     }
@@ -78,7 +82,7 @@ public func beEnabled() -> Predicate<XCUIElement> {
 
 /// A Nimble matcher that succeeds when an XCUIElement is disabled
 public func beDisabled() -> Predicate<XCUIElement> {
-    return Predicate.simple("beDisabled") { actualExpression in
+    Predicate.simple("beDisabled") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         return PredicateStatus(bool: !actual.isEnabled)
     }

--- a/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
+++ b/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
@@ -11,7 +11,7 @@ import Quick
 import XCTest
 
 extension TimeInterval {
-    init?(dispatchTimeInterval: DispatchTimeInterval) {
+    init(dispatchTimeInterval: DispatchTimeInterval) {
         switch dispatchTimeInterval {
         case .seconds(let value):
             self = Double(value)
@@ -26,9 +26,9 @@ extension TimeInterval {
             self = Double(value) / 1_000_000_000
 
         case .never:
-            return nil
+            self = 1_000_000_000
         @unknown default:
-            return nil
+            self = 1_000_000_000
         }
     }
 }
@@ -46,6 +46,7 @@ public func containText(_ text: String) -> Predicate<XCUIElement> {
 public func showUp() -> Predicate<XCUIElement> {
     Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
+        // swiftlint:disable:next force_unwrapping
         return PredicateStatus(bool: actual.waitForExistence(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)!
         ))
     }
@@ -66,7 +67,7 @@ public func disappear() -> Predicate<XCUIElement> {
     Predicate.simple("disappear") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
         QuickSpec.current.expectation(for: NSPredicate(format: "exists == FALSE"), evaluatedWith: actual)
-        QuickSpec.current.waitForExpectations(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)!
+        QuickSpec.current.waitForExpectations(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)
         )
         return PredicateStatus(bool: !actual.exists)
     }

--- a/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
+++ b/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
@@ -46,8 +46,7 @@ public func containText(_ text: String) -> Predicate<XCUIElement> {
 public func showUp() -> Predicate<XCUIElement> {
     Predicate.simple("show up") { actualExpression in
         guard let actual = try actualExpression.evaluate() else { return .fail }
-        // swiftlint:disable:next force_unwrapping
-        return PredicateStatus(bool: actual.waitForExistence(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)!
+        return PredicateStatus(bool: actual.waitForExistence(timeout: TimeInterval(dispatchTimeInterval: Nimble.AsyncDefaults.timeout)
         ))
     }
 }

--- a/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
+++ b/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
@@ -52,8 +52,8 @@ class SPGDPRExampleAppUITests: QuickSpec {
     }
 
     /// The SDK stores data in the UserDefaults and it takes a while until it persists its in-memory data
-    func waitForUserDefaultsToPersist(_ delay: Int = 3, execute: @escaping () -> Void) {
-        waitUntil(timeout: .seconds(delay * 2)) { done in
+    func waitForUserDefaultsToPersist(_ delay: Int = 10, execute: @escaping () -> Void) {
+        waitUntil(timeout: .seconds(delay + 5)) { done in
             DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(delay)) {
                 execute()
                 done()

--- a/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
+++ b/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
@@ -6,10 +6,12 @@
 //  Copyright © 2020 All rights reserved.
 //
 
-import XCTest
-import Quick
-import Nimble
+// swiftlint:disable function_body_length
+
 @testable import ConsentViewController
+import Nimble
+import Quick
+import XCTest
 
 class SPGDPRExampleAppUITests: QuickSpec {
     var app: ExampleApp!
@@ -140,4 +142,3 @@ class SPGDPRExampleAppUITests: QuickSpec {
         }
     }
 }
-

--- a/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
+++ b/Example/SPGDPRExampleAppUITests/SPGDPRExampleAppUITests.swift
@@ -135,7 +135,8 @@ class SPGDPRExampleAppUITests: QuickSpec {
         }
 
         it("Shows a translated message") {
-            self.app.relaunch(clean: true, resetAtt: true, args: [
+            self.app.relaunch(clean: true, resetAtt: false, args: [
+                "att": false,
                 "language": SPMessageLanguage.Spanish.rawValue
             ])
             expect(self.app.gdprMessage.spanishMessageTitle).toEventually(showUp())

--- a/Example/SPMBuild/AppDelegate.swift
+++ b/Example/SPMBuild/AppDelegate.swift
@@ -10,9 +10,6 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
@@ -31,7 +28,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
-

--- a/Example/SPMBuild/SceneDelegate.swift
+++ b/Example/SPMBuild/SceneDelegate.swift
@@ -8,10 +8,10 @@
 
 import UIKit
 
+// swiftlint:disable unused_optional_binding
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
     var window: UIWindow?
-
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -47,7 +47,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
 }
-

--- a/Example/SPMBuild/ViewController.swift
+++ b/Example/SPMBuild/ViewController.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 CocoaPods. All rights reserved.
 //
 
-import UIKit
 import ConsentViewController
+import UIKit
 
 /// This App exists solely to make sure our SPM package is building
 
@@ -15,6 +15,7 @@ class ViewController: UIViewController {
     let consentManager = SPConsentManager(
         accountId: 0,
         propertyId: 0,
+        // swiftlint:disable:next force_try
         propertyName: try! SPPropertyName("any"),
         campaigns: SPCampaigns(gdpr: SPCampaign()),
         delegate: nil
@@ -25,4 +26,3 @@ class ViewController: UIViewController {
         consentManager.loadMessage()
     }
 }
-

--- a/Example/SourcePointMetaApp/Layers/ExpandableHeaderView/ExpandableHeaderView.swift
+++ b/Example/SourcePointMetaApp/Layers/ExpandableHeaderView/ExpandableHeaderView.swift
@@ -20,6 +20,7 @@ class ExpandableHeaderView: UITableViewHeaderFooterView {
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(selectHeaderAction)))
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }


### PR DESCRIPTION
- [x] Fix linting config files to point out forced unwrapping
- [x] Enable as many linting rules as possible
- [x] Disable swiftlint on example apps, specs and wheerever is not crucial to the SDK
- [x] [DIA-1842](https://sourcepoint.atlassian.net/browse/DIA-1842) Make sure `SPDateCreated` has no forced unwraps and default to `.now()` if its value is missing on API responses. Fixes #416 
- [x] Remove as many forced unwraps as possible from the SDK code

[DIA-1842]: https://sourcepoint.atlassian.net/browse/DIA-1842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ