### PR TITLE
DIA-2478 expose GPP config through SPCampaigns

### DIFF
--- a/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
@@ -155,6 +155,7 @@ protocol CampaignConsent {
             - rejectedCategories: \(rejectedCategories)
             - uspstring: \(uspstring)
             - signedLspa: \(signedLspa)
+            - GPPData: \(GPPData)
         )
         """
     }

--- a/ConsentViewController/Classes/SPCampaigns.swift
+++ b/ConsentViewController/Classes/SPCampaigns.swift
@@ -10,21 +10,78 @@ import Foundation
 /// A collection of key/value pairs passed to the scenario builder on SP's dashboard
 public typealias SPTargetingParams = [String: String]
 
+/// Class to encapsulate GPP configuration. This config can be used with CCPA campaigns and have
+/// no effect in campaigns of other legislations.
+@objcMembers public class SPGPPConfig: NSObject, Encodable {
+    @objc public enum SPMspaBinaryFlag: Int, Encodable, Equatable {
+        case yes, no
+
+        public var string: String { self == .yes ? "yes" : "no" }
+
+        public func encode(to encoder: Encoder) throws {
+            var valueContainer = encoder.singleValueContainer()
+            try valueContainer.encode(string)
+        }
+    }
+
+    @objc public enum SPMspaTernaryFlag: Int, Encodable, Equatable {
+        case yes, no, notApplicable
+
+        public var string: String {
+            switch self {
+                case .yes: return "yes"
+                case .no: return "no"
+                case .notApplicable: return "na"
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var valueContainer = encoder.singleValueContainer()
+            try valueContainer.encode(string)
+        }
+    }
+
+    let MspaCoveredTransaction: SPMspaBinaryFlag?
+    let MspaOptOutOptionMode: SPMspaTernaryFlag?
+    let MspaServiceProviderMode: SPMspaTernaryFlag?
+
+    public init(
+        MspaCoveredTransaction: SPMspaBinaryFlag? = nil,
+        MspaOptOutOptionMode: SPMspaTernaryFlag? = nil,
+        MspaServiceProviderMode: SPMspaTernaryFlag? = nil
+    ) {
+        self.MspaCoveredTransaction = MspaCoveredTransaction
+        self.MspaOptOutOptionMode = MspaOptOutOptionMode
+        self.MspaServiceProviderMode = MspaServiceProviderMode
+    }
+}
+
 /// Contains information about the property/campaign.
 @objcMembers public class SPCampaign: NSObject {
     let targetingParams: SPTargetingParams
+
     let groupPmId: String?
 
+    /// Class to encapsulate GPP configuration. This parameter has only effect in CCPA campaigns.
+    let GPPConfig: SPGPPConfig
+
     override public var description: String {
-        "SPCampaign(targetingParams: \(targetingParams), groupPmId: \(groupPmId as Any))"
+        """
+        SPCampaign
+            - targetingParams: \(targetingParams)
+            - groupPmId: \(groupPmId as Any)
+            - GPPConfig: \(GPPConfig as Any)
+        """
     }
 
     public init(
         targetingParams: SPTargetingParams = [:],
-        groupPmId: String? = nil
+        groupPmId: String? = nil,
+        gppConfig: SPGPPConfig = SPGPPConfig()
     ) {
         self.targetingParams = targetingParams
         self.groupPmId = groupPmId
+        self.GPPConfig = gppConfig
     }
 }
 

--- a/ConsentViewController/Classes/SPCampaigns.swift
+++ b/ConsentViewController/Classes/SPCampaigns.swift
@@ -54,6 +54,16 @@ public typealias SPTargetingParams = [String: String]
         self.MspaOptOutOptionMode = MspaOptOutOptionMode
         self.MspaServiceProviderMode = MspaServiceProviderMode
     }
+
+    @objc public init(
+        MspaCoveredTransaction: SPMspaBinaryFlag,
+        MspaOptOutOptionMode: SPMspaTernaryFlag,
+        MspaServiceProviderMode: SPMspaTernaryFlag
+    ) {
+        self.MspaCoveredTransaction = MspaCoveredTransaction
+        self.MspaOptOutOptionMode = MspaOptOutOptionMode
+        self.MspaServiceProviderMode = MspaServiceProviderMode
+    }
 }
 
 /// Contains information about the property/campaign.

--- a/ConsentViewController/Classes/SourcePointClient/ChoiceRequests.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ChoiceRequests.swift
@@ -16,7 +16,7 @@ struct GDPRChoiceBody: Encodable, Equatable {
     let sampleRate: Float?
     let idfaStatus: SPIDFAStatus?
     let granularStatus: ConsentStatus.GranularStatus?
-    let includeData = IncludeData()
+    let includeData: IncludeData
 }
 
 struct CCPAChoiceBody: Encodable, Equatable {
@@ -26,5 +26,5 @@ struct CCPAChoiceBody: Encodable, Equatable {
     let sendPVData: Bool
     let propertyId: Int
     let sampleRate: Float?
-    let includeData = IncludeData()
+    let includeData: IncludeData
 }

--- a/ConsentViewController/Classes/SourcePointClient/IncludeData.swift
+++ b/ConsentViewController/Classes/SourcePointClient/IncludeData.swift
@@ -5,21 +5,38 @@
 //  Created by Andre Herculano on 18.04.23.
 //
 
-// swiftlint:disable line_length
-
 import Foundation
 
-struct IncludeData: Encodable, Equatable {
-    static let string = #"{"TCData":{"type":"RecordString"},"webConsentPayload":{"type":"string"},"localState":{"type":"RecordString"},"categories":true,"translateMessage":true,"GPPData":{"MspaCoveredTransaction":"no","MspaOptOutOptionMode":"na","MspaServiceProviderMode":"na"}}"#
-
+struct IncludeData: Equatable {
     let localState = ["type": "RecordString"]
     let TCData = ["type": "RecordString"]
     let webConsentPayload = ["type": "string"]
     let categories = true
     let translateMessage = true
-    let GPPData = [
-        "MspaCoveredTransaction": "no",
-        "MspaOptOutOptionMode": "na",
-        "MspaServiceProviderMode": "na"
-    ]
+    let gppConfig: SPGPPConfig?
+}
+
+extension IncludeData: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case localState, TCData, webConsentPayload, categories, translateMessage
+        case gppConfig = "GPPData"
+    }
+
+    var string: String? {
+        if let encoded = try? JSONEncoder().encode(self),
+           let stringified = String(data: encoded, encoding: .utf8) {
+            return stringified
+        }
+        return nil
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(localState, forKey: .localState)
+        try container.encode(TCData, forKey: .TCData)
+        try container.encode(webConsentPayload, forKey: .webConsentPayload)
+        try container.encode(categories, forKey: .categories)
+        try container.encode(translateMessage, forKey: .translateMessage)
+        try container.encodeIfPresent(gppConfig, forKey: .gppConfig)
+    }
 }

--- a/ConsentViewController/Classes/SourcePointClient/MessageRequest.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MessageRequest.swift
@@ -43,5 +43,5 @@ struct MessageRequest: Equatable, Encodable {
     let consentLanguage: SPMessageLanguage
     let campaigns: CampaignsRequest
     let pubData: SPPublisherData
-    let includeData = IncludeData()
+    let includeData: IncludeData
 }

--- a/ConsentViewController/Classes/SourcePointClient/MessagesRequest.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MessagesRequest.swift
@@ -40,7 +40,7 @@ struct MessagesRequest: QueryParamEncodable {
         let hasCSP = true
         let campaignEnv: SPCampaignEnv?
         let idfaStatus: SPIDFAStatus?
-        let includeData = IncludeData()
+        let includeData: IncludeData
     }
 
     struct MetaData: QueryParamEncodable {

--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -131,6 +131,7 @@ protocol SourcePointProtocol {
         propertyId: Int,
         metadata: ConsentStatusMetaData,
         authId: String?,
+        includeData: IncludeData,
         handler: @escaping ConsentStatusHandler
     )
 
@@ -148,6 +149,7 @@ protocol SourcePointProtocol {
         accountId: Int,
         propertyId: Int,
         metadata: ChoiceAllMetaDataParam,
+        includeData: IncludeData,
         handler: @escaping ChoiceHandler
     )
 
@@ -367,13 +369,17 @@ class SourcePointClient: SourcePointProtocol {
 
 // MARK: V7 - cost optimised APIs
 extension SourcePointClient {
-    func consentStatusURLWithParams(propertyId: Int, metadata: ConsentStatusMetaData, authId: String?) -> URL? {
+    func consentStatusURLWithParams(
+        propertyId: Int,
+        metadata: ConsentStatusMetaData,
+        includeData: IncludeData,
+        authId: String?) -> URL? {
         var url = Constants.Urls.CONSENT_STATUS_URL.appendQueryItems([
             "propertyId": String(propertyId),
             "metadata": metadata.stringified(),
             "hasCsp": "true",
             "withSiteActions": "false",
-            "includeData": IncludeData.string
+            "includeData": includeData.string
         ])
         if let authId = authId {
             url = url?.appendQueryItems(["authId": authId])
@@ -385,13 +391,15 @@ extension SourcePointClient {
         propertyId: Int,
         metadata: ConsentStatusMetaData,
         authId: String?,
+        includeData: IncludeData,
         handler: @escaping ConsentStatusHandler
     ) {
         guard let url = consentStatusURLWithParams(
             propertyId: propertyId,
             metadata: metadata,
-            authId: authId)
-        else {
+            includeData: includeData,
+            authId: authId
+        ) else {
             handler(Result.failure(InvalidConsentStatusQueryParamsError()))
             return
         }
@@ -461,6 +469,7 @@ extension SourcePointClient {
         propertyId: Int,
         withSiteActions: Bool,
         includeCustomVendorsRes: Bool,
+        includeData: IncludeData,
         metadata: ChoiceAllMetaDataParam
     ) -> URL? {
         var baseUrl: URL
@@ -478,7 +487,7 @@ extension SourcePointClient {
             "withSiteActions": String(withSiteActions),
             "includeCustomVendorsRes": String(includeCustomVendorsRes),
             "metadata": metadata.stringified(),
-            "includeData": IncludeData.string
+            "includeData": includeData.string
         ])
     }
 
@@ -487,6 +496,7 @@ extension SourcePointClient {
         accountId: Int,
         propertyId: Int,
         metadata: ChoiceAllMetaDataParam,
+        includeData: IncludeData,
         handler: @escaping ChoiceHandler
     ) {
         guard let url = choiceAllUrlWithParams(
@@ -496,6 +506,7 @@ extension SourcePointClient {
             propertyId: propertyId,
             withSiteActions: false,
             includeCustomVendorsRes: false,
+            includeData: includeData,
             metadata: metadata
         ) else {
             handler(Result.failure(InvalidChoiceAllParamsError()))

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -146,6 +146,8 @@ class SourcepointClientCoordinator: SPClientCoordinator {
     var gdprUUID: String? { state.gdpr?.uuid }
     var ccpaUUID: String? { state.ccpa?.uuid }
 
+    let includeData: IncludeData
+
     /// Checks if this user has data from the previous version of the SDK (v6).
     /// This check should only done once so we remove the data stored by the older SDK and return false after that.
     var migratingUser: Bool {
@@ -209,7 +211,8 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 ),
                 consentLanguage: language,
                 campaignEnv: campaigns.environment,
-                idfaStatus: idfaStatus
+                idfaStatus: idfaStatus,
+                includeData: includeData
             ),
             metadata: .init(
                 ccpa: .init(applies: state.ccpa?.applies),
@@ -245,6 +248,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         self.propertyName = propertyName
         self.language = language
         self.campaigns = campaigns
+        self.includeData = IncludeData(gppConfig: campaigns.ccpa?.GPPConfig)
         self.storage = storage
         self.spClient = spClient ?? SourcePointClient(
             accountId: accountId,
@@ -441,7 +445,8 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                         state.hasCCPALocalData
                     )
                 ),
-                authId: authId
+                authId: authId,
+                includeData: includeData
             ) { result in
                 switch result {
                     case .success(let response):
@@ -616,7 +621,8 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 metadata: .init(
                     gdpr: campaigns.gdpr != nil ? .init(applies: state.gdpr?.applies ?? false) : nil,
                     ccpa: campaigns.ccpa != nil ? .init(applies: state.ccpa?.applies ?? false) : nil
-                )
+                ),
+                includeData: includeData
             ) { result in
                 switch result {
                     case .success(let response):
@@ -651,7 +657,8 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 propertyId: propertyId,
                 sampleRate: state.gdprMetaData?.sampleRate,
                 idfaStatus: idfaStatus,
-                granularStatus: postPayloadFromGetCall?.granularStatus
+                granularStatus: postPayloadFromGetCall?.granularStatus,
+                includeData: includeData
             )
         ) { handler($0) }
     }
@@ -670,7 +677,8 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 pmSaveAndExitVariables: action.pmPayload,
                 sendPVData: state.ccpaMetaData?.wasSampled ?? false,
                 propertyId: propertyId,
-                sampleRate: state.ccpaMetaData?.sampleRate
+                sampleRate: state.ccpaMetaData?.sampleRate,
+                includeData: includeData
             )
         ) { handler($0) }
     }

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -500,6 +500,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                         state.ccpa?.rejectedCategories = consents.rejectedCategories
                         state.ccpa?.childPmId = consents.childPmId
                         state.ccpa?.webConsentPayload = $0.webConsentPayload
+                        state.ccpa?.GPPData = consents.GPPData
                     default: break
                 }
             }

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -122,6 +122,8 @@
 		822BF2CB2657E29800177B0E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 822BF2C92657E29800177B0E /* Main.storyboard */; };
 		822BF2CD2657E29900177B0E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 822BF2CC2657E29900177B0E /* Assets.xcassets */; };
 		822BF2D02657E29900177B0E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 822BF2CE2657E29900177B0E /* LaunchScreen.storyboard */; };
+		822E88F62A7BC5AF00843B2B /* IncludeDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822E88F52A7BC5AF00843B2B /* IncludeDataSpec.swift */; };
+		822E88F82A7BC8CB00843B2B /* SPGPPConcifgSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822E88F72A7BC8CB00843B2B /* SPGPPConcifgSpec.swift */; };
 		822FD7E02A0BF41D004CD221 /* GenericWebMessageViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822FD7DF2A0BF41D004CD221 /* GenericWebMessageViewControllerSpec.swift */; };
 		8231B14022BA5A6B00D2669B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8231B13F22BA5A6B00D2669B /* AppDelegate.swift */; };
 		8231B14222BA5A6B00D2669B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8231B14122BA5A6B00D2669B /* LoginViewController.swift */; };
@@ -403,6 +405,8 @@
 		822BF2D62657E29900177B0E /* NativePMExampleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NativePMExampleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		822BF2E12657E29900177B0E /* NativePMExampleAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NativePMExampleAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		822BF2E72657E29900177B0E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		822E88F52A7BC5AF00843B2B /* IncludeDataSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncludeDataSpec.swift; sourceTree = "<group>"; };
+		822E88F72A7BC8CB00843B2B /* SPGPPConcifgSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPGPPConcifgSpec.swift; sourceTree = "<group>"; };
 		822FD7DF2A0BF41D004CD221 /* GenericWebMessageViewControllerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericWebMessageViewControllerSpec.swift; sourceTree = "<group>"; };
 		8231B13D22BA5A6B00D2669B /* AuthExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AuthExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8231B13F22BA5A6B00D2669B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -1386,6 +1390,8 @@
 				828AD5572981231A008B4F1E /* CCPAConsentStatusSpec.swift */,
 				82CFB3EE2A431D89002B0EF2 /* SPCCPAConsentSpec.swift */,
 				AAA25A682A28ABFE005FE84A /* SPConsentManagerSpec.swift */,
+				822E88F52A7BC5AF00843B2B /* IncludeDataSpec.swift */,
+				822E88F72A7BC8CB00843B2B /* SPGPPConcifgSpec.swift */,
 			);
 			path = ConsentViewController_ExampleTests;
 			sourceTree = "<group>";
@@ -2728,6 +2734,7 @@
 				8248A497247D17AA00A7D9AD /* SimpleClientSpec.swift in Sources */,
 				828AD5582981231A008B4F1E /* CCPAConsentStatusSpec.swift in Sources */,
 				82C4936028F17A2D00898E7A /* CampaignSpec.swift in Sources */,
+				822E88F62A7BC5AF00843B2B /* IncludeDataSpec.swift in Sources */,
 				6DA66EA3255D1A690034E11A /* SPMessageLanguageSpec.swift in Sources */,
 				82EA4E302491019900DC01C9 /* HttpMock.swift in Sources */,
 				82E3D60728C8F39B004B1189 /* CustomMatchers.swift in Sources */,
@@ -2758,6 +2765,7 @@
 				826D31AD2498DE340026A6B9 /* MockConsentDelegate.swift in Sources */,
 				8248A499247E5FCC00A7D9AD /* SPGDPRConsentsSpec.swift in Sources */,
 				82BB0E6A28BF3433006FBB60 /* SPDateCreatedSpec.swift in Sources */,
+				822E88F82A7BC8CB00843B2B /* SPGPPConcifgSpec.swift in Sources */,
 				6D687AD724A8F1C1001DFB11 /* MessageMock.swift in Sources */,
 				82665C312444ECF600CCE738 /* SPJsonSpec.swift in Sources */,
 				82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */,

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -123,7 +123,7 @@
 		822BF2CD2657E29900177B0E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 822BF2CC2657E29900177B0E /* Assets.xcassets */; };
 		822BF2D02657E29900177B0E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 822BF2CE2657E29900177B0E /* LaunchScreen.storyboard */; };
 		822E88F62A7BC5AF00843B2B /* IncludeDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822E88F52A7BC5AF00843B2B /* IncludeDataSpec.swift */; };
-		822E88F82A7BC8CB00843B2B /* SPGPPConcifgSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822E88F72A7BC8CB00843B2B /* SPGPPConcifgSpec.swift */; };
+		822E88F82A7BC8CB00843B2B /* SPGPPConfigSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822E88F72A7BC8CB00843B2B /* SPGPPConfigSpec.swift */; };
 		822FD7E02A0BF41D004CD221 /* GenericWebMessageViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822FD7DF2A0BF41D004CD221 /* GenericWebMessageViewControllerSpec.swift */; };
 		8231B14022BA5A6B00D2669B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8231B13F22BA5A6B00D2669B /* AppDelegate.swift */; };
 		8231B14222BA5A6B00D2669B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8231B14122BA5A6B00D2669B /* LoginViewController.swift */; };
@@ -406,7 +406,7 @@
 		822BF2E12657E29900177B0E /* NativePMExampleAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NativePMExampleAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		822BF2E72657E29900177B0E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		822E88F52A7BC5AF00843B2B /* IncludeDataSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncludeDataSpec.swift; sourceTree = "<group>"; };
-		822E88F72A7BC8CB00843B2B /* SPGPPConcifgSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPGPPConcifgSpec.swift; sourceTree = "<group>"; };
+		822E88F72A7BC8CB00843B2B /* SPGPPConfigSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPGPPConfigSpec.swift; sourceTree = "<group>"; };
 		822FD7DF2A0BF41D004CD221 /* GenericWebMessageViewControllerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericWebMessageViewControllerSpec.swift; sourceTree = "<group>"; };
 		8231B13D22BA5A6B00D2669B /* AuthExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AuthExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8231B13F22BA5A6B00D2669B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -1391,7 +1391,7 @@
 				82CFB3EE2A431D89002B0EF2 /* SPCCPAConsentSpec.swift */,
 				AAA25A682A28ABFE005FE84A /* SPConsentManagerSpec.swift */,
 				822E88F52A7BC5AF00843B2B /* IncludeDataSpec.swift */,
-				822E88F72A7BC8CB00843B2B /* SPGPPConcifgSpec.swift */,
+				822E88F72A7BC8CB00843B2B /* SPGPPConfigSpec.swift */,
 			);
 			path = ConsentViewController_ExampleTests;
 			sourceTree = "<group>";
@@ -2765,7 +2765,7 @@
 				826D31AD2498DE340026A6B9 /* MockConsentDelegate.swift in Sources */,
 				8248A499247E5FCC00A7D9AD /* SPGDPRConsentsSpec.swift in Sources */,
 				82BB0E6A28BF3433006FBB60 /* SPDateCreatedSpec.swift in Sources */,
-				822E88F82A7BC8CB00843B2B /* SPGPPConcifgSpec.swift in Sources */,
+				822E88F82A7BC8CB00843B2B /* SPGPPConfigSpec.swift in Sources */,
 				6D687AD724A8F1C1001DFB11 /* MessageMock.swift in Sources */,
 				82665C312444ECF600CCE738 /* SPJsonSpec.swift in Sources */,
 				82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */,

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -57,7 +57,12 @@ class SourcePointClientMock: SourcePointProtocol {
         )
     }
 
-    func consentStatus(propertyId: Int, metadata: ConsentStatusMetaData, authId: String?, handler: @escaping ConsentStatusHandler) {
+    func consentStatus(
+        propertyId: Int,
+        metadata: ConsentStatusMetaData,
+        authId: String?,
+        includeData: IncludeData,
+        handler: @escaping ConsentStatusHandler) {
     }
 
     func getMessages(_ params: MessagesRequest, handler: @escaping MessagesHandler) {
@@ -194,6 +199,7 @@ class SourcePointClientMock: SourcePointProtocol {
         accountId: Int,
         propertyId: Int,
         metadata: ChoiceAllMetaDataParam,
+        includeData: IncludeData,
         handler: @escaping ChoiceHandler
     ) {
         handler(.success(ChoiceAllResponse(gdpr: nil, ccpa: nil)))

--- a/Example/ConsentViewController_ExampleTests/IncludeDataSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/IncludeDataSpec.swift
@@ -1,0 +1,50 @@
+//
+//  IncludeDataSpec.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 03.08.23.
+//  Copyright © 2023 CocoaPods. All rights reserved.
+//
+
+@testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
+
+public func stringify<T: Encodable>(_ obj: T) -> String {
+    guard let data = try? JSONEncoder().encode(obj),
+          let metadataString = String(data: data, encoding: .utf8) else {
+        return ""
+    }
+
+    return metadataString
+}
+
+class IncludeDataSpec: QuickSpec {
+    override func spec() {
+        it("can be stringified") {
+            let stringified = stringify(IncludeData(gppConfig: nil))
+            expect(stringified).to(contain(#""localState":{"type":"RecordString"}"#))
+            expect(stringified).to(contain(#""TCData":{"type":"RecordString"}"#))
+            expect(stringified).to(contain(#""webConsentPayload":{"type":"string"}"#))
+            expect(stringified).to(contain(#""categories":true"#))
+            expect(stringified).to(contain(#""translateMessage":true"#))
+        }
+
+        describe("when gpp config is nil") {
+            it("doesn't include gpp data") {
+                expect(stringify(IncludeData(gppConfig: nil))).notTo(contain(
+                    #""GPPData""#
+                ))
+            }
+        }
+
+        describe("when gpp config is present") {
+            it("includes GPPData") {
+                expect(stringify(IncludeData(gppConfig: SPGPPConfig()))).to(contain(
+                    #""GPPData""#
+                ))
+            }
+        }
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -64,6 +64,7 @@ class SPClientCoordinatorSpec: QuickSpec {
                                     expect(consents.gdpr?.consents?.euconsent).notTo(beEmpty())
                                     expect(consents.gdpr?.consents?.vendorGrants).notTo(beEmpty())
                                     expect(consents.ccpa?.consents?.uspstring) == "1---"
+
                                 case .failure(let error):
                                     fail(error.failureReason)
                             }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -83,6 +83,14 @@ class SPClientCoordinatorSpec: QuickSpec {
                                     expect(consents.gdpr?.consents?.euconsent).notTo(beEmpty())
                                     expect(consents.gdpr?.consents?.vendorGrants).notTo(beEmpty())
                                     expect(consents.ccpa?.consents?.uspstring) == "1YNN"
+
+                                    // TODO: remove this conditional once GPP changes are in prod
+                                    if prod {
+                                        expect(consents.ccpa?.consents?.GPPData.dictionaryValue).to(beEmpty())
+                                    } else {
+                                        expect(consents.ccpa?.consents?.GPPData.dictionaryValue).notTo(beEmpty())
+                                    }
+
                                 case .failure(let error):
                                     fail(error.failureReason)
                             }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
@@ -50,7 +50,8 @@ class SourcePointClientSpec: QuickSpec {
                     ccpa: nil,
                     ios14: nil
                 ),
-                pubData: [:]
+                pubData: [:],
+                includeData: IncludeData(gppConfig: nil)
             ))
     }
 
@@ -151,7 +152,8 @@ class SourcePointClientSpec: QuickSpec {
                             campaigns: MessagesRequest.Body.Campaigns(),
                             consentLanguage: .BrowserDefault,
                             campaignEnv: nil,
-                            idfaStatus: nil
+                            idfaStatus: nil,
+                            includeData: IncludeData(gppConfig: nil)
                         ),
                         metadata: MessagesRequest.MetaData(ccpa: nil, gdpr: nil),
                         nonKeyedLocalState: MessagesRequest.NonKeyedLocalState(nonKeyedLocalState: SPJson())
@@ -177,7 +179,8 @@ class SourcePointClientSpec: QuickSpec {
                                 propertyId: 0,
                                 sampleRate: 1,
                                 idfaStatus: nil,
-                                granularStatus: .init()
+                                granularStatus: .init(),
+                                includeData: IncludeData(gppConfig: nil)
                             )
                         ) { _ in }
                         expect(httpClient.postWasCalledWithUrl) == "https://cdn.privacy-mgmt.com/wrapper/v2/choice/gdpr/11?env=prod"
@@ -196,7 +199,8 @@ class SourcePointClientSpec: QuickSpec {
                             propertyId: 0,
                             sampleRate: 1,
                             idfaStatus: nil,
-                            granularStatus: .init()
+                            granularStatus: .init(),
+                            includeData: IncludeData(gppConfig: nil)
                         )
                         client.postGDPRAction(
                             actionType: .AcceptAll,
@@ -219,7 +223,8 @@ class SourcePointClientSpec: QuickSpec {
                                 pmSaveAndExitVariables: nil,
                                 sendPVData: true,
                                 propertyId: 1,
-                                sampleRate: 1
+                                sampleRate: 1,
+                                includeData: IncludeData(gppConfig: nil)
                             )
                         ) { _ in }
                         expect(httpClient.postWasCalledWithUrl) == "https://cdn.privacy-mgmt.com/wrapper/v2/choice/ccpa/11?env=prod"
@@ -234,7 +239,8 @@ class SourcePointClientSpec: QuickSpec {
                             pmSaveAndExitVariables: nil,
                             sendPVData: true,
                             propertyId: 1,
-                            sampleRate: 1
+                            sampleRate: 1,
+                            includeData: IncludeData(gppConfig: nil)
                         )
                         client.postCCPAAction(
                             actionType: .AcceptAll,

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -11,7 +11,7 @@ import Foundation
 import Nimble
 import Quick
 
-// swiftlint:disable force_try line_length function_body_length cyclomatic_complexity
+// swiftlint:disable force_try line_length function_body_length cyclomatic_complexity type_body_length
 
 class UnmockedSourcepointClientSpec: QuickSpec {
     override func spec() {
@@ -37,21 +37,37 @@ class UnmockedSourcepointClientSpec: QuickSpec {
         describe("consentStatusURLWithParams") {
             describe("with auth id") {
                 it("should add the authId query param") {
-                    let url = client.consentStatusURLWithParams(propertyId: propertyId, metadata: emptyMetaData, authId: "john doe")
+                    let url = client.consentStatusURLWithParams(
+                        propertyId: propertyId,
+                        metadata: emptyMetaData,
+                        includeData: IncludeData(gppConfig: nil),
+                        authId: "john doe"
+                    )
                     expect(url?.query).to(contain("authId=john%20doe"))
                 }
             }
 
             describe("without auth id") {
                 it("should not add the authId query param") {
-                    let url = client.consentStatusURLWithParams(propertyId: propertyId, metadata: emptyMetaData, authId: nil)
+                    let url = client.consentStatusURLWithParams(
+                        propertyId: propertyId,
+                        metadata: emptyMetaData,
+                        includeData: IncludeData(gppConfig: nil),
+                        authId: nil
+                    )
                     expect(url?.query).notTo(contain("authId="))
                 }
             }
 
             it("should contain all query params") {
-                let url = client.consentStatusURLWithParams(propertyId: propertyId, metadata: emptyMetaData, authId: nil)
-                let paramsRaw = "env=\(Constants.Urls.envParam)&scriptType=ios&scriptVersion=\(SPConsentManager.VERSION)&hasCsp=true&includeData=\(IncludeData.string)&metadata={}&propertyId=17801&withSiteActions=false"
+                let includeData = IncludeData(gppConfig: nil)
+                let url = client.consentStatusURLWithParams(
+                    propertyId: propertyId,
+                    metadata: emptyMetaData,
+                    includeData: includeData,
+                    authId: nil
+                )
+                let paramsRaw = "env=\(Constants.Urls.envParam)&scriptType=ios&scriptVersion=\(SPConsentManager.VERSION)&hasCsp=true&includeData=\(stringify(includeData))&metadata={}&propertyId=17801&withSiteActions=false"
                 expect(url?.query) == paramsRaw.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
             }
         }
@@ -77,7 +93,9 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                                 idfaStatus: nil
                             )
                         ),
-                        authId: "user_auth_id") { result in
+                        authId: "user_auth_id",
+                        includeData: IncludeData(gppConfig: nil)
+                    ) { result in
                             switch result {
                             case .success(let response):
                                 expect(response).to(beAnInstanceOf(ConsentStatusResponse.self))
@@ -116,7 +134,8 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                             ),
                             consentLanguage: .Spanish,
                             campaignEnv: nil,
-                            idfaStatus: nil
+                            idfaStatus: nil,
+                            includeData: IncludeData(gppConfig: nil)
                         ),
                         metadata: MessagesRequest.MetaData(
                             ccpa: MessagesRequest.MetaData.Campaign(applies: true),
@@ -242,7 +261,8 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                         metadata: .init(
                             gdpr: .init(applies: true),
                             ccpa: .init(applies: true)
-                        )
+                        ),
+                        includeData: IncludeData(gppConfig: nil)
                     ) { result in
                         switch result {
                         case .success(let response):
@@ -269,7 +289,8 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                         metadata: .init(
                             gdpr: .init(applies: true),
                             ccpa: .init(applies: true)
-                        )
+                        ),
+                        includeData: IncludeData(gppConfig: nil)
                     ) { result in
                         switch result {
                         case .success(let response):

--- a/Example/ConsentViewController_ExampleTests/SPGPPConcifgSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPGPPConcifgSpec.swift
@@ -1,0 +1,36 @@
+//
+//  SPGPPConcifgSpec.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 03.08.23.
+//  Copyright © 2023 CocoaPods. All rights reserved.
+//
+
+@testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
+
+class SPGPPConfigSpec: QuickSpec {
+    override func spec() {
+        describe("when all flags are nil") {
+            it("json is an empty object") {
+                expect(SPGPPConfig()).to(encodeToValue("{}"))
+            }
+        }
+
+        describe("when some or all flags are set") {
+            it("json contains only the set flags") {
+                expect(SPGPPConfig(MspaCoveredTransaction: .no)).to(encodeToValue(
+                    #"{"MspaCoveredTransaction":"no"}"#
+                ))
+            }
+        }
+
+        describe("SPMspaBinaryFlag") {
+            it("encodes to a single value") {
+                expect(SPGPPConfig.SPMspaBinaryFlag.no).to(encodeToValue(#""no""#))
+            }
+        }
+    }
+}

--- a/Example/ConsentViewController_ExampleTests/SPGPPConfigSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPGPPConfigSpec.swift
@@ -30,6 +30,17 @@ class SPGPPConfigSpec: QuickSpec {
         describe("SPMspaBinaryFlag") {
             it("encodes to a single value") {
                 expect(SPGPPConfig.SPMspaBinaryFlag.no).to(encodeToValue(#""no""#))
+                expect(SPGPPConfig.SPMspaBinaryFlag.yes).to(encodeToValue(#""yes""#))
+            }
+        }
+
+        describe("SPMspaTernaryFlag") {
+            it("encodes to a single value") {
+                expect(SPGPPConfig.SPMspaTernaryFlag.no).to(encodeToValue(#""no""#))
+                expect(SPGPPConfig.SPMspaTernaryFlag.yes).to(encodeToValue(#""yes""#))
+                expect(SPGPPConfig.SPMspaTernaryFlag.notApplicable).to(
+                    encodeToValue(#""na""#)
+                )
             }
         }
     }

--- a/Example/ObjC-ExampleApp/ViewController.m
+++ b/Example/ObjC-ExampleApp/ViewController.m
@@ -29,14 +29,20 @@
 
     SPPropertyName *propertyName = [[SPPropertyName alloc] init:@"mobile.multicampaign.demo" error:NULL];
 
+    SPGPPConfig *gppConfig = [[SPGPPConfig alloc]
+                              initWithMspaCoveredTransaction:nil
+                              MspaOptOutOptionMode:nil
+                              MspaServiceProviderMode:nil
+    ];
+
     SPCampaign *campaign = [[SPCampaign alloc]
                             initWithTargetingParams: [NSDictionary dictionary]
                             groupPmId: NULL
-                            gppConfig: [SPGPPConfig alloc]];
+                            gppConfig: gppConfig];
 
     SPCampaigns *campaigns = [[SPCampaigns alloc]
                               initWithGdpr: campaign
-                              ccpa: NULL
+                              ccpa: campaign
                               ios14: campaign
                               environment: SPCampaignEnvPublic];
 

--- a/Example/ObjC-ExampleApp/ViewController.m
+++ b/Example/ObjC-ExampleApp/ViewController.m
@@ -31,7 +31,8 @@
 
     SPCampaign *campaign = [[SPCampaign alloc]
                             initWithTargetingParams: [NSDictionary dictionary]
-                            groupPmId: nil];
+                            groupPmId: NULL
+                            gppConfig: [SPGPPConfig alloc]];
 
     SPCampaigns *campaigns = [[SPCampaigns alloc]
                               initWithGdpr: campaign

--- a/Example/ObjC-ExampleAppUITests/CustomMatchers.swift
+++ b/Example/ObjC-ExampleAppUITests/CustomMatchers.swift
@@ -10,6 +10,8 @@ import Nimble
 import Quick
 import XCTest
 
+public typealias Predicate = Nimble.Predicate
+
 /// A matcher that checks if a `XCUIElement` contains the given text
 public func containText(_ text: String) -> Predicate<XCUIElement> {
     Predicate.simple("contain text") { actualExpression in

--- a/Example/ObjC-ExampleAppUITests/ExampleApp.swift
+++ b/Example/ObjC-ExampleAppUITests/ExampleApp.swift
@@ -66,12 +66,16 @@ class ExampleApp: XCUIApplication {
         staticTexts["unknown"].exists
     }
 
-    var consentMessage: XCUIElement {
+    var gdprMessage: XCUIElement {
         webViews.first(withLabel: "GDPR Message")
     }
 
+    var ccpaMessage: XCUIElement {
+        webViews.first(withLabel: "CCPA Message")
+    }
+
     var acceptAllButton: XCUIElement {
-        consentMessage.buttons.first(withLabel: "Accept")
+        buttons.first(withLabel: "Accept")
     }
 
     var sdkStatus: XCUIElement {

--- a/Example/ObjC-ExampleAppUITests/ObjC_ExampleAppUITests.swift
+++ b/Example/ObjC-ExampleAppUITests/ObjC_ExampleAppUITests.swift
@@ -52,9 +52,16 @@ class ObjCExampleAppUITests: QuickSpec {
 
         it("Accept all through message") {
             runAttScenario()
-            expect(self.app.consentMessage).toEventually(showUp())
+            expect(self.app.gdprMessage).toEventually(showUp())
             self.app.acceptAllButton.tap()
-            expect(self.app.consentMessage).to(disappear())
+            expect(self.app.gdprMessage).to(disappear())
+
+            expect(self.app.ccpaMessage).toEventually(showUp())
+            self.app.acceptAllButton.tap()
+            expect(self.app.ccpaMessage).to(disappear())
+
+            expect(self.app.sdkStatus).toEventually(containText("Finished"))
+
             self.app.relaunch()
             expect(self.app.sdkStatus).toEventually(containText("Finished"))
         }


### PR DESCRIPTION
In the temporary GPP solution, the client should have the option to set some flags for GPP. 
Those flags are exposed as an attribute of `SPCampaigns` called `gppConfig: SPGPPConfig`. 

Although the config is available for all campaigns, the SDK only utilises the gppConfig of the ccpa campaign. 