### PR TITLE
DIA-2292 store GPPData

### DIFF
--- a/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
@@ -103,8 +103,8 @@ protocol CampaignConsent {
     enum CodingKeys: String, CodingKey {
         case status, rejectedVendors, rejectedCategories,
              uuid, childPmId, consentStatus,
-             webConsentPayload, signedLspa, applies
-        case gppData = "GPPData"
+             webConsentPayload, signedLspa, applies,
+             GPPData
     }
 
     /// Indicates if the user has rejected `.All`, `.Some` or `.None` of the vendors **and** categories.
@@ -126,7 +126,7 @@ protocol CampaignConsent {
     public var dateCreated = SPDateCreated.now()
 
     /// A dictionary with all GPP related data
-    public var gppData: SPJson
+    public var GPPData: SPJson
 
     /// In case `/getMessages` request was done with `groupPmId`, `childPmId` will be returned
     var childPmId: String?
@@ -168,7 +168,7 @@ protocol CampaignConsent {
         childPmId: String? = nil,
         consentStatus: ConsentStatus = ConsentStatus(),
         webConsentPayload: SPWebConsentPayload? = nil,
-        gppData: SPJson = SPJson()
+        GPPData: SPJson = SPJson()
     ) {
         self.uuid = uuid
         self.status = status
@@ -178,7 +178,7 @@ protocol CampaignConsent {
         self.childPmId = childPmId
         self.consentStatus = consentStatus
         self.webConsentPayload = webConsentPayload
-        self.gppData = gppData
+        self.GPPData = GPPData
     }
 
     public required init(from decoder: Decoder) throws {
@@ -192,7 +192,7 @@ protocol CampaignConsent {
         consentStatus = try (try? container.decode(ConsentStatus.self, forKey: .consentStatus)) ?? ConsentStatus(from: decoder)
         webConsentPayload = try container.decodeIfPresent(SPWebConsentPayload.self, forKey: .webConsentPayload)
         applies = try container.decodeIfPresent(Bool.self, forKey: .applies) ?? false
-        gppData = try container.decodeIfPresent(SPJson.self, forKey: .gppData) ?? SPJson()
+        GPPData = try container.decodeIfPresent(SPJson.self, forKey: .GPPData) ?? SPJson()
     }
 
     public static func empty() -> SPCCPAConsent { SPCCPAConsent(

--- a/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
@@ -100,10 +100,11 @@ protocol CampaignConsent {
  That is, if the user has rejected `.All` or `.None` vendors/categories, those arrays will be empty.
  */
 @objcMembers public class SPCCPAConsent: NSObject, Codable, CampaignConsent {
-    enum CodingKeys: CodingKey {
+    enum CodingKeys: String, CodingKey {
         case status, rejectedVendors, rejectedCategories,
              uuid, childPmId, consentStatus,
              webConsentPayload, signedLspa, applies
+        case gppData = "GPPData"
     }
 
     /// Indicates if the user has rejected `.All`, `.Some` or `.None` of the vendors **and** categories.
@@ -123,6 +124,9 @@ protocol CampaignConsent {
 
     /// The date in which the consent profile was created or updated
     public var dateCreated = SPDateCreated.now()
+
+    /// A dictionary with all GPP related data
+    public var gppData: SPJson
 
     /// In case `/getMessages` request was done with `groupPmId`, `childPmId` will be returned
     var childPmId: String?
@@ -163,7 +167,8 @@ protocol CampaignConsent {
         signedLspa: Bool,
         childPmId: String? = nil,
         consentStatus: ConsentStatus = ConsentStatus(),
-        webConsentPayload: SPWebConsentPayload? = nil
+        webConsentPayload: SPWebConsentPayload? = nil,
+        gppData: SPJson = SPJson()
     ) {
         self.uuid = uuid
         self.status = status
@@ -173,6 +178,7 @@ protocol CampaignConsent {
         self.childPmId = childPmId
         self.consentStatus = consentStatus
         self.webConsentPayload = webConsentPayload
+        self.gppData = gppData
     }
 
     public required init(from decoder: Decoder) throws {
@@ -186,6 +192,7 @@ protocol CampaignConsent {
         consentStatus = try (try? container.decode(ConsentStatus.self, forKey: .consentStatus)) ?? ConsentStatus(from: decoder)
         webConsentPayload = try container.decodeIfPresent(SPWebConsentPayload.self, forKey: .webConsentPayload)
         applies = try container.decodeIfPresent(Bool.self, forKey: .applies) ?? false
+        gppData = try container.decodeIfPresent(SPJson.self, forKey: .gppData) ?? SPJson()
     }
 
     public static func empty() -> SPCCPAConsent { SPCCPAConsent(

--- a/ConsentViewController/Classes/LocalStorage/SPLocalStorage.swift
+++ b/ConsentViewController/Classes/LocalStorage/SPLocalStorage.swift
@@ -44,6 +44,7 @@ extension UserDefaults: Storage {
 protocol SPLocalStorage {
     var storage: Storage { get set }
     var tcfData: [String: Any]? { get set }
+    var gppData: [String: Any]? { get set }
     var usPrivacyString: String? { get set }
     var userData: SPUserData { get set }
     var localState: SPJson? { get set }

--- a/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
+++ b/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
@@ -10,21 +10,22 @@ import Foundation
 class SPUserDefaults: SPLocalStorage {
     public static let SP_KEY_PREFIX = "sp_"
     public static let IAB_KEY_PREFIX = "IABTCF_"
+    public static let GPP_KEY_PREFIX = "IABGPP_"
     public static let US_PRIVACY_STRING_KEY = "IABUSPrivacy_String"
 
     static let LOCAL_STATE_KEY = "\(SP_KEY_PREFIX)localState"
     static let USER_DATA_KEY = "\(SP_KEY_PREFIX)userData"
-    static let GDPR_CHILD_PM_ID_KEY = "\(SPUserDefaults.SP_KEY_PREFIX)GDPRchildPmId"
-    static let CCPA_CHILD_PM_ID_KEY = "\(SPUserDefaults.SP_KEY_PREFIX)CCPAchildPmId"
+    static let GDPR_CHILD_PM_ID_KEY = "\(SP_KEY_PREFIX)GDPRchildPmId"
+    static let CCPA_CHILD_PM_ID_KEY = "\(SP_KEY_PREFIX)CCPAchildPmId"
 
-    static let SP_STATE_KEY = "\(SPUserDefaults.SP_KEY_PREFIX)state"
+    static let SP_STATE_KEY = "\(SP_KEY_PREFIX)state"
 
     var storage: Storage
 
     var tcfData: [String: Any]? {
         get {
             storage.dictionaryRepresentation().filter {
-                $0.key.starts(with: SPUserDefaults.IAB_KEY_PREFIX)
+                $0.key.starts(with: Self.IAB_KEY_PREFIX)
             }
         }
         set {
@@ -33,46 +34,58 @@ class SPUserDefaults: SPLocalStorage {
         }
     }
 
+    var gppData: [String: Any]? {
+        get {
+            storage.dictionaryRepresentation().filter {
+                $0.key.starts(with: Self.GPP_KEY_PREFIX)
+            }
+        }
+        set {
+            storage.removeObjects(forKeys: Array((gppData ?? [:]).keys))
+            storage.setValuesForKeys(newValue ?? [:])
+        }
+    }
+
     var usPrivacyString: String? {
-        get { storage.string(forKey: SPUserDefaults.US_PRIVACY_STRING_KEY) }
-        set { storage.set(newValue, forKey: SPUserDefaults.US_PRIVACY_STRING_KEY) }
+        get { storage.string(forKey: Self.US_PRIVACY_STRING_KEY) }
+        set { storage.set(newValue, forKey: Self.US_PRIVACY_STRING_KEY) }
     }
 
     var userData: SPUserData {
         get {
             storage.object(
                 ofType: SPUserData.self,
-                forKey: SPUserDefaults.USER_DATA_KEY
+                forKey: Self.USER_DATA_KEY
             ) ?? SPUserData()
         }
         set {
-            storage.setObject(newValue, forKey: SPUserDefaults.USER_DATA_KEY)
+            storage.setObject(newValue, forKey: Self.USER_DATA_KEY)
         }
     }
 
     var localState: SPJson? {
-        get { storage.object(ofType: SPJson.self, forKey: SPUserDefaults.LOCAL_STATE_KEY) }
-        set { storage.setObject(newValue, forKey: SPUserDefaults.LOCAL_STATE_KEY) }
+        get { storage.object(ofType: SPJson.self, forKey: Self.LOCAL_STATE_KEY) }
+        set { storage.setObject(newValue, forKey: Self.LOCAL_STATE_KEY) }
     }
 
     var gdprChildPmId: String? {
-        get { storage.string(forKey: SPUserDefaults.GDPR_CHILD_PM_ID_KEY) }
-        set { storage.set(newValue, forKey: SPUserDefaults.GDPR_CHILD_PM_ID_KEY) }
+        get { storage.string(forKey: Self.GDPR_CHILD_PM_ID_KEY) }
+        set { storage.set(newValue, forKey: Self.GDPR_CHILD_PM_ID_KEY) }
     }
 
     var ccpaChildPmId: String? {
-        get { storage.string(forKey: SPUserDefaults.CCPA_CHILD_PM_ID_KEY) }
-        set { storage.set(newValue, forKey: SPUserDefaults.CCPA_CHILD_PM_ID_KEY) }
+        get { storage.string(forKey: Self.CCPA_CHILD_PM_ID_KEY) }
+        set { storage.set(newValue, forKey: Self.CCPA_CHILD_PM_ID_KEY) }
     }
 
     var spState: SourcepointClientCoordinator.State? {
         get {
             storage.object(
                 ofType: SourcepointClientCoordinator.State.self,
-                forKey: SPUserDefaults.SP_STATE_KEY
+                forKey: Self.SP_STATE_KEY
             )
         }
-        set { storage.setObject(newValue, forKey: SPUserDefaults.SP_STATE_KEY) }
+        set { storage.setObject(newValue, forKey: Self.SP_STATE_KEY) }
     }
 
     required init(storage: Storage = UserDefaults.standard) {

--- a/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
+++ b/ConsentViewController/Classes/LocalStorage/SPUserDefaults.swift
@@ -101,6 +101,7 @@ class SPUserDefaults: SPLocalStorage {
     func clear() {
         localState = nil
         tcfData = [:]
+        gppData = [:]
         usPrivacyString = ""
         userData = SPUserData()
         gdprChildPmId = nil

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -190,6 +190,9 @@ import UIKit
         if let uspString = userData.ccpa?.consents?.uspstring {
             storage.usPrivacyString = uspString
         }
+        if let gppData = userData.ccpa?.consents?.GPPData {
+            storage.gppData = gppData.dictionaryValue
+        }
     }
 
     func report(action: SPAction) {

--- a/ConsentViewController/Classes/SourcePointClient/ChoiceAllResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ChoiceAllResponse.swift
@@ -18,6 +18,7 @@ struct ChoiceAllResponse: Decodable {
         let rejectedCategories: [String]
         let gpcEnabled: Bool?
         let webConsentPayload: SPWebConsentPayload?
+        let GPPData: SPJson
     }
 
     struct GDPR: Decodable {
@@ -54,7 +55,7 @@ extension ChoiceAllResponse.CCPA: Decodable {
     enum CodingKeys: String, CodingKey {
         case dateCreated, consentedAll, rejectedAll,
              status, rejectedVendors, rejectedCategories,
-             gpcEnabled, webConsentPayload
+             gpcEnabled, webConsentPayload, GPPData
         case uspstring = "uspString"
     }
 
@@ -69,7 +70,8 @@ extension ChoiceAllResponse.CCPA: Decodable {
             rejectedVendors: ((container.decodeIfPresent([String?].self, forKey: .rejectedVendors)) ?? []).compactMap { $0 },
             rejectedCategories: ((container.decodeIfPresent([String?].self, forKey: .rejectedCategories)) ?? []).compactMap { $0 },
             gpcEnabled: container.decodeIfPresent(Bool.self, forKey: .gpcEnabled),
-            webConsentPayload: container.decodeIfPresent(SPWebConsentPayload.self, forKey: .webConsentPayload)
+            webConsentPayload: container.decodeIfPresent(SPWebConsentPayload.self, forKey: .webConsentPayload),
+            GPPData: container.decodeIfPresent(SPJson.self, forKey: .GPPData) ?? SPJson()
         )
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/ChoiceResponses.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ChoiceResponses.swift
@@ -28,13 +28,14 @@ struct CCPAChoiceResponse: Equatable {
     let rejectedVendors: [String]?
     let rejectedCategories: [String]?
     let webConsentPayload: SPWebConsentPayload?
+    let GPPData: SPJson
 }
 
 extension CCPAChoiceResponse: Decodable {
     enum CodingKeys: CodingKey {
         case uuid, dateCreated, consentedAll, rejectedAll,
              status, uspstring, rejectedVendors, rejectedCategories,
-             gpcEnabled, webConsentPayload
+             gpcEnabled, webConsentPayload, GPPData
     }
 
     init(from decoder: Decoder) throws {
@@ -49,7 +50,8 @@ extension CCPAChoiceResponse: Decodable {
             gpcEnabled: container.decodeIfPresent(Bool.self, forKey: .gpcEnabled),
             rejectedVendors: ((container.decodeIfPresent([String?].self, forKey: .rejectedVendors)) ?? []).compactMap { $0 },
             rejectedCategories: ((container.decodeIfPresent([String?].self, forKey: .rejectedCategories)) ?? []).compactMap { $0 },
-            webConsentPayload: container.decodeIfPresent(SPWebConsentPayload.self, forKey: .webConsentPayload)
+            webConsentPayload: container.decodeIfPresent(SPWebConsentPayload.self, forKey: .webConsentPayload),
+            GPPData: container.decodeIfPresent(SPJson.self, forKey: .GPPData) ?? SPJson()
         )
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/ConsentStatusResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ConsentStatusResponse.swift
@@ -25,6 +25,7 @@ struct ConsentStatusResponse: Decodable, Equatable {
             let rejectedCategories, rejectedVendors: [String]
             let status: CCPAConsentStatus
             let webConsentPayload: SPWebConsentPayload?
+            let GPPData: SPJson?
         }
 
         let gdpr: GDPR?

--- a/ConsentViewController/Classes/SourcePointClient/IncludeData.swift
+++ b/ConsentViewController/Classes/SourcePointClient/IncludeData.swift
@@ -10,11 +10,16 @@
 import Foundation
 
 struct IncludeData: Encodable, Equatable {
-    static let string = "{\"TCData\":{\"type\":\"RecordString\"},\"webConsentPayload\":{\"type\":\"string\"},\"localState\":{\"type\":\"RecordString\"},\"categories\":true,\"translateMessage\":true}"
+    static let string = #"{"TCData":{"type":"RecordString"},"webConsentPayload":{"type":"string"},"localState":{"type":"RecordString"},"categories":true,"translateMessage":true,"GPPData":{"MspaCoveredTransaction":"no","MspaOptOutOptionMode":"na","MspaServiceProviderMode":"na"}}"#
 
     let localState = ["type": "RecordString"]
     let TCData = ["type": "RecordString"]
     let webConsentPayload = ["type": "string"]
     let categories = true
     let translateMessage = true
+    let GPPData = [
+        "MspaCoveredTransaction": "no",
+        "MspaOptOutOptionMode": "na",
+        "MspaServiceProviderMode": "na"
+    ]
 }

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -422,6 +422,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             )
             state.ccpa?.childPmId = nil
             state.ccpa?.webConsentPayload = ccpa.webConsentPayload
+            state.ccpa?.GPPData = ccpa.GPPData ?? SPJson()
         }
         storage.spState = state
     }
@@ -601,6 +602,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         if let ccpa = response.ccpa, campaign == .ccpa {
             state.ccpa?.dateCreated = ccpa.dateCreated
             state.ccpa?.status = ccpa.status
+            state.ccpa?.GPPData = ccpa.GPPData
         }
         storage.spState = state
     }
@@ -701,6 +703,9 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         self.postChoice(action) { postResult in
             switch postResult {
                 case .success(let response):
+                    if action.type == .SaveAndExit {
+                        self.state.ccpa?.GPPData = response.GPPData
+                    }
                     self.state.ccpa?.uuid = response.uuid
                     self.state.ccpa?.dateCreated = response.dateCreated
                     self.state.ccpa?.status = response.status ?? getResponse?.ccpa?.status ?? .RejectedAll

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		82A99CCE255D958000A85024 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = 82A99CCD255D958000A85024 /* index.html */; };
 		82AC4A8225934FB600817B65 /* SPDeviceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AC4A8125934FB600817B65 /* SPDeviceSpec.swift */; };
 		82B224182580D5D60032BC49 /* SPURLExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B224172580D5D60032BC49 /* SPURLExtensionsSpec.swift */; };
+		82B9AB4F2A740EE600565C13 /* SourcepointCoordinatorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B9AB4E2A740EE600565C13 /* SourcepointCoordinatorMock.swift */; };
 		82BB0E5F28BE1A9B006FBB60 /* UnmockedSourcepointClientSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BB0E5E28BE1A9B006FBB60 /* UnmockedSourcepointClientSpec.swift */; };
 		82BB0E6A28BF3433006FBB60 /* SPDateCreatedSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BB0E6928BF3433006FBB60 /* SPDateCreatedSpec.swift */; };
 		82BB0E6F28BF4BAB006FBB60 /* QueryParamEncodableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BB0E6E28BF4BAB006FBB60 /* QueryParamEncodableSpec.swift */; };
@@ -441,6 +442,7 @@
 		82AC4A8125934FB600817B65 /* SPDeviceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPDeviceSpec.swift; sourceTree = "<group>"; };
 		82ACF6AB2487E73C006E207A /* SPUserDefaultsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPUserDefaultsSpec.swift; sourceTree = "<group>"; };
 		82B224172580D5D60032BC49 /* SPURLExtensionsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPURLExtensionsSpec.swift; sourceTree = "<group>"; };
+		82B9AB4E2A740EE600565C13 /* SourcepointCoordinatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourcepointCoordinatorMock.swift; sourceTree = "<group>"; };
 		82BB0E5E28BE1A9B006FBB60 /* UnmockedSourcepointClientSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnmockedSourcepointClientSpec.swift; sourceTree = "<group>"; };
 		82BB0E6928BF3433006FBB60 /* SPDateCreatedSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPDateCreatedSpec.swift; sourceTree = "<group>"; };
 		82BB0E6E28BF4BAB006FBB60 /* QueryParamEncodableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryParamEncodableSpec.swift; sourceTree = "<group>"; };
@@ -1213,6 +1215,7 @@
 			children = (
 				825F4B7F2487B5D100769B6A /* SourcePointClient */,
 				8229C6152991390300F755AA /* SPClientCoordinatorSpec.swift */,
+				82B9AB4E2A740EE600565C13 /* SourcepointCoordinatorMock.swift */,
 			);
 			path = SPClientCoordinator;
 			sourceTree = "<group>";
@@ -2761,6 +2764,7 @@
 				826D31B1249A46C40026A6B9 /* GDPRUIiDelegateMock.swift in Sources */,
 				829DA56425D5573800612517 /* SPConsentSpec.swift in Sources */,
 				82B224182580D5D60032BC49 /* SPURLExtensionsSpec.swift in Sources */,
+				82B9AB4F2A740EE600565C13 /* SourcepointCoordinatorMock.swift in Sources */,
 				82EA4E362491328A00DC01C9 /* InMemoryStorageMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Nimble
 
+public typealias Predicate = Nimble.Predicate
+
 extension URL {
     public var queryParams: [String: String]? {
         guard

--- a/Example/ConsentViewController_ExampleTests/Helpers/LocalStorageMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/LocalStorageMock.swift
@@ -17,6 +17,7 @@ class LocalStorageMock: SPLocalStorage {
     var nonKeyedLocalState = SPJson()
     var storage: Storage = InMemoryStorageMock()
     var tcfData: [String: Any]? = [:]
+    var gppData: [String: Any]? = [:]
     var usPrivacyString: String?
     var propertyId: Int?
     var spState: SourcepointClientCoordinator.State?

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -99,7 +99,8 @@ class SourcePointClientMock: SourcePointProtocol {
                 gpcEnabled: nil,
                 rejectedVendors: nil,
                 rejectedCategories: nil,
-                webConsentPayload: nil
+                webConsentPayload: nil,
+                GPPData: SPJson()
             )))
         }
     }

--- a/Example/ConsentViewController_ExampleTests/LocalStorage/SPUserDefaultsSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/LocalStorage/SPUserDefaultsSpec.swift
@@ -10,7 +10,7 @@
 import Nimble
 import Quick
 
-// swiftlint:disable force_cast function_body_length
+// swiftlint:disable function_body_length
 
 class SPUserDefaultsSpec: QuickSpec {
     func randomUserConsents() -> SPUserData {
@@ -44,6 +44,47 @@ class SPUserDefaultsSpec: QuickSpec {
                     userDefaults.tcfData = [iabKey: 99]
                     expect(localStorage.storage[iabKey] as? Int) == 99
                 }
+
+                it("when reassigned, remove pre-existing values") {
+                    let iabKeyA = "\(SPUserDefaults.IAB_KEY_PREFIX)_key_a"
+                    let iabKeyB = "\(SPUserDefaults.IAB_KEY_PREFIX)_key_b"
+                    let userDefaults = SPUserDefaults(storage: localStorage)
+                    localStorage.storage = [iabKeyA: 999]
+                    userDefaults.tcfData = [iabKeyB: 123]
+                    expect(localStorage.storage.keys).notTo(contain(iabKeyA))
+                    expect(localStorage.storage.keys).to(contain(iabKeyB))
+                }
+            }
+
+            describe("gppData") {
+                it("is empty dictionary by default") {
+                    let userDefaults = SPUserDefaults(storage: localStorage)
+                    expect(userDefaults.gppData).to(beEmpty())
+                }
+
+                it("gets its value from the local storage") {
+                    let gppKey = "\(SPUserDefaults.GPP_KEY_PREFIX)_key"
+                    localStorage.storage = [gppKey: 99]
+                    let userDefaults = SPUserDefaults(storage: localStorage)
+                    expect(userDefaults.gppData?[gppKey] as? Int) == 99
+                }
+
+                it("persists the value in the local storage") {
+                    let gppKey = "\(SPUserDefaults.GPP_KEY_PREFIX)_key"
+                    let userDefaults = SPUserDefaults(storage: localStorage)
+                    userDefaults.gppData = [gppKey: 99]
+                    expect(localStorage.storage[gppKey] as? Int) == 99
+                }
+
+                it("when reassigned, remove pre-existing values") {
+                    let gppKeyA = "\(SPUserDefaults.GPP_KEY_PREFIX)_key_a"
+                    let gppKeyB = "\(SPUserDefaults.GPP_KEY_PREFIX)_key_b"
+                    let userDefaults = SPUserDefaults(storage: localStorage)
+                    localStorage.storage = [gppKeyA: 999]
+                    userDefaults.gppData = [gppKeyB: 123]
+                    expect(localStorage.storage.keys).notTo(contain(gppKeyA))
+                    expect(localStorage.storage.keys).to(contain(gppKeyB))
+                }
             }
 
             describe("userData") {
@@ -63,7 +104,7 @@ class SPUserDefaultsSpec: QuickSpec {
                     let userData = SPUserData()
                     let userDefaults = SPUserDefaults(storage: localStorage)
                     userDefaults.userData = userData
-                    let stored = localStorage.storage[SPUserDefaults.USER_DATA_KEY] as! SPUserData
+                    let stored = localStorage.storage[SPUserDefaults.USER_DATA_KEY] as? SPUserData
                     expect(stored) == userData
                 }
             }
@@ -102,9 +143,20 @@ class SPUserDefaultsSpec: QuickSpec {
 
                 it("sets tcfData back to its default value") {
                     let userDefaults = SPUserDefaults(storage: localStorage)
-                    userDefaults.tcfData = ["foo": "bar"]
+                    let tcfKey = "\(SPUserDefaults.IAB_KEY_PREFIX)foo"
+                    userDefaults.tcfData = [tcfKey: "bar"]
+                    expect(userDefaults.tcfData).notTo(beEmpty())
                     userDefaults.clear()
                     expect(userDefaults.tcfData).to(beEmpty())
+                }
+
+                it("sets gppData back to its default value") {
+                    let userDefaults = SPUserDefaults(storage: localStorage)
+                    let gppKey = "\(SPUserDefaults.GPP_KEY_PREFIX)foo"
+                    userDefaults.gppData = [gppKey: "bar"]
+                    expect(userDefaults.gppData).notTo(beEmpty())
+                    userDefaults.clear()
+                    expect(userDefaults.gppData).to(beEmpty())
                 }
             }
 

--- a/Example/ConsentViewController_ExampleTests/SPCCPAConsentSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPCCPAConsentSpec.swift
@@ -22,6 +22,7 @@ class SPCCPAConsentsSpec: QuickSpec {
                 expect(consents.uuid).to(beNil())
                 expect(consents.applies).to(beFalse())
                 expect(consents.status).to(equal(.RejectedNone))
+                expect(consents.gppData).to(equal(SPJson()))
             }
         }
 
@@ -33,13 +34,20 @@ class SPCCPAConsentsSpec: QuickSpec {
                     "rejectedVendors": [],
                     "rejectedCategories": [],
                     "consentStatus": {},
-                    "signedLspa": false
+                    "signedLspa": false,
+                    "GPPData": {
+                        "foo": "bar"
+                    }
                 }
                 """.data(using: .utf8)
             }
             let consent = try ccpaConsents.decoded() as SPCCPAConsent
             expect(consent.applies).to(beTrue())
-            expect(consent.applies).to(beTrue())
+            expect(consent.status).to(equal(.RejectedNone))
+            expect(consent.rejectedVendors).to(beEmpty())
+            expect(consent.rejectedCategories).to(beEmpty())
+            expect(consent.signedLspa).to(beFalse())
+            expect(consent.gppData.dictionaryValue?["foo"] as? String).to(equal("bar"))
         }
     }
 }

--- a/Example/ConsentViewController_ExampleTests/SPCCPAConsentSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPCCPAConsentSpec.swift
@@ -22,7 +22,7 @@ class SPCCPAConsentsSpec: QuickSpec {
                 expect(consents.uuid).to(beNil())
                 expect(consents.applies).to(beFalse())
                 expect(consents.status).to(equal(.RejectedNone))
-                expect(consents.gppData).to(equal(SPJson()))
+                expect(consents.GPPData).to(equal(SPJson()))
             }
         }
 
@@ -47,7 +47,7 @@ class SPCCPAConsentsSpec: QuickSpec {
             expect(consent.rejectedVendors).to(beEmpty())
             expect(consent.rejectedCategories).to(beEmpty())
             expect(consent.signedLspa).to(beFalse())
-            expect(consent.gppData.dictionaryValue?["foo"] as? String).to(equal("bar"))
+            expect(consent.GPPData.dictionaryValue?["foo"] as? String).to(equal("bar"))
         }
     }
 }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -51,7 +51,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
 
             it("should contain all query params") {
                 let url = client.consentStatusURLWithParams(propertyId: propertyId, metadata: emptyMetaData, authId: nil)
-                let paramsRaw = "env=\(Constants.Urls.envParam)&scriptType=ios&scriptVersion=\(SPConsentManager.VERSION)&hasCsp=true&includeData={\"TCData\":{\"type\":\"RecordString\"},\"webConsentPayload\":{\"type\":\"string\"},\"localState\":{\"type\":\"RecordString\"},\"categories\":true,\"translateMessage\":true}&metadata={}&propertyId=17801&withSiteActions=false"
+                let paramsRaw = "env=\(Constants.Urls.envParam)&scriptType=ios&scriptVersion=\(SPConsentManager.VERSION)&hasCsp=true&includeData=\(IncludeData.string)&metadata={}&propertyId=17801&withSiteActions=false"
                 expect(url?.query) == paramsRaw.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
             }
         }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcepointCoordinatorMock.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcepointCoordinatorMock.swift
@@ -1,0 +1,43 @@
+//
+//  SourcepointCoordinatorMock.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 28.07.23.
+//  Copyright © 2023 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import ConsentViewController
+
+// swiftlint:disable force_try
+
+class CoordinatorMock: SPClientCoordinator {
+    var authId: String?
+    var deviceManager: SPDeviceManager = SPDevice()
+    var userData: SPUserData = SPUserData()
+    var language: SPMessageLanguage = .BrowserDefault
+    var spClient: SourcePointProtocol = SourcePointClientMock(
+        accountId: 0,
+        propertyName: try! SPPropertyName(""),
+        campaignEnv: .Public,
+        timeout: 10
+    )
+
+    var loadMessagesResult: Result<LoadMessagesReturnType, SPError>!
+
+    func loadMessages(forAuthId: String?, pubData: SPPublisherData?, _ handler: @escaping MessagesAndConsentsHandler) {
+        handler(loadMessagesResult)
+    }
+
+    func reportAction(_ action: SPAction, handler: @escaping (Result<SPUserData, SPError>) -> Void) {}
+
+    func reportIdfaStatus(status: SPIDFAStatus, osVersion: String) {}
+
+    func logErrorMetrics(_ error: SPError) {}
+
+    func deleteCustomConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String], handler: @escaping (Result<SPGDPRConsent, SPError>) -> Void) {}
+
+    func customConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String], handler: @escaping GDPRCustomConsentHandler) {}
+
+    func setRequestTimeout(_ timeout: TimeInterval) {}
+}

--- a/Example/ConsentViewController_ExampleTests/SPDeviceSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPDeviceSpec.swift
@@ -16,7 +16,9 @@ class SPDeviceSpec: QuickSpec {
         describe("osVersion") {
             it("should contain the major version in its return") {
                 let version = SPDevice.standard.osVersion
-                if #available(iOS 16, *) {
+                if #available(iOS 17, *) {
+                    expect(version).to(contain("17."))
+                } else if #available(iOS 16, *) {
                     expect(version).to(contain("16."))
                 } else if #available(iOS 15, *) {
                     expect(version).to(contain("15."))

--- a/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
+++ b/Example/SPGDPRExampleAppUITests/Helpers/CustomMatchers.swift
@@ -10,6 +10,8 @@ import Nimble
 import Quick
 import XCTest
 
+public typealias Predicate = Nimble.Predicate
+
 extension TimeInterval {
     init(dispatchTimeInterval: DispatchTimeInterval) {
         switch dispatchTimeInterval {


### PR DESCRIPTION
[DIA-2292](https://sourcepoint.atlassian.net/browse/DIA-2292)

- [x] add GPPData object to IncludeData (to request GPPData to the server)
- [x] add gppData to `SPCCPAConsent` 
- [x] store gpp data, key by key, in local storage
- [x] make sure to remove previous gpp keys when re-assigning gppData
- [x] add `GPPData` to responses' models
- [x] make sure to update legislation data on `onConsentReady` 
- [ ] request consent data for existing users (users have `hasLocalData = true` and the APIs won't return consent data for those, unless taking consent action). This is likely to be done in a separate PR. 

[DIA-2292]: https://sourcepoint.atlassian.net/browse/DIA-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ