### PR TITLE
DIA-2461 refactor ChoiceAll request params

### DIFF
--- a/ConsentViewController/Classes/SourcePointClient/ChoiceAllResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ChoiceAllResponse.swift
@@ -42,7 +42,7 @@ struct ChoiceAllResponse: Decodable {
     let ccpa: CCPA?
 }
 
-struct ChoiceAllBodyRequest: QueryParamEncodable {
+struct ChoiceAllMetaDataParam: QueryParamEncodable {
     struct Campaign: Encodable {
         let applies: Bool
     }

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -147,7 +147,7 @@ protocol SourcePointProtocol {
         actionType: SPActionType,
         accountId: Int,
         propertyId: Int,
-        metadata: ChoiceAllBodyRequest,
+        metadata: ChoiceAllMetaDataParam,
         handler: @escaping ChoiceHandler
     )
 
@@ -497,7 +497,7 @@ extension SourcePointClient {
         propertyId: Int,
         withSiteActions: Bool,
         includeCustomVendorsRes: Bool,
-        metadata: ChoiceAllBodyRequest
+        metadata: ChoiceAllMetaDataParam
     ) -> URL? {
         var baseUrl: URL
         if actionType == .AcceptAll {
@@ -509,10 +509,10 @@ extension SourcePointClient {
         }
         return baseUrl.appendQueryItems([
             "accountId": String(accountId),
-            "hasCsp": hasCsp.description,
+            "hasCsp": String(hasCsp),
             "propertyId": String(propertyId),
-            "withSiteActions": withSiteActions.description,
-            "includeCustomVendorsRes": includeCustomVendorsRes.description,
+            "withSiteActions": String(withSiteActions),
+            "includeCustomVendorsRes": String(includeCustomVendorsRes),
             "metadata": metadata.stringified(),
             "includeData": IncludeData.string
         ])
@@ -522,7 +522,7 @@ extension SourcePointClient {
         actionType: SPActionType,
         accountId: Int,
         propertyId: Int,
-        metadata: ChoiceAllBodyRequest,
+        metadata: ChoiceAllMetaDataParam,
         handler: @escaping ChoiceHandler
     ) {
         guard let url = choiceAllUrlWithParams(

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -192,7 +192,7 @@ class SourcePointClientMock: SourcePointProtocol {
         actionType: SPActionType,
         accountId: Int,
         propertyId: Int,
-        metadata: ChoiceAllBodyRequest,
+        metadata: ChoiceAllMetaDataParam,
         handler: @escaping ChoiceHandler
     ) {
         handler(.success(ChoiceAllResponse(gdpr: nil, ccpa: nil)))


### PR DESCRIPTION
The requests to `GET choice/consent-all` and `GET choice/reject-all` have all the correct params. This PR only renames a class to be more specific. 