### PR TITLE
DIA-2453 fix meta-data's metadata query param

### DIFF
--- a/ConsentViewController/Classes/SourcePointClient/MetaDataRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MetaDataRequestResponse.swift
@@ -26,12 +26,9 @@ struct MetaDataResponse: Decodable, Equatable {
     let gdpr: GDPR?
 }
 
-struct MetaDataBodyRequest: QueryParamEncodable {
+struct MetaDataQueryParam: QueryParamEncodable {
     struct Campaign: Encodable {
         let groupPmId: String?
-        let hasLocalData: Bool
-        let dateCreated: SPDateCreated?
-        let uuid: String?
     }
 
     let gdpr, ccpa: Campaign?

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -139,7 +139,7 @@ protocol SourcePointProtocol {
     func metaData(
         accountId: Int,
         propertyId: Int,
-        metadata: MetaDataBodyRequest,
+        metadata: MetaDataQueryParam,
         handler: @escaping MetaDataHandler
     )
 
@@ -428,7 +428,7 @@ extension SourcePointClient {
     func metaDataURLWithParams(
         accountId: Int,
         propertyId: Int,
-        metadata: MetaDataBodyRequest
+        metadata: MetaDataQueryParam
     ) -> URL? {
         let url = Constants.Urls.META_DATA_URL.appendQueryItems([
             "accountId": String(accountId),
@@ -441,7 +441,7 @@ extension SourcePointClient {
     func metaData(
         accountId: Int,
         propertyId: Int,
-        metadata: MetaDataBodyRequest,
+        metadata: MetaDataQueryParam,
         handler: @escaping MetaDataHandler
     ) {
         guard let url = metaDataURLWithParams(

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -166,22 +166,16 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         (campaigns.ios14 != nil && state.ios14?.status != .accepted)
     }
 
-    var metaDataParamsFromState: MetaDataBodyRequest {
+    var metaDataParamsFromState: MetaDataQueryParam {
         .init(
             gdpr: campaigns.gdpr != nil ?
                     .init(
-                        groupPmId: campaigns.gdpr?.groupPmId,
-                        hasLocalData: state.gdpr?.uuid != nil,
-                        dateCreated: state.gdpr?.dateCreated,
-                        uuid: state.gdpr?.uuid
+                        groupPmId: campaigns.gdpr?.groupPmId
                     ) :
                     nil,
             ccpa: campaigns.ccpa != nil ?
                 .init(
-                    groupPmId: campaigns.ccpa?.groupPmId,
-                    hasLocalData: state.ccpa?.uuid != nil,
-                    dateCreated: state.ccpa?.dateCreated,
-                    uuid: state.ccpa?.uuid
+                    groupPmId: campaigns.ccpa?.groupPmId
                 ) :
                 nil
         )

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -184,7 +184,7 @@ class SourcePointClientMock: SourcePointProtocol {
     func metaData(
         accountId: Int,
         propertyId: Int,
-        metadata: MetaDataBodyRequest,
+        metadata: MetaDataQueryParam,
         handler: @escaping MetaDataHandler
     ) { }
 

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -176,9 +176,10 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                 waitUntil { done in
                     client.metaData(accountId: accountId,
                                     propertyId: 17_801,
-                                    metadata: MetaDataBodyRequest(
-                                        gdpr: MetaDataBodyRequest.Campaign(groupPmId: nil, hasLocalData: true, dateCreated: nil, uuid: nil),
-                                        ccpa: MetaDataBodyRequest.Campaign(groupPmId: nil, hasLocalData: false, dateCreated: nil, uuid: nil))) {
+                                    metadata: MetaDataQueryParam(
+                                        gdpr: .init(groupPmId: nil),
+                                        ccpa: .init(groupPmId: nil)
+                                    )) {
                             switch $0 {
                             case .success(let response):
                                 let GDPR = response.gdpr
@@ -198,13 +199,14 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                 waitUntil { done in
                     client.metaData(accountId: accountId,
                                     propertyId: 17_801,
-                                    metadata: MetaDataBodyRequest(
-                                        gdpr: MetaDataBodyRequest.Campaign(groupPmId: "99999999999", hasLocalData: true, dateCreated: nil, uuid: nil),
-                                        ccpa: MetaDataBodyRequest.Campaign(groupPmId: nil, hasLocalData: false, dateCreated: nil, uuid: nil))) {
+                                    metadata: MetaDataQueryParam(
+                                        gdpr: .init(groupPmId: "99999999999"),
+                                        ccpa: .init(groupPmId: nil)
+                                    )) {
                             switch $0 {
                             case .success(let response):
                                 let GDPR = response.gdpr
-                                expect(GDPR?.childPmId)=="99999999999"
+                                expect(GDPR?.childPmId) == "99999999999"
 
                             case .failure(let error):
                                 fail(error.failureReason)


### PR DESCRIPTION
This fix removes data from the metadata query param to the meta-data endpoint. The data removed is harming our ability to cache meta-data response, thus increasing our costs and response times.