### PR TITLE
DIA-2065 / DIA-2120 fix state management for authenticated consent and handle pv-data response

### DIFF
--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -100,7 +100,7 @@ import UIKit
         spClient: SourcePointProtocol,
         storage: SPLocalStorage,
         spCoordinator: SPClientCoordinator,
-        deviceManager: SPDeviceManager = SPDevice()
+        deviceManager: SPDeviceManager = SPDevice.standard
     ) {
         self.propertyId = propertyId
         self.campaigns = campaigns
@@ -241,11 +241,7 @@ import UIKit
     }
 
     public func gracefullyDegradeOnError(_ error: SPError) {
-        spCoordinator.logErrorMetrics(
-            error,
-            osVersion: deviceManager.osVersion(),
-            deviceFamily: deviceManager.deviceFamily()
-        )
+        spCoordinator.logErrorMetrics(error)
         if !userData.isEqual(SPUserData()) {
             delegate?.onConsentReady?(userData: userData)
             handleSDKDone()
@@ -258,11 +254,7 @@ import UIKit
     }
 
     public func onError(_ error: SPError) {
-        spCoordinator.logErrorMetrics(
-            error,
-            osVersion: deviceManager.osVersion(),
-            deviceFamily: deviceManager.deviceFamily()
-        )
+        spCoordinator.logErrorMetrics(error)
         if cleanUserDataOnError {
             Self.clearAllData()
         }
@@ -275,11 +267,7 @@ import UIKit
             return childPmId
         }
 
-        spCoordinator.logErrorMetrics(
-            MissingChildPmIdError(usedId: fallbackId),
-            osVersion: deviceManager.osVersion(),
-            deviceFamily: deviceManager.deviceFamily()
-        )
+        spCoordinator.logErrorMetrics(MissingChildPmIdError(usedId: fallbackId))
         return fallbackId
     }
 }
@@ -513,7 +501,7 @@ extension SPConsentManager: SPMessageUIDelegate {
             SPIDFAStatus.requestAuthorisation { [weak self] status in
                 self?.spCoordinator.reportIdfaStatus(
                     status: status,
-                    osVersion: self?.deviceManager.osVersion() ?? ""
+                    osVersion: self?.deviceManager.osVersion ?? ""
                 )
                 if status == .accepted {
                     action.type = .IDFAAccepted

--- a/ConsentViewController/Classes/SPDeviceManager.swift
+++ b/ConsentViewController/Classes/SPDeviceManager.swift
@@ -9,20 +9,22 @@ import Foundation
 import UIKit
 
 protocol SPDeviceManager {
-    func osVersion () -> String
-    func deviceFamily () -> String
+    var osVersion: String { get }
+    var deviceFamily: String { get }
 }
 
 struct SPDevice: SPDeviceManager {
+    static var standard: SPDevice { SPDevice() }
+
     /// Returns the Version of the OS. E.g 1.2
     /// - SeeAlso: UIDevice.current.systemVersion
-    func osVersion() -> String {
+    var osVersion: String {
         UIDevice.current.systemVersion
     }
 
     /// Tries to get the device family from its unix. If none can be found it returns `apple-unknown`.
     /// Example: iphone-11.5
-    func deviceFamily() -> String {
+    var deviceFamily: String {
         if let simulatorModelIdentifier = ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] {
             return simulatorModelIdentifier
         }

--- a/ConsentViewController/Classes/SourcePointClient/PvDataRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/PvDataRequestResponse.swift
@@ -8,20 +8,12 @@
 import Foundation
 
 struct PvDataResponse: Decodable, Equatable {
-    struct GDPR: Decodable, Equatable {
-        struct Cookie: Decodable, Equatable {
-            let key: String
-            let value: String
-            let maxAge: Int
-            let shareRootDomain: Bool
-            let session: Bool
-        }
-
+    struct Campaign: Decodable, Equatable {
         let uuid: String
-        let cookies: [Cookie]
     }
 
-    let gdpr: GDPR?
+    let gdpr: Campaign?
+    let ccpa: Campaign?
 }
 
 struct PvDataRequestBody: Codable, Equatable {

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -156,7 +156,7 @@ protocol SourcePointProtocol {
 
 extension SourcePointProtocol {
     func pvData(_ body: PvDataRequestBody, handler: PvDataHandler? = nil) {
-        pvData(body, handler: nil)
+        pvData(body, handler: handler)
     }
 }
 

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -167,7 +167,7 @@
 		82E5DBBC29E5A4C30083A054 /* SPLoggerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E5DBBB29E5A4C30083A054 /* SPLoggerMock.swift */; };
 		82EA4E302491019900DC01C9 /* HttpMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E2F2491019900DC01C9 /* HttpMock.swift */; };
 		82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */; };
-		82EA4E342491324400DC01C9 /* GDPRLocalStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */; };
+		82EA4E342491324400DC01C9 /* LocalStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E332491324400DC01C9 /* LocalStorageMock.swift */; };
 		82EA4E362491328A00DC01C9 /* InMemoryStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */; };
 		82EA4FA42488EB7300BA48BF /* GDPRUserDefaultsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82ACF6AB2487E73C006E207A /* GDPRUserDefaultsSpec.swift */; };
 		82EA4FA62489171200BA48BF /* GDPRLocalStorageSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4FA52489171200BA48BF /* GDPRLocalStorageSpec.swift */; };
@@ -458,7 +458,7 @@
 		82E5DBBB29E5A4C30083A054 /* SPLoggerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPLoggerMock.swift; sourceTree = "<group>"; };
 		82EA4E2F2491019900DC01C9 /* HttpMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HttpMock.swift; path = Helpers/HttpMock.swift; sourceTree = "<group>"; };
 		82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SourcePointClientMock.swift; path = Helpers/SourcePointClientMock.swift; sourceTree = "<group>"; };
-		82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GDPRLocalStorageMock.swift; path = Helpers/GDPRLocalStorageMock.swift; sourceTree = "<group>"; };
+		82EA4E332491324400DC01C9 /* LocalStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LocalStorageMock.swift; path = Helpers/LocalStorageMock.swift; sourceTree = "<group>"; };
 		82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InMemoryStorageMock.swift; path = Helpers/InMemoryStorageMock.swift; sourceTree = "<group>"; };
 		82EA4FA52489171200BA48BF /* GDPRLocalStorageSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRLocalStorageSpec.swift; sourceTree = "<group>"; };
 		82F9411724A10379007D30B1 /* CustomMatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMatchers.swift; sourceTree = "<group>"; };
@@ -1325,7 +1325,7 @@
 				826D31B0249A46C40026A6B9 /* GDPRUIiDelegateMock.swift */,
 				82EA4E2F2491019900DC01C9 /* HttpMock.swift */,
 				82EA4E31249101EC00DC01C9 /* SourcePointClientMock.swift */,
-				82EA4E332491324400DC01C9 /* GDPRLocalStorageMock.swift */,
+				82EA4E332491324400DC01C9 /* LocalStorageMock.swift */,
 				82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */,
 				826D31AC2498DE340026A6B9 /* MockConsentDelegate.swift */,
 				826D31B2249A71E20026A6B9 /* ConnectivityMock.swift */,
@@ -2665,7 +2665,7 @@
 				6DA66EA3255D1A690034E11A /* SPMessageLanguageSpec.swift in Sources */,
 				82EA4E302491019900DC01C9 /* HttpMock.swift in Sources */,
 				82E3D60728C8F39B004B1189 /* CustomMatchers.swift in Sources */,
-				82EA4E342491324400DC01C9 /* GDPRLocalStorageMock.swift in Sources */,
+				82EA4E342491324400DC01C9 /* LocalStorageMock.swift in Sources */,
 				6D605DF62423B96C00BB3E5F /* SPErrorSpec.swift in Sources */,
 				822E21FB255EB5CA00DA02D6 /* GDPRWebViewExtensionsSpec.swift in Sources */,
 				82E5DBBC29E5A4C30083A054 /* SPLoggerMock.swift in Sources */,

--- a/Example/ConsentViewController_ExampleTests/Helpers/LocalStorageMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/LocalStorageMock.swift
@@ -9,7 +9,7 @@
 @testable import ConsentViewController
 import Foundation
 
-class GDPRLocalStorageMock: SPLocalStorage {
+class LocalStorageMock: SPLocalStorage {
     var gdprChildPmId: String?
     var ccpaChildPmId: String?
     var userData = SPUserData()

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -17,7 +17,7 @@ class SPClientCoordinatorSpec: QuickSpec {
     override func spec() {
         SPConsentManager.clearAllData()
 
-        var coordinator: SPClientCoordinator!
+        var coordinator: SourcepointClientCoordinator!
 
         beforeSuite {
             Nimble.AsyncDefaults.timeout = .seconds(30)
@@ -64,22 +64,83 @@ class SPClientCoordinatorSpec: QuickSpec {
             }
         }
 
-        describe("authenticated consent") {
+        describe("resetStateIfAuthIdChanged") {
+            describe("when previous auth Id is nil and new auth id is different than nil") {
+                it("does not reset state and sets stored auth id to the new one") {
+                    coordinator.state.storedAuthId = nil
+                    let gdprCampaignState = coordinator.state.gdpr
+                    let gdprMetadataState = coordinator.state.gdprMetaData
+                    let ccpaCampaignState = coordinator.state.ccpa
+                    let ccpaMetadataState = coordinator.state.ccpaMetaData
+
+                    coordinator.authId = "foo"
+                    coordinator.resetStateIfAuthIdChanged()
+
+                    expect(gdprCampaignState).to(be(coordinator.state.gdpr))
+                    expect(gdprMetadataState).to(equal(coordinator.state.gdprMetaData))
+                    expect(ccpaCampaignState).to(be(coordinator.state.ccpa))
+                    expect(ccpaMetadataState).to(equal(coordinator.state.ccpaMetaData))
+                    expect(coordinator.state.storedAuthId).to(equal("foo"))
+                }
+            }
+
+            describe("when new auth id is nil") {
+                it("does not reset state nor stored auth id") {
+                    coordinator.state.storedAuthId = "foo"
+                    let gdprCampaignState = coordinator.state.gdpr
+                    let gdprMetadataState = coordinator.state.gdprMetaData
+                    let ccpaCampaignState = coordinator.state.ccpa
+                    let ccpaMetadataState = coordinator.state.ccpaMetaData
+
+                    coordinator.authId = nil
+                    coordinator.resetStateIfAuthIdChanged()
+
+                    expect(gdprCampaignState).to(be(coordinator.state.gdpr))
+                    expect(gdprMetadataState).to(equal(coordinator.state.gdprMetaData))
+                    expect(ccpaCampaignState).to(be(coordinator.state.ccpa))
+                    expect(ccpaMetadataState).to(equal(coordinator.state.ccpaMetaData))
+                    expect(coordinator.state.storedAuthId).to(equal("foo"))
+                }
+            }
+
+            describe("when previous stored auth id is different than current auth id (and both are not nil)") {
+                it("resets state and overwrites stored auth id with the new one") {
+                    coordinator.state.storedAuthId = "foo"
+                    let gdprCampaignState = coordinator.state.gdpr
+                    let gdprMetadataState = coordinator.state.gdprMetaData
+                    let ccpaCampaignState = coordinator.state.ccpa
+                    // changing a single value so we can see it has changed in the expectations below
+                    coordinator.state.ccpaMetaData?.sampleRate = 0.5
+                    let ccpaMetadataState = coordinator.state.ccpaMetaData
+
+                    coordinator.authId = "bar"
+                    coordinator.resetStateIfAuthIdChanged()
+
+                    expect(gdprCampaignState).notTo(be(coordinator.state.gdpr))
+                    expect(gdprMetadataState).notTo(equal(coordinator.state.gdprMetaData))
+                    expect(ccpaCampaignState).notTo(be(coordinator.state.ccpa))
+                    expect(ccpaMetadataState).notTo(equal(coordinator.state.ccpaMetaData))
+                    expect(coordinator.state.storedAuthId).to(equal("bar"))
+                }
+            }
+        }
+
+        fdescribe("authenticated consent") {
             it("only changes consent uuid after a different auth id is used") {
                 waitUntil { done in
                     coordinator.loadMessages(forAuthId: nil) { guestUserResponse in
                         let (_, guestUserData) = try! guestUserResponse.get()
                         let guestGDPRUUID = guestUserData.gdpr?.consents?.uuid
                         let guestCCPAUUID = guestUserData.ccpa?.consents?.uuid
-                        expect(guestGDPRUUID).to(beNil())
-                        expect(guestCCPAUUID).to(beNil())
+                        expect(guestGDPRUUID).notTo(beNil())
+                        expect(guestCCPAUUID).notTo(beNil())
 
                         coordinator.loadMessages(forAuthId: UUID().uuidString) { loggedInResponse in
                             let (_, loggedInUserData) = try! loggedInResponse.get()
                             let loggedInGDPRUUID = loggedInUserData.gdpr?.consents?.uuid
                             let loggedInCCPAUUID = loggedInUserData.ccpa?.consents?.uuid
-                            expect(loggedInGDPRUUID).notTo(beNil())
-                            expect(loggedInCCPAUUID).notTo(beNil())
+                            expect(loggedInGDPRUUID).to(equal(guestGDPRUUID))
+                            expect(loggedInCCPAUUID).to(equal(guestCCPAUUID))
 
                             coordinator.loadMessages(forAuthId: nil) { loggedOutResponse in
                                 let (_, loggedOutUserData) = try! loggedOutResponse.get()

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -125,7 +125,7 @@ class SPClientCoordinatorSpec: QuickSpec {
             }
         }
 
-        fdescribe("authenticated consent") {
+        describe("authenticated consent") {
             it("only changes consent uuid after a different auth id is used") {
                 waitUntil { done in
                     coordinator.loadMessages(forAuthId: nil) { guestUserResponse in

--- a/Example/ConsentViewController_ExampleTests/SPDeviceSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPDeviceSpec.swift
@@ -15,7 +15,7 @@ class SPDeviceSpec: QuickSpec {
     override func spec() {
         describe("osVersion") {
             it("should contain the major version in its return") {
-                let version = SPDevice().osVersion()
+                let version = SPDevice.standard.osVersion
                 if #available(iOS 16, *) {
                     expect(version).to(contain("16."))
                 } else if #available(iOS 15, *) {
@@ -38,7 +38,7 @@ class SPDeviceSpec: QuickSpec {
 
         describe("deviceFamily") {
             it("should include iphone on its return") {
-                expect(SPDevice().deviceFamily()).to(contain("iPhone"))
+                expect(SPDevice.standard.deviceFamily).to(contain("iPhone"))
             }
         }
     }


### PR DESCRIPTION
This PR addresses 2 items:
## State management when `authId` changes
The SDK now correctly implements the following logic, related to state management when `authId` changes:
1. `authId` changes from `nil` -> `"something"`: state is persisted (consent is then linked to the current uuid)
2. `authId` changes from `"something"` -> `nil`: state is persisted (stored `authId` remains `"something"`)
3. `authId` changes from `"something"` -> `"something else"`: state is reset (and `authId` becomes `"something else"`)

## Handling `/pv-data` response
The `/pv-data` endpoint not only logs a "pageview" but also returns a new consent uuid for a given campaign.

Previously the SDK would not wait for the response of `/pv-data`. And this causes issues with reporting as well as a missing consent uuid in the stored consent data (until the user takes a consent action).