### PR TITLE
Fix date formatter failing

### DIFF
--- a/ConsentViewController/Classes/SPDateCreated.swift
+++ b/ConsentViewController/Classes/SPDateCreated.swift
@@ -8,10 +8,16 @@
 import Foundation
 
 public struct SPDateCreated: Codable, Equatable {
-    static let format: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-        return formatter
+    static let format: SPDateFormatter = {
+        if #available(iOS 11.0, *) {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [ .withFullDate, .withFullTime, .withFractionalSeconds, .withTimeZone ]
+            return formatter
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+            return formatter
+        }
     }()
 
     let originalDateString: String
@@ -37,3 +43,12 @@ public struct SPDateCreated: Codable, Equatable {
         try container.encode(originalDateString)
     }
 }
+
+protocol SPDateFormatter {
+    func string(from date: Date) -> String
+    
+    func date(from string: String) -> Date?
+}
+
+extension DateFormatter: SPDateFormatter { }
+extension ISO8601DateFormatter: SPDateFormatter { }

--- a/Example/ConsentViewController_ExampleTests/SPDateCreatedSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPDateCreatedSpec.swift
@@ -17,9 +17,15 @@ import Quick
 class SPDateCreatedSpec: QuickSpec {
     override func spec() {
         func dateFromString(_ date: String) -> Date? {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-            return formatter.date(from: date)
+            if #available(iOS 11.0, *) {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [ .withFullDate, .withFullTime, .withFractionalSeconds, .withTimeZone ]
+                return formatter.date(from: date)
+            } else {
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                return formatter.date(from: date)
+            }
         }
 
         describe("SPDateCreated") {


### PR DESCRIPTION
## Why:
- We observed the date formatter returning nil unexpectedly on certain devices.
- This led to the app always using the default date (now()). This means that the customers would be presented the cmp prompt every time as the last updated time is always older than the vendor list change.

### This change addresses the need by:
- Use ISO8601DateFormatter for iOS 11 and above.