### PR TITLE
Make better use of `SPLogger`

### DIFF
--- a/ConsentViewController/Classes/OSLogger.swift
+++ b/ConsentViewController/Classes/OSLogger.swift
@@ -23,8 +23,15 @@ struct OSLogger: SPLogger {
     static let category = "SPSDK"
     static var standard: OSLogger { OSLogger() }
 
+    private init () {}
+
     let consentLog = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: OSLogger.category)
-    let level = SPLogLevel(rawValue: Bundle.framework.object(forInfoDictionaryKey: "SPLogLevel") as? String ?? "debug")
+    
+    let level = SPLogLevel(rawValue:
+        Bundle.main.object(forInfoDictionaryKey: "SPLogLevel") as? String ??
+        Bundle.framework.object(forInfoDictionaryKey: "SPLogLevel") as? String ??
+        "prod"
+    )
 
     func log(_ message: String) {
         if level == .debug {

--- a/ConsentViewController/Classes/OSLogger.swift
+++ b/ConsentViewController/Classes/OSLogger.swift
@@ -14,34 +14,37 @@ protocol SPLogger {
     func error(_ message: String)
 }
 
+enum SPLogLevel: String {
+    case debug
+    case prod
+}
+
 struct OSLogger: SPLogger {
     static let category = "SPSDK"
+    static var standard: OSLogger { OSLogger() }
 
-    var consentLog: OSLog? {
-        if #available(iOS 10.0, *) {
-            return OSLog(subsystem: Bundle.main.bundleIdentifier!, category: OSLogger.category)
-        } else {
-            return nil
-        }
-    }
+    let consentLog = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: OSLogger.category)
+    let level = SPLogLevel(rawValue: Bundle.framework.object(forInfoDictionaryKey: "SPLogLevel") as? String ?? "debug")
 
     func log(_ message: String) {
-        osLog("%s", message)
+        if level == .debug {
+            osLog("%s", message)
+        }
     }
 
     func debug(_ message: String) {
-        osLog("%s", message)
+        if level == .debug {
+            osLog("%s", message)
+        }
     }
 
     func error(_ message: String) {
-        osLog("%s", message)
+        if level == .debug {
+            osLog("%s", message)
+        }
     }
 
     private func osLog(_ message: StaticString, _ args: CVarArg) {
-        if #available(iOS 10, *), let consentLog = consentLog {
-            os_log(message, log: consentLog, type: .default, args)
-        } else {
-            print(message, args)
-        }
+        os_log(message, log: consentLog, type: .default, args)
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
@@ -48,8 +48,6 @@ class SimpleClient: HttpClient {
     let session: SPURLSession
     let dispatchQueue: SPDispatchQueue
 
-    let logCalls = false
-
     init(connectivityManager: Connectivity, logger: SPLogger, urlSession: SPURLSession, dispatchQueue: SPDispatchQueue) {
         self.connectivityManager = connectivityManager
         self.logger = logger
@@ -62,14 +60,14 @@ class SimpleClient: HttpClient {
         config.timeoutIntervalForResource = timeout
         self.init(
             connectivityManager: ConnectivityManager(),
-            logger: OSLogger(),
+            logger: OSLogger.standard,
             urlSession: URLSession(configuration: config),
             dispatchQueue: DispatchQueue.main
         )
     }
 
     func logRequest(_ type: String, _ request: URLRequest, _ body: Data?) {
-        if logCalls, let method = request.httpMethod, let url = request.url {
+        if let method = request.httpMethod, let url = request.url {
             logger.debug("\(type) \(method) \(url)")
             if let body = body, let bodyString = String(data: body, encoding: .utf8) {
                 logger.debug(bodyString)
@@ -78,11 +76,11 @@ class SimpleClient: HttpClient {
     }
 
     func logRequest(_ request: URLRequest, _ body: Data?) {
-        logRequest("REQUEST", request, body)
+        logRequest("request -", request, body)
     }
 
     func logResponse(_ request: URLRequest, _ response: Data?) {
-        logRequest("RESPONSE", request, response)
+        logRequest("response -", request, response)
     }
 
     func request(_ urlRequest: URLRequest, _ handler: @escaping ResponseHandler) {

--- a/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
+++ b/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
@@ -182,9 +182,9 @@ import WebKit
         }
         DispatchQueue.main.async {
             OSLogger.standard.debug("RenderingApp - injecting message json")
-//            self.webview?.evaluateJavaScript("""
-//                window.SDK.loadMessage(\(jsonString));
-//            """)
+            self.webview?.evaluateJavaScript("""
+                window.SDK.loadMessage(\(jsonString));
+            """)
         }
     }
 

--- a/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
+++ b/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
@@ -83,11 +83,7 @@ import WebKit
     // swiftlint:disable:next line_length
     public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         guard let url = navigationAction.request.url else { return nil }
-        if #available(iOS 10.0, *) {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-        } else {
-            UIApplication.shared.openURL(url)
-        }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
         return nil
     }
 
@@ -147,10 +143,12 @@ import WebKit
     }
 
     override func loadMessage() {
+        OSLogger.standard.debug("RenderingApp - loading: \(url.absoluteString)")
         webview?.load(URLRequest(url: url, timeoutInterval: timeout))
     }
 
     override func loadPrivacyManager(url: URL) {
+        OSLogger.standard.debug("RenderingApp - loading: \(url.absoluteString)")
         webview?.load(URLRequest(url: url, timeoutInterval: timeout))
     }
 
@@ -183,9 +181,10 @@ import WebKit
             return
         }
         DispatchQueue.main.async {
-            self.webview?.evaluateJavaScript("""
-                window.SDK.loadMessage(\(jsonString));
-            """)
+            OSLogger.standard.debug("RenderingApp - injecting message json")
+//            self.webview?.evaluateJavaScript("""
+//                window.SDK.loadMessage(\(jsonString));
+//            """)
         }
     }
 
@@ -195,6 +194,7 @@ import WebKit
             let eventName = RenderingAppEvents(rawValue: messageBody["name"]?.stringValue ?? ""),
             let body = messageBody["body"]
         {
+            OSLogger.standard.debug("RenderingApp - event: \(eventName.rawValue), payload: \(body)")
             switch eventName {
             case .readyForPreload: handleMessagePreload()
             case .onMessageReady: messageUIDelegate?.loaded(self)
@@ -219,7 +219,7 @@ import WebKit
             case .unknown: break
             }
         } else {
-            print("[RenderingApp] UnknownBody(\(message.body))")
+            OSLogger.standard.error("RenderingApp - UnknownBody(\(message.body))")
         }
     }
 }

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		82E1E3F125D19D0200E96E12 /* MessageResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E1E3F025D19D0200E96E12 /* MessageResponseSpec.swift */; };
 		82E3D60528C64528004B1189 /* MessagesResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E3D60428C64527004B1189 /* MessagesResponseSpec.swift */; };
 		82E3D60728C8F39B004B1189 /* CustomMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E3D60628C8F39B004B1189 /* CustomMatchers.swift */; };
+		82E5DBBC29E5A4C30083A054 /* SPLoggerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E5DBBB29E5A4C30083A054 /* SPLoggerMock.swift */; };
 		82EA4E302491019900DC01C9 /* HttpMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E2F2491019900DC01C9 /* HttpMock.swift */; };
 		82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */; };
 		82EA4E342491324400DC01C9 /* GDPRLocalStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */; };
@@ -454,6 +455,7 @@
 		82E1E3F025D19D0200E96E12 /* MessageResponseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageResponseSpec.swift; sourceTree = "<group>"; };
 		82E3D60428C64527004B1189 /* MessagesResponseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesResponseSpec.swift; sourceTree = "<group>"; };
 		82E3D60628C8F39B004B1189 /* CustomMatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomMatchers.swift; path = Helpers/CustomMatchers.swift; sourceTree = "<group>"; };
+		82E5DBBB29E5A4C30083A054 /* SPLoggerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPLoggerMock.swift; sourceTree = "<group>"; };
 		82EA4E2F2491019900DC01C9 /* HttpMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HttpMock.swift; path = Helpers/HttpMock.swift; sourceTree = "<group>"; };
 		82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SourcePointClientMock.swift; path = Helpers/SourcePointClientMock.swift; sourceTree = "<group>"; };
 		82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GDPRLocalStorageMock.swift; path = Helpers/GDPRLocalStorageMock.swift; sourceTree = "<group>"; };
@@ -1268,6 +1270,7 @@
 				82BB0E6E28BF4BAB006FBB60 /* QueryParamEncodableSpec.swift */,
 				82E3D60428C64527004B1189 /* MessagesResponseSpec.swift */,
 				82C4935F28F17A2D00898E7A /* CampaignSpec.swift */,
+				82E5DBBB29E5A4C30083A054 /* SPLoggerMock.swift */,
 			);
 			path = SourcePointClient;
 			sourceTree = "<group>";
@@ -2665,6 +2668,7 @@
 				82EA4E342491324400DC01C9 /* GDPRLocalStorageMock.swift in Sources */,
 				6D605DF62423B96C00BB3E5F /* SPErrorSpec.swift in Sources */,
 				822E21FB255EB5CA00DA02D6 /* GDPRWebViewExtensionsSpec.swift in Sources */,
+				82E5DBBC29E5A4C30083A054 /* SPLoggerMock.swift in Sources */,
 				5687C4F227A1B11A003456E7 /* SPPropertyNameSpec.swift in Sources */,
 				82E3D60528C64528004B1189 /* MessagesResponseSpec.swift in Sources */,
 				82E1E3F125D19D0200E96E12 /* MessageResponseSpec.swift in Sources */,

--- a/Example/ConsentViewController.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/ConsentViewController.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "http://github.com/SourcePointUSA/ios-cmp-app.git",
       "state" : {
-        "revision" : "7e5a73b51e240274723fa5fd62e6edd748799f89",
-        "version" : "7.0.0"
+        "revision" : "195bd090a7480d723653768c5b7a00525ac00567",
+        "version" : "7.0.3"
       }
     }
   ],

--- a/Example/ConsentViewController/Info.plist
+++ b/Example/ConsentViewController/Info.plist
@@ -49,6 +49,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>SPLogLevel</key>
+	<string>debug</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -16,15 +16,15 @@ class ViewController: UIViewController {
     var idfaStatus: SPIDFAStatus { SPIDFAStatus.current() }
     var myVendorAccepted: VendorStatus = .Unknown
     lazy var config = { Config(fromStorageWithDefaults: Config(
-        accountId: 22,
-        propertyId: 16893,
-        propertyName: "mobile.multicampaign.demo",
+        accountId: 1112,
+        propertyId: 30107,
+        propertyName: "test.skystore.de.ios",
         gdpr: true,
-        ccpa: true,
-        att: true,
+        ccpa: false,
+        att: false,
         language: .BrowserDefault,
-        gdprPmId: "488393",
-        ccpaPmId: "509688"
+        gdprPmId: "768779",
+        ccpaPmId: ""
     ))}()
 
     lazy var consentManager: SPSDK = { SPConsentManager(

--- a/Example/ConsentViewController/ViewController.swift
+++ b/Example/ConsentViewController/ViewController.swift
@@ -16,15 +16,15 @@ class ViewController: UIViewController {
     var idfaStatus: SPIDFAStatus { SPIDFAStatus.current() }
     var myVendorAccepted: VendorStatus = .Unknown
     lazy var config = { Config(fromStorageWithDefaults: Config(
-        accountId: 1112,
-        propertyId: 30107,
-        propertyName: "test.skystore.de.ios",
+        accountId: 22,
+        propertyId: 16893,
+        propertyName: "mobile.multicampaign.demo",
         gdpr: true,
-        ccpa: false,
-        att: false,
+        ccpa: true,
+        att: true,
         language: .BrowserDefault,
-        gdprPmId: "768779",
-        ccpaPmId: ""
+        gdprPmId: "488393",
+        ccpaPmId: "509688"
     ))}()
 
     lazy var consentManager: SPSDK = { SPConsentManager(

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SPLoggerMock.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SPLoggerMock.swift
@@ -1,0 +1,18 @@
+//
+//  SPLoggerMock.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 11.04.23.
+//  Copyright © 2023 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import ConsentViewController
+
+struct SPLoggerMock: SPLogger {
+    func log(_ message: String) {}
+
+    func debug(_ message: String) {}
+
+    func error(_ message: String) {}
+}

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SimpleClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SimpleClientSpec.swift
@@ -78,7 +78,7 @@ class SimpleClientSpec: QuickSpec {
                 let session = URLSessionMock()
                 let client = SimpleClient(
                     connectivityManager: ConnectivityMock(connected: true),
-                    logger: OSLogger(),
+                    logger: SPLoggerMock(),
                     urlSession: session,
                     dispatchQueue: DispatchQueue.main
                 )
@@ -91,7 +91,7 @@ class SimpleClientSpec: QuickSpec {
                 session.configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
                 let client = SimpleClient(
                     connectivityManager: ConnectivityMock(connected: true),
-                    logger: OSLogger(),
+                    logger: SPLoggerMock(),
                     urlSession: session,
                     dispatchQueue: DispatchQueue.main
                 )
@@ -103,7 +103,7 @@ class SimpleClientSpec: QuickSpec {
                 let queue = DispatchQueueMock()
                 let client = SimpleClient(
                     connectivityManager: ConnectivityMock(connected: true),
-                    logger: OSLogger(),
+                    logger: SPLoggerMock(),
                     urlSession: URLSession.shared,
                     dispatchQueue: queue
                 )
@@ -123,7 +123,7 @@ class SimpleClientSpec: QuickSpec {
                 )
                 let client = SimpleClient(
                     connectivityManager: ConnectivityMock(connected: true),
-                    logger: OSLogger(),
+                    logger: SPLoggerMock(),
                     urlSession: session,
                     dispatchQueue: DispatchQueue.main
                 )
@@ -141,7 +141,7 @@ class SimpleClientSpec: QuickSpec {
                     )
                     let client = SimpleClient(
                         connectivityManager: ConnectivityMock(connected: true),
-                        logger: OSLogger(),
+                        logger: SPLoggerMock(),
                         urlSession: session,
                         dispatchQueue: DispatchQueueMock()
                     )
@@ -160,7 +160,7 @@ class SimpleClientSpec: QuickSpec {
                     )
                     let client = SimpleClient(
                         connectivityManager: ConnectivityMock(connected: true),
-                        logger: OSLogger(),
+                        logger: SPLoggerMock(),
                         urlSession: session,
                         dispatchQueue: DispatchQueueMock()
                     )
@@ -180,7 +180,7 @@ class SimpleClientSpec: QuickSpec {
             it("calls the completionHandler with an NoInternetConnection error") {
                 let client = SimpleClient(
                     connectivityManager: ConnectivityMock(connected: false),
-                    logger: OSLogger(),
+                    logger: SPLoggerMock(),
                     urlSession: URLSession.shared,
                     dispatchQueue: DispatchQueue.main
                 )


### PR DESCRIPTION
We now can log several events to XCode console without using `print` and without polluting our client's console by using `os_log`. 

With the new log levels, `debug` is only active on our Example app.