### PR TITLE
DIA-2541 implement local data versioning

### DIFF
--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -11,7 +11,7 @@ import Foundation
 import Nimble
 import Quick
 
-// swiftlint:disable force_try function_body_length file_length
+// swiftlint:disable force_try function_body_length file_length type_body_length
 
 class SPClientCoordinatorSpec: QuickSpec {
     override func spec() {

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -158,7 +158,7 @@ class SPClientCoordinatorSpec: QuickSpec {
             }
         }
 
-        fdescribe("consent-status") {
+        describe("consent-status") {
             it("is called when an authId is passed") {
                 waitUntil { done in
                     spClientMock = SourcePointClientMock()

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -11,7 +11,7 @@ import Foundation
 import Nimble
 import Quick
 
-// swiftlint:disable force_try function_body_length
+// swiftlint:disable force_try function_body_length file_length
 
 class SPClientCoordinatorSpec: QuickSpec {
     override func spec() {
@@ -151,6 +151,188 @@ class SPClientCoordinatorSpec: QuickSpec {
                                     let body = spClientMock.postCCPAActionCalledWith["body"] as? CCPAChoiceBody
                                     expect(body?.pubData).to(equal(ccpaAction.encodablePubData))
                             }
+                            done()
+                        }
+                    }
+                }
+            }
+        }
+
+        fdescribe("consent-status") {
+            it("is called when an authId is passed") {
+                waitUntil { done in
+                    spClientMock = SourcePointClientMock()
+                    coordinator = SourcepointClientCoordinator(
+                        accountId: accountId,
+                        propertyName: propertyName,
+                        propertyId: propertyId,
+                        campaigns: campaigns,
+                        storage: LocalStorageMock(),
+                        spClient: spClientMock
+                    )
+                    coordinator.loadMessages(forAuthId: "test", pubData: nil) { _ in
+                        expect(spClientMock.consentStatusCalled).to(beTrue())
+                        expect(coordinator.shouldCallConsentStatus).to(beTrue())
+                        done()
+                    }
+                }
+            }
+
+            it("is called when the SDK detects local data from v6") {
+                waitUntil { done in
+                    let storage = LocalStorageMock()
+                    storage.localState = try? SPJson([
+                        "gdpr": [
+                            "uuid": "test"
+                        ]
+                    ])
+                    spClientMock = SourcePointClientMock()
+                    coordinator = SourcepointClientCoordinator(
+                        accountId: accountId,
+                        propertyName: propertyName,
+                        propertyId: propertyId,
+                        campaigns: campaigns,
+                        storage: storage,
+                        spClient: spClientMock
+                    )
+                    coordinator.loadMessages(forAuthId: nil, pubData: nil) { _ in
+                        expect(spClientMock.consentStatusCalled).to(beTrue())
+                        done()
+                    }
+                }
+            }
+
+            describe("when local data is outdated") {
+                describe("and it has NO uuid stored") {
+                    it("consent-status is not called") {
+                        waitUntil { done in
+                            let storage = LocalStorageMock()
+                            storage.spState = SourcepointClientCoordinator.State(localVersion: 0)
+                            spClientMock = SourcePointClientMock()
+                            coordinator = SourcepointClientCoordinator(
+                                accountId: accountId,
+                                propertyName: propertyName,
+                                propertyId: propertyId,
+                                campaigns: campaigns,
+                                storage: storage,
+                                spClient: spClientMock
+                            )
+                            coordinator.loadMessages(forAuthId: nil, pubData: nil) { _ in
+                                expect(spClientMock.consentStatusCalled).to(beFalse())
+                                done()
+                            }
+                        }
+                    }
+                }
+
+                describe("and it has any uuid stored") {
+                    it("consent-status is called") {
+                        waitUntil { done in
+                            let storage = LocalStorageMock()
+                            let consents = SPGDPRConsent.empty()
+                            consents.uuid = "test"
+                            storage.spState = SourcepointClientCoordinator.State(
+                                gdpr: consents,
+                                localVersion: 0
+                            )
+                            spClientMock = SourcePointClientMock()
+                            coordinator = SourcepointClientCoordinator(
+                                accountId: accountId,
+                                propertyName: propertyName,
+                                propertyId: propertyId,
+                                campaigns: campaigns,
+                                storage: storage,
+                                spClient: spClientMock
+                            )
+                            coordinator.loadMessages(forAuthId: nil, pubData: nil) { _ in
+                                expect(spClientMock.consentStatusCalled).to(beTrue())
+                                done()
+                            }
+                        }
+                    }
+                }
+
+                it("is not called again after it's been called first time") {
+                    waitUntil { done in
+                        let storage = LocalStorageMock()
+                        let consents = SPGDPRConsent.empty()
+                        consents.uuid = "test"
+                        storage.spState = SourcepointClientCoordinator.State(
+                            gdpr: consents,
+                            localVersion: 0
+                        )
+                        spClientMock = SourcePointClientMock()
+                        coordinator = SourcepointClientCoordinator(
+                            accountId: accountId,
+                            propertyName: propertyName,
+                            propertyId: propertyId,
+                            campaigns: campaigns,
+                            storage: storage,
+                            spClient: spClientMock
+                        )
+                        coordinator.loadMessages(forAuthId: nil, pubData: nil) { _ in
+                            expect(spClientMock.consentStatusCalled).to(beTrue())
+                            spClientMock.consentStatusCalled = false
+
+                            coordinator.loadMessages(forAuthId: nil, pubData: nil) { _ in
+                                expect(spClientMock.consentStatusCalled).to(beFalse())
+                                done()
+                            }
+                        }
+                    }
+                }
+            }
+
+            describe("when succeeds") {
+                it("sets the localDataVersion attribute to be the same as the hardcoded one") {
+                    waitUntil { done in
+                        let storage = LocalStorageMock()
+                        let consents = SPGDPRConsent.empty()
+                        consents.uuid = "test"
+                        storage.spState = SourcepointClientCoordinator.State(
+                            gdpr: consents,
+                            localVersion: 0
+                        )
+                        spClientMock = SourcePointClientMock()
+                        coordinator = SourcepointClientCoordinator(
+                            accountId: accountId,
+                            propertyName: propertyName,
+                            propertyId: propertyId,
+                            campaigns: campaigns,
+                            storage: storage,
+                            spClient: spClientMock
+                        )
+                        coordinator.loadMessages(forAuthId: nil, pubData: nil) { _ in
+                            expect(coordinator.state.localVersion)
+                                .to(equal(SourcepointClientCoordinator.State.version))
+                            done()
+                        }
+                    }
+                }
+            }
+
+            describe("when it fails") {
+                it("leaves localDataVersion as is") {
+                    waitUntil { done in
+                        let storage = LocalStorageMock()
+                        let consents = SPGDPRConsent.empty()
+                        consents.uuid = "test"
+                        storage.spState = SourcepointClientCoordinator.State(
+                            gdpr: consents,
+                            localVersion: 0
+                        )
+                        spClientMock = SourcePointClientMock()
+                        spClientMock.error = SPError()
+                        coordinator = SourcepointClientCoordinator(
+                            accountId: accountId,
+                            propertyName: propertyName,
+                            propertyId: propertyId,
+                            campaigns: campaigns,
+                            storage: storage,
+                            spClient: spClientMock
+                        )
+                        coordinator.loadMessages(forAuthId: nil, pubData: nil) { _ in
+                            expect(coordinator.state.localVersion).to(equal(0))
                             done()
                         }
                     }


### PR DESCRIPTION
When new consent data is introduced (such as `GPPData`), the SDK will need to call `/consent-status` . 

We’ll implement that logic via local data versioning.

1. The SDK will have a hardcoded version value, starting at 1
2. The SDK will have a stored local data version.
3. When calling loadMessage , the SDK checks if its stored local data version is different than the hardcoded one.
    1. If version is different, call /consent-status (or authId is present)
        * on /consent-status response, update stored local data version to be equal to hardcoded one
    2. If version is the same, message flow continues

Following the logic above, whenever we determine the SDK should get new consent data, we simply increase the hardcoded version and release the code.

In the future we can think of having an endpoint returning the local data version, so we can increase its value remotely, without the need to release a new SDK. 