### PR TITLE
[DIA-2061] `childPmId` is saved to `UserDefaults` when it comes in `/meta-data` response

### DIFF
--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -251,7 +251,7 @@ import UIKit
         delegate?.onError?(error: error)
     }
 
-    private func selectPrivacyManagerId(fallbackId: String, groupPmId: String?, childPmId: String?) -> String {
+    func selectPrivacyManagerId(fallbackId: String, groupPmId: String?, childPmId: String?) -> String {
         if let groupPmId = groupPmId, groupPmId.isNotEmpty(),
            let childPmId = childPmId, childPmId.isNotEmpty() {
             return childPmId

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -192,14 +192,9 @@ import UIKit
         }
     }
 
-    func saveChildPmId(_ messages: [MessageToDisplay]) {
-        for message in messages {
-            switch message.type {
-                case .ccpa: storage.ccpaChildPmId = message.childPmId
-                case .gdpr: storage.ccpaChildPmId = message.childPmId
-                default: break
-            }
-        }
+    func saveChildPmId(_ messages: SPUserData) {
+        storage.ccpaChildPmId = messages.ccpa?.consents?.childPmId
+        storage.gdprChildPmId = messages.gdpr?.consents?.childPmId
     }
 
     func report(action: SPAction) {
@@ -310,7 +305,7 @@ import UIKit
                 switch result {
                     case .success(let (messages, consents)):
                         strongSelf.storeLegislationConsent(userData: consents)
-                        strongSelf.saveChildPmId(messages)
+                        strongSelf.saveChildPmId(consents)
                         strongSelf.messageControllersStack = strongSelf.messagesToViewController(messages)
                         strongSelf.messagesToShow = strongSelf.messageControllersStack.count
                         if strongSelf.messageControllersStack.isEmpty {

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -192,11 +192,6 @@ import UIKit
         }
     }
 
-    func saveChildPmId(_ messages: SPUserData) {
-        storage.ccpaChildPmId = messages.ccpa?.consents?.childPmId
-        storage.gdprChildPmId = messages.gdpr?.consents?.childPmId
-    }
-
     func report(action: SPAction) {
         responsesToReceive += 1
         switch action.campaignType {
@@ -305,7 +300,6 @@ import UIKit
                 switch result {
                     case .success(let (messages, consents)):
                         strongSelf.storeLegislationConsent(userData: consents)
-                        strongSelf.saveChildPmId(consents)
                         strongSelf.messageControllersStack = strongSelf.messagesToViewController(messages)
                         strongSelf.messagesToShow = strongSelf.messageControllersStack.count
                         if strongSelf.messageControllersStack.isEmpty {

--- a/ConsentViewController/Classes/SourcePointClient/MetaDataRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MetaDataRequestResponse.swift
@@ -18,6 +18,7 @@ struct MetaDataResponse: Decodable, Equatable {
         let legalBasisChangeDate: SPDateCreated
         let version: Int
         let _id: String
+        let childPmId: String?
         let applies: Bool
         let sampleRate: Float
     }
@@ -28,6 +29,7 @@ struct MetaDataResponse: Decodable, Equatable {
 
 struct MetaDataBodyRequest: QueryParamEncodable {
     struct Campaign: Encodable {
+        let groupPmId: String?
         let hasLocalData: Bool
         let dateCreated: SPDateCreated?
         let uuid: String?

--- a/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SimpleClient.swift
@@ -99,8 +99,10 @@ class SimpleClient: HttpClient {
                         switch response.statusCode {
                         case 408:
                             handler(.failure(ConnectionTimeoutAPIError(apiCode: apiCode)))
-                        case 400...407,409...499,500...599:
+
+                        case 400...407, 409...499, 500...599:
                             handler(.failure(InvalidResponseAPIError(apiCode: apiCode)))
+
                         default:
                             handler(.failure(GenericNetworkError(request: urlRequest, response: response)))
                         }
@@ -121,7 +123,7 @@ class SimpleClient: HttpClient {
         urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.httpMethod = "POST"
         urlRequest.httpBody = body
-        request(urlRequest, apiCode: apiCode , handler)
+        request(urlRequest, apiCode: apiCode, handler)
     }
 
     func get(urlString: String, apiCode: InvalidResponsAPICode = .EMPTY, handler: @escaping ResponseHandler) {
@@ -129,7 +131,7 @@ class SimpleClient: HttpClient {
             handler(.failure(InvalidURLError(urlString: urlString)))
             return
         }
-        request(URLRequest(url: url), apiCode: apiCode , handler)
+        request(URLRequest(url: url), apiCode: apiCode, handler)
     }
 
     func delete(urlString: String, body: Data?, apiCode: InvalidResponsAPICode = .EMPTY, handler: @escaping ResponseHandler) {
@@ -141,6 +143,6 @@ class SimpleClient: HttpClient {
         urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.httpMethod = "DELETE"
         urlRequest.httpBody = body
-        request(urlRequest, apiCode: apiCode , handler)
+        request(urlRequest, apiCode: apiCode, handler)
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -364,7 +364,9 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             state.gdprMetaData?.additionsChangeDate = gdprMetaData.additionsChangeDate
             state.gdprMetaData?.legalBasisChangeDate = gdprMetaData.legalBasisChangeDate
             state.gdprMetaData?.updateSampleFields(gdprMetaData.sampleRate)
-            storage.gdprChildPmId = gdprMetaData.childPmId ?? ""
+            if campaigns.gdpr?.groupPmId != gdprMetaData.childPmId {
+                storage.gdprChildPmId = gdprMetaData.childPmId ?? ""
+            }
         }
         if let ccpaMetaData = response.ccpa {
             state.ccpa?.applies = ccpaMetaData.applies

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -173,6 +173,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         .init(
             gdpr: campaigns.gdpr != nil ?
                     .init(
+                        groupPmId: campaigns.gdpr?.groupPmId,
                         hasLocalData: state.gdpr?.uuid != nil,
                         dateCreated: state.gdpr?.dateCreated,
                         uuid: state.gdpr?.uuid
@@ -180,6 +181,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                     nil,
             ccpa: campaigns.ccpa != nil ?
                 .init(
+                    groupPmId: campaigns.ccpa?.groupPmId,
                     hasLocalData: state.ccpa?.uuid != nil,
                     dateCreated: state.ccpa?.dateCreated,
                     uuid: state.ccpa?.uuid

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -364,6 +364,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             state.gdprMetaData?.additionsChangeDate = gdprMetaData.additionsChangeDate
             state.gdprMetaData?.legalBasisChangeDate = gdprMetaData.legalBasisChangeDate
             state.gdprMetaData?.updateSampleFields(gdprMetaData.sampleRate)
+            storage.gdprChildPmId = gdprMetaData.childPmId ?? ""
         }
         if let ccpaMetaData = response.ccpa {
             state.ccpa?.applies = ccpaMetaData.applies

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -44,6 +44,39 @@ class SPClientCoordinatorSpec: QuickSpec {
 
         describe("a property with GDPR and CCPA campaigns") {
             describe("loadMessage") {
+                it("should return gpoupPmId from metaData and save") {
+                    coordinator = SourcepointClientCoordinator(
+                        accountId: 22,
+                        propertyName: try! SPPropertyName("mobile.prop-1"),
+                        propertyId: 24188,
+                        campaigns: SPCampaigns(
+                            gdpr: SPCampaign(groupPmId: "613056"),
+                            ccpa: SPCampaign()
+                        ),
+                        storage: LocalStorageMock()
+                    )
+                    waitUntil { done in
+                        coordinator.loadMessages(forAuthId: nil) { result in
+                            switch result {
+                            case .success(let (_, consents)):
+                                    expect(consents.gdpr?.consents?.applies).to(beTrue())
+                                    expect(consents.gdpr?.consents?.euconsent).notTo(beEmpty())
+                                    expect(consents.gdpr?.consents?.vendorGrants).notTo(beEmpty())
+                                    expect(consents.ccpa?.consents?.uspstring) == "1---"
+                                case .failure(let error):
+                                    fail(error.failureReason)
+                            }
+                            expect(coordinator.storage.gdprChildPmId)=="613057"
+                            // TODO: add handle childPmId response from messages
+                            done()
+                        }
+                    }
+                }
+            }
+        }
+
+        describe("a property with GDPR and CCPA campaigns") {
+            describe("loadMessage") {
                 it("should return 2 messages and consents") {
                     waitUntil { done in
                         coordinator.loadMessages(forAuthId: nil) { result in

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -42,16 +42,6 @@ class SPClientCoordinatorSpec: QuickSpec {
             )
         }
 
-        describe("selectPrivacyManagerId") {
-            it("сhecks logic of selectPrivacyManagerId") {
-                var manager = SPConsentManager(accountId: 1, propertyId: 1, propertyName: coordinator.propertyName, campaigns: coordinator.campaigns, delegate: nil)
-                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: "2", childPmId: "3"))=="3"
-                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: nil, childPmId: "3"))=="1"
-                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: "2", childPmId: nil))=="1"
-                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: nil, childPmId: nil))=="1"
-            }
-        }
-
         describe("a property with GDPR and CCPA campaigns") {
             describe("loadMessage") {
                 it("should return gpoupPmId from metaData and save") {

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -41,7 +41,7 @@ class SPClientCoordinatorSpec: QuickSpec {
                 storage: LocalStorageMock()
             )
         }
-        
+
         describe("selectPrivacyManagerId") {
             it("сhecks logic of selectPrivacyManagerId") {
                 var manager = SPConsentManager(accountId: 1, propertyId: 1, propertyName: coordinator.propertyName, campaigns: coordinator.campaigns, delegate: nil)
@@ -77,16 +77,10 @@ class SPClientCoordinatorSpec: QuickSpec {
                                     fail(error.failureReason)
                             }
                             expect(coordinator.storage.gdprChildPmId)=="613057"
-                            // TODO: add handle childPmId response from messages
                             done()
                         }
                     }
                 }
-            }
-        }
-
-        describe("a property with GDPR and CCPA campaigns") {
-            describe("loadMessage") {
                 it("should return 2 messages and consents") {
                     waitUntil { done in
                         coordinator.loadMessages(forAuthId: nil) { result in

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -41,6 +41,16 @@ class SPClientCoordinatorSpec: QuickSpec {
                 storage: LocalStorageMock()
             )
         }
+        
+        describe("selectPrivacyManagerId") {
+            it("сhecks logic of selectPrivacyManagerId") {
+                var manager = SPConsentManager(accountId: 1, propertyId: 1, propertyName: coordinator.propertyName, campaigns: coordinator.campaigns, delegate: nil)
+                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: "2", childPmId: "3"))=="3"
+                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: nil, childPmId: "3"))=="1"
+                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: "2", childPmId: nil))=="1"
+                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: nil, childPmId: nil))=="1"
+            }
+        }
 
         describe("a property with GDPR and CCPA campaigns") {
             describe("loadMessage") {

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -177,8 +177,8 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                     client.metaData(accountId: accountId,
                                     propertyId: 17_801,
                                     metadata: MetaDataBodyRequest(
-                                        gdpr: MetaDataBodyRequest.Campaign(hasLocalData: true, dateCreated: nil, uuid: nil),
-                                        ccpa: MetaDataBodyRequest.Campaign(hasLocalData: false, dateCreated: nil, uuid: nil))) {
+                                        gdpr: MetaDataBodyRequest.Campaign(groupPmId: nil, hasLocalData: true, dateCreated: nil, uuid: nil),
+                                        ccpa: MetaDataBodyRequest.Campaign(groupPmId: nil, hasLocalData: false, dateCreated: nil, uuid: nil))) {
                             switch $0 {
                             case .success(let response):
                                 let GDPR = response.gdpr

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -194,9 +194,6 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                     }
                 }
             }
-        }
-
-        describe("meta-data_groupPmId") {
             it("Check if groupPmId echo") {
                 waitUntil { done in
                     client.metaData(accountId: accountId,

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -196,6 +196,28 @@ class UnmockedSourcepointClientSpec: QuickSpec {
             }
         }
 
+        describe("meta-data_groupPmId") {
+            it("Check if groupPmId echo") {
+                waitUntil { done in
+                    client.metaData(accountId: accountId,
+                                    propertyId: 17_801,
+                                    metadata: MetaDataBodyRequest(
+                                        gdpr: MetaDataBodyRequest.Campaign(groupPmId: "99999999999", hasLocalData: true, dateCreated: nil, uuid: nil),
+                                        ccpa: MetaDataBodyRequest.Campaign(groupPmId: nil, hasLocalData: false, dateCreated: nil, uuid: nil))) {
+                            switch $0 {
+                            case .success(let response):
+                                let GDPR = response.gdpr
+                                expect(GDPR?.childPmId)=="99999999999"
+
+                            case .failure(let error):
+                                fail(error.failureReason)
+                            }
+                            done()
+                    }
+                }
+            }
+        }
+
         describe("choice/reject-all") {
             it("should call the endpoint and parse the response into ChoiceAllResponse") {
                 waitUntil { done in

--- a/Example/ConsentViewController_ExampleTests/SPConsentManagerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPConsentManagerSpec.swift
@@ -1,0 +1,55 @@
+//
+//  SPConsentManagerSpec.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by main on 01/06/2023.
+//  Copyright © 2023 CocoaPods. All rights reserved.
+//
+
+@testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
+
+// swiftlint:disable force_try
+
+class SPConsentManagerSpec: QuickSpec {
+    override func spec() {
+        SPConsentManager.clearAllData()
+
+        var coordinator: SourcepointClientCoordinator!
+
+        beforeSuite {
+            Nimble.AsyncDefaults.timeout = .seconds(30)
+            Nimble.AsyncDefaults.pollInterval = .milliseconds(100)
+        }
+
+        afterSuite {
+            Nimble.AsyncDefaults.timeout = .seconds(1)
+            Nimble.AsyncDefaults.pollInterval = .milliseconds(10)
+        }
+
+        beforeEach {
+            coordinator = SourcepointClientCoordinator(
+                accountId: 22,
+                propertyName: try! SPPropertyName("mobile.multicampaign.demo"),
+                propertyId: 16_893,
+                campaigns: SPCampaigns(
+                    gdpr: SPCampaign(),
+                    ccpa: SPCampaign()
+                ),
+                storage: LocalStorageMock()
+            )
+        }
+
+        describe("selectPrivacyManagerId") {
+            it("сhecks logic of selectPrivacyManagerId") {
+                var manager = SPConsentManager(accountId: 1, propertyId: 1, propertyName: coordinator.propertyName, campaigns: coordinator.campaigns, delegate: nil)
+                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: "2", childPmId: "3"))=="3"
+                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: nil, childPmId: "3"))=="1"
+                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: "2", childPmId: nil))=="1"
+                expect(manager.selectPrivacyManagerId(fallbackId: "1", groupPmId: nil, childPmId: nil))=="1"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- [x] `childPmId` no longer comes from messages
- [x]  save `childPmId` which comes from `/meta-data` to `UserDefaults`
- [x] resend `childPmId`
- [x] ...
- [x] Profit!