### PR TITLE
DIA-2621 add usnat to `/meta-data`

### DIFF
--- a/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
@@ -150,7 +150,7 @@ protocol CampaignConsent {
 
     override open var description: String {
         """
-        UserConsent(
+        SPCCPAConsent(
             - uuid: \(uuid ?? "")
             - status: \(status.rawValue)
             - rejectedVendors: \(rejectedVendors)

--- a/ConsentViewController/Classes/Consents/SPUSNatConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPUSNatConsent.swift
@@ -1,0 +1,61 @@
+//
+//  SPUSNatConsent.swift
+//  Pods
+//
+//  Created by Andre Herculano on 02.11.23.
+//
+
+import Foundation
+
+@objcMembers public class SPUSNatConsent: NSObject, Codable, CampaignConsent, NSCopying {
+    var uuid: String?
+
+    var applies: Bool
+
+    var dateCreated: SPDate
+
+    /// Used by the rendering app
+    var webConsentPayload: SPWebConsentPayload?
+
+    override open var description: String {
+        """
+        SPUSNatConsent(
+            - uuid: \(uuid ?? "")
+            - applies: \(applies)
+            - dateCreated: \(dateCreated)
+        )
+        """
+    }
+
+    init(
+        uuid: String? = nil,
+        applies: Bool,
+        dateCreated: SPDate,
+        webConsentPayload: SPWebConsentPayload? = nil
+    ) {
+        self.uuid = uuid
+        self.applies = applies
+        self.dateCreated = dateCreated
+    }
+
+    public static func empty() -> SPUSNatConsent { SPUSNatConsent(
+        applies: false,
+        dateCreated: .now()
+    )}
+
+    override public func isEqual(_ object: Any?) -> Bool {
+        if let other = object as? SPUSNatConsent {
+            return other.uuid == uuid &&
+                other.applies == applies
+        } else {
+            return false
+        }
+    }
+
+    public func copy(with zone: NSZone? = nil) -> Any { SPUSNatConsent(
+        uuid: uuid,
+        applies: applies,
+        dateCreated: dateCreated,
+        webConsentPayload: webConsentPayload
+    )}
+}

--- a/ConsentViewController/Classes/Consents/SPUserData.swift
+++ b/ConsentViewController/Classes/Consents/SPUserData.swift
@@ -150,7 +150,7 @@ public protocol SPObjcUserData {
         usnat?.consents
     }
 
-    /// Indicates whether GDPR applies based on the VendorList configuration.
+    /// Indicates whether USNat applies based on the VendorList configuration.
     public func objcUSNatApplies() -> Bool {
         usnat?.applies ?? false
     }

--- a/ConsentViewController/Classes/Consents/SPUserData.swift
+++ b/ConsentViewController/Classes/Consents/SPUserData.swift
@@ -20,17 +20,17 @@ public struct SPWebConsents: Codable, Equatable {
         }
     }
 
-    let gdpr: SPWebConsent?
-    let ccpa: SPWebConsent?
+    let gdpr, ccpa, usnat: SPWebConsent?
 
-    public init(gdpr: SPWebConsent? = nil, ccpa: SPWebConsent? = nil) {
+    public init(gdpr: SPWebConsent? = nil, ccpa: SPWebConsent? = nil, usnat: SPWebConsent? = nil) {
         self.gdpr = gdpr
         self.ccpa = ccpa
+        self.usnat = usnat
     }
 }
 
 public class SPConsent<ConsentType: Codable & Equatable & NSCopying>: NSObject, Codable, NSCopying {
-    /// The consents data. See: `SPGDPRConsent`, `SPCCPAConsent`
+    /// The consents data. See: `SPGDPRConsent`, `SPCCPAConsent`, `SPUSNatConsent`
     public let consents: ConsentType?
 
     // swiftlint:disable:next todo
@@ -66,27 +66,35 @@ public class SPConsent<ConsentType: Codable & Equatable & NSCopying>: NSObject, 
     /// - SeeAlso: `SPCCPAConsent`
     public let ccpa: SPConsent<SPCCPAConsent>?
 
+    /// Consent data for USNat. This attribute will be nil if your setup doesn't include a CCPA campaign
+    /// - SeeAlso: `SPUSNatConsent`
+    public let usnat: SPConsent<SPUSNatConsent>?
+
     var webConsents: SPWebConsents { SPWebConsents(
         gdpr: .init(uuid: gdpr?.consents?.uuid, webConsentPayload: gdpr?.consents?.webConsentPayload),
-        ccpa: .init(uuid: ccpa?.consents?.uuid, webConsentPayload: ccpa?.consents?.webConsentPayload)
+        ccpa: .init(uuid: ccpa?.consents?.uuid, webConsentPayload: ccpa?.consents?.webConsentPayload),
+        usnat: .init(uuid: usnat?.consents?.uuid, webConsentPayload: usnat?.consents?.webConsentPayload)
     )}
 
     override public var description: String {
-        "gdpr: \(String(describing: gdpr)), ccpa: \(String(describing: ccpa))"
+        "gdpr: \(String(describing: gdpr)), ccpa: \(String(describing: ccpa)), usnat: \(String(describing: usnat))"
     }
 
     public init(
         gdpr: SPConsent<SPGDPRConsent>? = nil,
-        ccpa: SPConsent<SPCCPAConsent>? = nil
+        ccpa: SPConsent<SPCCPAConsent>? = nil,
+        usnat: SPConsent<SPUSNatConsent>? = nil
     ) {
         self.gdpr = gdpr
         self.ccpa = ccpa
+        self.usnat = usnat
     }
 
     public func copy(with zone: NSZone? = nil) -> Any {
         SPUserData(
             gdpr: gdpr?.copy() as? SPConsent<SPGDPRConsent>,
-            ccpa: ccpa?.copy() as? SPConsent<SPCCPAConsent>
+            ccpa: ccpa?.copy() as? SPConsent<SPCCPAConsent>,
+            usnat: usnat?.copy() as? SPConsent<SPUSNatConsent>
         )
     }
 
@@ -95,7 +103,9 @@ public class SPConsent<ConsentType: Codable & Equatable & NSCopying>: NSObject, 
             return  gdpr?.applies == object.gdpr?.applies &&
                     gdpr?.consents == object.gdpr?.consents &&
                     ccpa?.applies == object.ccpa?.applies &&
-                    ccpa?.consents == object.ccpa?.consents
+                    ccpa?.consents == object.ccpa?.consents &&
+                    usnat?.applies == object.usnat?.applies &&
+                    usnat?.consents == object.usnat?.consents
         } else {
             return false
         }
@@ -107,6 +117,8 @@ public protocol SPObjcUserData {
     func objcGDPRApplies() -> Bool
     func objcCCPAConsents() -> SPCCPAConsent?
     func objcCCPAApplies() -> Bool
+    func objcUSNatConsents() -> SPUSNatConsent?
+    func objcUSNatApplies() -> Bool
 }
 
 @objc extension SPUserData: SPObjcUserData {
@@ -121,14 +133,25 @@ public protocol SPObjcUserData {
         gdpr?.applies ?? false
     }
 
-    /// Returns GDPR consent data if any available.
+    /// Returns CCPA consent data if any available.
     /// - SeeAlso: `SPCCPAConsent`
     public func objcCCPAConsents() -> SPCCPAConsent? {
         ccpa?.consents
     }
 
-    /// Indicates whether GDPR applies based on the VendorList configuration.
+    /// Indicates whether CCPA applies based on the VendorList configuration.
     public func objcCCPAApplies() -> Bool {
         ccpa?.applies ?? false
+    }
+
+    /// Returns USNat consent data if any available.
+    /// - SeeAlso: `SPUSNatConsent`
+    public func objcUSNatConsents() -> SPUSNatConsent? {
+        usnat?.consents
+    }
+
+    /// Indicates whether GDPR applies based on the VendorList configuration.
+    public func objcUSNatApplies() -> Bool {
+        usnat?.applies ?? false
     }
 }

--- a/ConsentViewController/Classes/SPCampaigns.swift
+++ b/ConsentViewController/Classes/SPCampaigns.swift
@@ -99,18 +99,18 @@ public typealias SPTargetingParams = [String: String]
     }
 }
 
-/// Set `gdpr` and/or `ccpa` if you wish to cover any of those legislations.
 /// It's important to notice the campaign you passed as parameter needs to have
 /// a active vendor list of that legislation.
 @objcMembers public class SPCampaigns: NSObject {
     public let environment: SPCampaignEnv
-    public let gdpr, ccpa, ios14: SPCampaign?
+    public let gdpr, ccpa, usnat, ios14: SPCampaign?
 
     override public var description: String {
         """
         SPCampaigns
             - gdpr: \(gdpr as Any)
             - cppa: \(ccpa as Any)
+            - usnat: \(usnat as Any)
             - ios14: \(ios14 as Any)
             - environment: \(environment)
         """
@@ -119,11 +119,13 @@ public typealias SPTargetingParams = [String: String]
     public init(
         gdpr: SPCampaign? = nil,
         ccpa: SPCampaign? = nil,
+        usnat: SPCampaign? = nil,
         ios14: SPCampaign? = nil,
         environment: SPCampaignEnv = .Public
     ) {
         self.gdpr = gdpr
         self.ccpa = ccpa
+        self.usnat = usnat
         self.ios14 = ios14
         self.environment = environment
     }

--- a/ConsentViewController/Classes/SourcePointClient/MetaDataRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MetaDataRequestResponse.swift
@@ -15,7 +15,6 @@ struct MetaDataResponse: Decodable, Equatable {
     struct GDPR: Decodable, Equatable {
         let additionsChangeDate: SPDate
         let legalBasisChangeDate: SPDate
-        let version: Int
         let _id: String
         let childPmId: String?
         let applies: Bool
@@ -26,7 +25,6 @@ struct MetaDataResponse: Decodable, Equatable {
         let additionsChangeDate: SPDate
         let applies: Bool
         let sampleRate: Float
-        let version: Int // TODO: ask Dan T if we should care about version
     }
 
     let ccpa: CCPA?

--- a/ConsentViewController/Classes/SourcePointClient/MetaDataRequestResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MetaDataRequestResponse.swift
@@ -21,9 +21,17 @@ struct MetaDataResponse: Decodable, Equatable {
         let applies: Bool
         let sampleRate: Float
     }
+    struct USNat: Decodable, Equatable {
+        let _id: String
+        let additionsChangeDate: SPDate
+        let applies: Bool
+        let sampleRate: Float
+        let version: Int // TODO: ask Dan T if we should care about version
+    }
 
     let ccpa: CCPA?
     let gdpr: GDPR?
+    let usnat: USNat?
 }
 
 struct MetaDataQueryParam: QueryParamEncodable {
@@ -31,5 +39,5 @@ struct MetaDataQueryParam: QueryParamEncodable {
         let groupPmId: String?
     }
 
-    let gdpr, ccpa: Campaign?
+    let gdpr, ccpa, usnat: Campaign?
 }

--- a/Example/ConsentViewController.xcodeproj/project.pbxproj
+++ b/Example/ConsentViewController.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@
 		82EA4E362491328A00DC01C9 /* InMemoryStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */; };
 		82EA4FA42488EB7300BA48BF /* SPUserDefaultsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82ACF6AB2487E73C006E207A /* SPUserDefaultsSpec.swift */; };
 		82EA4FA62489171200BA48BF /* UserDefaultsExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EA4FA52489171200BA48BF /* UserDefaultsExtensionSpec.swift */; };
+		82F136452AF3E78A0047A6F8 /* SPUSNatConsentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F136442AF3E78A0047A6F8 /* SPUSNatConsentSpec.swift */; };
 		82F9411824A10379007D30B1 /* CustomMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F9411724A10379007D30B1 /* CustomMatchers.swift */; };
 		82F9411A24A10416007D30B1 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F9411924A10416007D30B1 /* ExampleApp.swift */; };
 		82FA47732A3C90DC0065BF6D /* SPPublisherDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FA47722A3C90DC0065BF6D /* SPPublisherDataSpec.swift */; };
@@ -741,6 +742,7 @@
 		82EA4E332491324400DC01C9 /* LocalStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LocalStorageMock.swift; path = Helpers/LocalStorageMock.swift; sourceTree = "<group>"; };
 		82EA4E352491328A00DC01C9 /* InMemoryStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InMemoryStorageMock.swift; path = Helpers/InMemoryStorageMock.swift; sourceTree = "<group>"; };
 		82EA4FA52489171200BA48BF /* UserDefaultsExtensionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtensionSpec.swift; sourceTree = "<group>"; };
+		82F136442AF3E78A0047A6F8 /* SPUSNatConsentSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPUSNatConsentSpec.swift; sourceTree = "<group>"; };
 		82F9411724A10379007D30B1 /* CustomMatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMatchers.swift; sourceTree = "<group>"; };
 		82F9411924A10416007D30B1 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 		82FA47722A3C90DC0065BF6D /* SPPublisherDataSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPPublisherDataSpec.swift; sourceTree = "<group>"; };
@@ -1929,6 +1931,7 @@
 				AAA25A682A28ABFE005FE84A /* SPConsentManagerSpec.swift */,
 				822E88F52A7BC5AF00843B2B /* IncludeDataSpec.swift */,
 				822E88F72A7BC8CB00843B2B /* SPGPPConfigSpec.swift */,
+				82F136442AF3E78A0047A6F8 /* SPUSNatConsentSpec.swift */,
 			);
 			path = ConsentViewController_ExampleTests;
 			sourceTree = "<group>";
@@ -3561,6 +3564,7 @@
 				82BB0E6A28BF3433006FBB60 /* SPDateCreatedSpec.swift in Sources */,
 				822E88F82A7BC8CB00843B2B /* SPGPPConfigSpec.swift in Sources */,
 				6D687AD724A8F1C1001DFB11 /* MessageMock.swift in Sources */,
+				82F136452AF3E78A0047A6F8 /* SPUSNatConsentSpec.swift in Sources */,
 				82665C312444ECF600CCE738 /* SPJsonSpec.swift in Sources */,
 				82EA4E32249101EC00DC01C9 /* SourcePointClientMock.swift in Sources */,
 				826D31B1249A46C40026A6B9 /* GDPRUIiDelegateMock.swift in Sources */,

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -237,7 +237,7 @@ class SourcePointClientMock: SourcePointProtocol {
         if let error = error {
             handler(.failure(error))
         } else {
-            handler(.success(.init(ccpa: nil, gdpr: nil)))
+            handler(.success(.init(ccpa: nil, gdpr: nil, usnat: nil)))
         }
     }
 

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -503,5 +503,33 @@ class SPClientCoordinatorSpec: QuickSpec {
                 }
             }
         }
+
+        // TODO: remove fdescribe
+        fdescribe("a property with USNat campaign") {
+            beforeEach {
+                coordinator = SourcepointClientCoordinator(
+                    accountId: accountId,
+                    propertyName: try! SPPropertyName("staging.mobile.demo"),
+                    propertyId: 8292,
+                    campaigns: SPCampaigns(usnat: SPCampaign()),
+                    storage: LocalStorageMock()
+                )
+            }
+
+            it("returns empty usnat user data with applies true") {
+                waitUntil { done in
+                    coordinator.loadMessages(forAuthId: nil, pubData: nil) { result in
+                        switch result {
+                            case .success(let (_, consents)):
+                                expect(consents.usnat?.consents?.applies).to(beTrue())
+
+                            case .failure(let error):
+                                fail(error.failureReason)
+                        }
+                        done()
+                    }
+                }
+            }
+        }
     }
 }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -205,6 +205,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
             }
         }
 
+        // TODO: setup USNat campaign on property 17801
         describe("meta-data") {
             it("should call the endpoint and parse the response into MetaDataResponse") {
                 waitUntil { done in
@@ -212,7 +213,8 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                                     propertyId: 17_801,
                                     metadata: MetaDataQueryParam(
                                         gdpr: .init(groupPmId: nil),
-                                        ccpa: .init(groupPmId: nil)
+                                        ccpa: .init(groupPmId: nil),
+                                        usnat: nil
                                     )) {
                             switch $0 {
                             case .success(let response):
@@ -229,13 +231,16 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                     }
                 }
             }
+
+            // TODO: setup USNat campaign on property 17801
             it("Check if groupPmId echo") {
                 waitUntil { done in
                     client.metaData(accountId: accountId,
                                     propertyId: 17_801,
                                     metadata: MetaDataQueryParam(
                                         gdpr: .init(groupPmId: "99999999999"),
-                                        ccpa: .init(groupPmId: nil)
+                                        ccpa: .init(groupPmId: nil),
+                                        usnat: nil
                                     )) {
                             switch $0 {
                             case .success(let response):

--- a/Example/ConsentViewController_ExampleTests/SPConsentSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPConsentSpec.swift
@@ -40,8 +40,19 @@ class SPConsentSpec: QuickSpec {
         }
     """
 
+    let usNatConsents = """
+        {
+            "applies": false,
+            "consents": {
+                "applies": false,
+                "dateCreated": "2124-10-27T16:59:00.092Z"
+            }
+        }
+    """
+
     override func spec() {
-        describe("SPConsent") {
+        // TODO: remove fdescribe
+        fdescribe("SPConsent") {
             describe("GDPR") {
                 it("can be decode from JSON") {
                     expect(self.gdprConsents).to(decodeToValue(
@@ -54,6 +65,14 @@ class SPConsentSpec: QuickSpec {
                 it("can be decode from JSON") {
                     expect(self.ccpaConsents).to(decodeToValue(
                         SPConsent<SPCCPAConsent>(consents: .empty(), applies: true)
+                    ))
+                }
+            }
+
+            describe("USNat") {
+                it("can be decode from JSON") {
+                    expect(self.usNatConsents).to(decodeToValue(
+                        SPConsent<SPUSNatConsent>(consents: .empty(), applies: false)
                     ))
                 }
             }

--- a/Example/ConsentViewController_ExampleTests/SPUSNatConsentSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPUSNatConsentSpec.swift
@@ -1,0 +1,43 @@
+//
+//  SPUSNatConsentSpec.swift
+//  ConsentViewController_ExampleTests
+//
+//  Created by Andre Herculano on 02.11.23.
+//  Copyright © 2023 CocoaPods. All rights reserved.
+//
+
+@testable import ConsentViewController
+import Foundation
+import Nimble
+import Quick
+
+class SPUSNatConsentsSpec: QuickSpec {
+    override func spec() {
+        // TODO: remove fdescribe
+        fdescribe("static empty()") {
+            it("contain empty defaults for all its fields") {
+                let consents = SPUSNatConsent.empty()
+                expect(consents.uuid).to(beNil())
+                expect(consents.applies).to(beFalse())
+                expect(consents.dateCreated.date.doubleValue).to(beCloseTo(SPDate(date: Date()).date.doubleValue, within: 0.001))
+            }
+        }
+
+        // TODO: remove fit
+        fit("is Codable") {
+            let usnatConsents = Result { """
+                {
+                    "applies": true,
+                    "dateCreated": "2023-02-06T16:20:53.707Z",
+                }
+                """.data(using: .utf8)
+            }
+            let consent = try usnatConsents.decoded() as SPUSNatConsent
+            expect(consent.applies).to(beTrue())
+            let date = Calendar.current.dateComponents([.day, .year, .month], from: consent.dateCreated.date)
+            expect(date.year).to(equal(2023))
+            expect(date.month).to(equal(02))
+            expect(date.day).to(equal(06))
+        }
+    }
+}

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -28,954 +28,958 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		009AB2408CA2894D8A7BA08746194FA5 /* CustomInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = E105D4CE3E1294C57780FD40F1B18C84 /* CustomInline.swift */; };
-		011B815709A47B8B6C76BD4FB3F1B99F /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F278F01ABEA6ADF72283305E88470CB /* Image.swift */; };
 		012B5C533F0D383B85D0376627B20DBA /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E52D2EDA2417EA4BA098CEFF6FAFE64 /* QuickTestSuite.swift */; };
 		012DAC50FDCA77492197A6E4BF248249 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = A2951E938C866691A0A2B9D510DCC6B0 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		021AF1A4B14E13683A2701099605008F /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AB079CF093527A4CFFAB09421335E5 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		022B1141357B4396AD2B271E32957C79 /* SPAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5475A5AA0068B5C7E68B5F416E428AA8 /* SPAction.swift */; };
 		02339A7908BF70B860FC985F334486CB /* JSONView-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 90B9957458BA7BE9BCF5C8E5AE2DCAFE /* JSONView-dummy.m */; };
-		0266BD3A3F06AC7599F48CDE46A97479 /* SPCampaignType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E84631157C0FF4981393CCAC765E14C /* SPCampaignType.swift */; };
+		02A38A93D00327FA02959C9711652F26 /* CustomConsentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312B839222265C5ABB21AEF7BDE52787 /* CustomConsentRequest.swift */; };
 		038B9A29198D9ECD65A926483B0BC6B4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
 		041B655D7F5932F03A65C154BC02BDAA /* IQInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED145CB8610837DAAB01AA6075562DD1 /* IQInvocation.swift */; };
-		0424A7BCA93D1423F1F13C0CC78C0ADB /* Paragraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B06ABE9E1342072D5858485F4F012E /* Paragraph.swift */; };
+		04302C24091025617A3C500B6DF3265D /* images in Resources */ = {isa = PBXBuildFile; fileRef = 581B8A297C5BCB99513CA8A43ABE49C6 /* images */; };
 		0496E7FAA26B24DA18937A4524CCCA7F /* RequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03360C3F37767F8978ECE6727624F1A /* RequestModel.swift */; };
 		04B0884964D9592302CA654E0B67E80E /* IQUIView+Hierarchy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0758C78A136FF46598392E3AC4DF0F9F /* IQUIView+Hierarchy.swift */; };
+		04E91FC349F89514314BE68387CAAE0C /* xml.c in Sources */ = {isa = PBXBuildFile; fileRef = 329F04CD8054B9D66AD1907605155E24 /* xml.c */; };
 		0514FCE6C64ADACA6745A4CC96A273D4 /* RequestModelBeautifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE05B6F5D5849C89D668385AE14DCBB5 /* RequestModelBeautifier.swift */; };
-		053EDC69C349C009E70B471DCAA43B2F /* ChoiceAllResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A817DE3655D89F8A82DE70045E8F51 /* ChoiceAllResponse.swift */; };
-		05944220BB1C9B120A79643BDEDAAC4D /* ChoiceRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439477ADCB521D4280C2A22395DF57E6 /* ChoiceRequests.swift */; };
+		0580F0E80B4C0D9B6A1C6221B36E718D /* ChoiceRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE5CB34B4AB1F63B2555EF3D87038CC /* ChoiceRequests.swift */; };
 		06729E48F280BABCE74C78167FB765DA /* DispatchTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878715BE17B7F8EEE0EE94835AE58C98 /* DispatchTimeInterval.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		075465E922CB9ED59B364962D6502A14 /* DownOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45116B4FE9CE942C3675B2BF08E8A83D /* DownOptions.swift */; };
+		06837F9F37D4713F9838A687323812A5 /* Down-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A88CE3A6E51C34187F86281DB75F54E7 /* Down-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06DDAC82CE15DCCA6E2F717E8E97F1E6 /* ConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1F1E83882B9DE7318ECFE065AAC229 /* ConnectivityManager.swift */; };
 		07971B868D8F8E3F0A93C6AA7957028A /* Pods-ConsentViewController_ExampleTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 047053BC498C04B9C5A54C9248EA470E /* Pods-ConsentViewController_ExampleTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		07987665D33F063D56F38605B3294C35 /* DownLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340BD7B6229112CF361278C3D4A29AC1 /* DownLayoutManager.swift */; };
-		07C2A05D4B726006EE5D1E3A877C8096 /* SPDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC16C315EDCAE62E1828446CBE23901 /* SPDelegate.swift */; };
 		07EE025F95C44FB172AF02EA33C17C01 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14D9A75C6D0D148766A787E6DAEEEA2 /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		0852D072998EB3EAF3644D6D6F6CFF80 /* MessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28EA9FB3734CAE2118135175D98F1D20 /* MessageRequest.swift */; };
+		089034098C0B0C3BFBFD0C724E452C31 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7B86DCBBC1489611E4530C9CDEB342 /* Constants.swift */; };
 		08A59FAAA2349A1A6C20E57187B31AEB /* Pods-ConsentViewController_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 53CCA4DCC9B066F8E74E39A9D62DE1AB /* Pods-ConsentViewController_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		08B185E08278AE7EC55F8BBB19693AC5 /* IQKeyboardManager+OrientationNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5047CC804189E94A9B3CEAB093F0C53A /* IQKeyboardManager+OrientationNotification.swift */; };
 		08C9932D0B3544DA85D912F8835E300A /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE089073D68EF0B27AEA02CF5701263 /* QuickConfiguration.m */; };
-		090DD00A7A9385D8B9181D17A381EBB9 /* SPCCPACategoryDetailsViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = D74D183755488CDCC8BCFA54A1B7EB2B /* SPCCPACategoryDetailsViewController.xib */; };
 		0967B12054E597F00420776748487EEB /* QuickTestObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D5605B91235BC3C8C2EBAC0ECBB279 /* QuickTestObservation.swift */; };
-		09EA6271886FA501E86A1166A39E1FAD /* QuoteStripeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F122B45B33E4C2924F2A6034B7D35605 /* QuoteStripeOptions.swift */; };
-		0A5CD2C51093BCCD820052572677ABC2 /* SPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177DD5FB31148C2407BA8D43A0902DB7 /* SPError.swift */; };
-		0AE135A7215AE85F9D752120828C1CF9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
+		09745F77B38B2953467EB4DB4A68B0F6 /* ConsentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DC7F0FB1838294BA74E9BFDB30157D /* ConsentStatus.swift */; };
+		0A060BBE78DF452A773DC6EEC71BC81C /* SPCCPAConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845B339986C9074BC7AE11FF95931123 /* SPCCPAConsent.swift */; };
 		0B35D8F6653593D2D64B70C98E23EA54 /* CwlCatchBadInstructionPosix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F0D55887BBB48A5F70C73FE33701EF /* CwlCatchBadInstructionPosix.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		0B5ABBFD41542196FEC9560AF979774A /* Down-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A88CE3A6E51C34187F86281DB75F54E7 /* Down-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0C0DB0E0332AB057D734A816C2EAE009 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
-		0C50C39A1ED303ABE7D73429DBB72698 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D175523BA47204A774F770AA3C336D7 /* Constants.swift */; };
-		0D5A638BEE7B8374BA9F97048B56E29C /* SPJSReceiver.js in Resources */ = {isa = PBXBuildFile; fileRef = F4C1045E7B11276558ACCB7A723DF82B /* SPJSReceiver.js */; };
-		0F39A4E863F3AE8A2B48EFC6D0F381AC /* SPAppleTVButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777FC6E3031FD3F408A7F684CAA9CA27 /* SPAppleTVButton.swift */; };
+		0CD806B915253E26DA4F3D090AA106B1 /* SPCampaignEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F151B5C0933D8A655A7DF020970178 /* SPCampaignEnv.swift */; };
+		0CDD87EBBE71EF6951C892FD6EF3EFE3 /* jest.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 0DB88029D7BE239F468C617AC20AB271 /* jest.config.json */; };
+		0D7D8F8D3DD745B2AB32EBEDD0055251 /* ListItemParagraphStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7885C864C246711D62F40EC398C873 /* ListItemParagraphStyler.swift */; };
 		0F64D5C89FE45D9D5B4EDE18C0A9E0BA /* Pods-AuthExampleUITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D2EA4D4CB879E31CCAF1E4E3D382970B /* Pods-AuthExampleUITests-dummy.m */; };
 		0F94B2449CA1ADA76AE79C0BF6A08549 /* IQKeyboardManagerConstantsInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E95A52AFAF15D941AE275A43898765 /* IQKeyboardManagerConstantsInternal.swift */; };
-		104634580142CFDE7F0F7FC20D9669EF /* SPJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA775630FBF5F32F26304E7C14ECA75 /* SPJson.swift */; };
 		11166EE5BB467C8A67D73EC236EA0F5A /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 22D6C8EDA33C564DE94EEA2C5A9F0E49 /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		11B9E8A96ACA07172EDC904B523176D1 /* DownXMLRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFEFC792F717489E1D0033C41385017 /* DownXMLRenderable.swift */; };
 		1240BCAA219CD48FCFAE2BBC86949E6C /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B9C691E324AE9E7F94E1561C96C4D8 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		13434450BF03A9E3AF6A140E12BAD742 /* SP_Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 0C5FF8AFF5BB78C11B41EDBDA9311585 /* SP_Icon.png */; };
+		12E82D709BF8639CEAD5ACE8C8452982 /* SPGDPRConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8192A816EE8F9CE7ED6486B77A00624C /* SPGDPRConsent.swift */; };
 		134A15A496D772F161498B36DE95A47A /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A772930289BCF3CAA8EA3D19487AA1 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		1398218008F3AA63D2AE0C882915DCBE /* Down.h in Headers */ = {isa = PBXBuildFile; fileRef = B65C472BE17C0D3E1326DCDB50A7EF8E /* Down.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		13AC433996F4710382EC700727501EA1 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7CFFF9CE15070521A2CA8C209A9889 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		13D33746AE0238795E807AE4DF2B58A5 /* javascript in Resources */ = {isa = PBXBuildFile; fileRef = 3DF8F244296F4E68BEBAFF70FBE0C89C /* javascript */; };
+		1424C808FC74FAA793098544D52BE410 /* ChildSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FA610780C15C414C40385861A21ED4 /* ChildSequence.swift */; };
 		146CDBE2D8EFEAB3955F969ADDD68E69 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F9CE199E7234100943A082F7090697 /* XCTestSuite+QuickTestSuiteBuilder.m */; };
+		14748721F3EABA6304877E4CC01E2D6D /* ListItemPrefixGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152016598FEB9AF219872CCA45E20932 /* ListItemPrefixGenerator.swift */; };
 		14CC389AB82BF9E3B222AEE442410AB0 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17190541F56BBA8694F01E6811EE3421 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		156FD4665CEB6CD15865CA2040CF0195 /* SPGDPRCategoryDetailsViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = BA0FC05392595124ACD912E0FAC83A97 /* SPGDPRCategoryDetailsViewController.xib */; };
 		1573F39406E1687394544FA3C9D397E1 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 53830D02039DE43B2FFBF8AF6FF4A78B /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		16476B64A67EA76BB4582B73F1CBE98A /* OSLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314BF0457A28BB12F453112044DD385D /* OSLogger.swift */; };
 		1673801F893DD37D8EF0010FB46F7A6E /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = DD783487C1DFFC517AF0E6DD261A5A09 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		167AAB25949728F2DDAEB849F507721F /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A7C3CEFD5E9479DB337765E09E0A7 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		1740CBB33D469AEDD5D7291A9268FA97 /* IQToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD22C13806BD78DC03B4768F517871B /* IQToolbar.swift */; };
-		19154EB3823C5EAD2CEF78D7F81B2E45 /* ErrorMetricsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F230947DA34DF18BEB412F130148E3BB /* ErrorMetricsRequest.swift */; };
-		1A08615492ABE417D55C41C1C250E0A6 /* String+ToHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27721A433338F97FF04F8BE5D90C9FBD /* String+ToHTML.swift */; };
-		1A3D29F1D945826397052BEBC9A153FC /* SPNativeUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CCECA6D5136305C7844F2F7745605E /* SPNativeUI.swift */; };
-		1A44CB217A52E069392B7C3B1B3E1BC3 /* parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C8CC7E8FC942BEC4A1E73BD846E9D6 /* parser.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		1873BFF189953A5AD740D2AEAC0D42CD /* SPPropertyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966B2E914EEE28ECF349826319E685A0 /* SPPropertyName.swift */; };
+		189466984306DFA00CF131DCEC21E2CD /* SPCampaigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64B56D57B02D8D11C91C959BA4069BC /* SPCampaigns.swift */; };
+		1896B671F28E3681E78D2584AD40406C /* SourcepointClientCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB34657D9ED942AFDD2DA7839D04063 /* SourcepointClientCoordinator.swift */; };
+		189EFDB22897339D2D3AECCC226AD990 /* ListItemOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D24D181ADD549C9848DE3C8A48A2426 /* ListItemOptions.swift */; };
+		18B9E29BA05D7E016600DBF59DA4CA98 /* render.c in Sources */ = {isa = PBXBuildFile; fileRef = 4070BC13DFC74E11C100FD3411A6AAD5 /* render.c */; };
+		1A8DFE1D2026DAF975A594D4679C0579 /* ConsentStatusMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0C0D6E820FBB1090FFA6175AC9BDFD /* ConsentStatusMetadata.swift */; };
 		1A9B9579E46EFBA63C5F57A6B17B5ECA /* IQKeyboardManagerSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7947BAB773F339EAC63DAAF04B2D8CFC /* IQKeyboardManagerSwift-dummy.m */; };
-		1C58692BE8698CA15A01733076A095FD /* SPMessageUIDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCEC17591F80FCF182482B83F37421A /* SPMessageUIDelegate.swift */; };
+		1ABB2CD31D8E70CB777ECB1304577E7D /* CustomBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79EB69639263444FE6B71A857954296D /* CustomBlock.swift */; };
+		1BF4B639116426C64048D8955717FFD1 /* SPSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B69A493B5BB16AFB91A94CCF3EC370 /* SPSDK.swift */; };
 		1C78D412C1AD5DB6D68ADACF00711FCA /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80168F271651A604523035FD37B31496 /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		1D2497AED2C9953CFEB7E73AB32E3372 /* SPLocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71857B94D3E4661FABC88C0FAF764D2C /* SPLocalStorage.swift */; };
 		1D5A907809481246E300E92B1CFEB0A3 /* Equal+Tuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CC00FA31E003434C6D65DF8F3DA91 /* Equal+Tuple.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		1D77C403F6D6009A8C80C71CFFC75683 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A9FAAF3CDE683DCE7F80696E3E1780 /* Visitor.swift */; };
 		1D8031C86A94D32E00ED55B80428A0F3 /* IQKeyboardManager+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726A34F9D4D17AE4EBF1C00A383C14CD /* IQKeyboardManager+Toolbar.swift */; };
-		1D9809F3DC6BD8650AE4707D96AC488A /* render.h in Headers */ = {isa = PBXBuildFile; fileRef = 10473F9F34E076F4BC8C76A0EDE622BC /* render.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1EB786BD76C5CAAEB8DF4BAD32D31DB2 /* SPPMHeader.xib in Sources */ = {isa = PBXBuildFile; fileRef = 2EDF6F527EBDA7A82AF59E4AB6C0E8A3 /* SPPMHeader.xib */; };
-		1EBE2D97BC331948096A4644A2398EE1 /* SPIDFAStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC21ED487A14977C49B886AC04D349A /* SPIDFAStatus.swift */; };
+		1EB3880702ADF3AB76FD14549329028B /* ParagraphStyleCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD9D4878151357A0A32FC57B0B6B9FE /* ParagraphStyleCollection.swift */; };
 		1EEDAD12DDDC3142EE57080A9A27A63E /* ShareUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6663C4A3C0BDC918F93DC3363922E4 /* ShareUtils.swift */; };
-		1F01BD7C7F30AD01BC98793E51581672 /* ConsentViewController-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 701342168D9B0F621F560A7CFC81E140 /* ConsentViewController-tvOS-dummy.m */; };
-		204F3FD59C01BE9D4B739D0C1D4A7BC0 /* node.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEC456ADDF2069AA24CA59D508A3A65 /* node.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		1F5672E7C94135D532FEC111C90DDD28 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7B86DCBBC1489611E4530C9CDEB342 /* Constants.swift */; };
+		1FA956015FCAF30ECCE011F2A0C36815 /* Barcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 70C9EEB9C55E8BEEED132AC3B3DFE809 /* Barcode.png */; };
+		1FA9F6A59A2F19C6FC273C20E5F6FD13 /* MessagesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A4828FB21F6D40312306A0E841E96D /* MessagesResponse.swift */; };
 		20616A47873318F80BFFEABAC9730122 /* IQTitleBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCB8C53F45A51260CC88D81CCF424D9 /* IQTitleBarButtonItem.swift */; };
 		2099A05ADC88085F1460378141F500FC /* Nimble-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E9B17F21B1EB972CCA0ECA3E2D9067E2 /* Nimble-iOS-dummy.m */; };
-		20E36053EBA9373855545B90AF3D7E8A /* Emphasis.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFACA9FCCC8A1B367EF4F8611D73E3A2 /* Emphasis.swift */; };
+		212BDF5D1202B62C7FB7AABFEBE43A22 /* GDPRPMPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B889D5BC3C973D012577EFE632A14F18 /* GDPRPMPayload.swift */; };
+		214AF75426F6BA735F2BBB8CDC12F9A6 /* DownRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617BC5E5ED6957F2FE55CFA65E0A023A /* DownRenderable.swift */; };
+		217F217989EC5B14A2AC4F4C56835817 /* SPConsentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6874BBA7D9E7AE21FD890E2B7584FEF0 /* SPConsentManager.swift */; };
 		218802C96398F5DCDFE50116A6EBA41A /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6299AFFC345696A42141091DCDB1341 /* ExampleGroup.swift */; };
-		2199682BD06BE237B4176002356C9E94 /* DownDebugLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142CB463E6DC28D50FDFB70636557B4E /* DownDebugLayoutManager.swift */; };
+		21A1CDA50E0EECA49422A00FA421546D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F14AA232F04EB7627811BC6CD5E590F /* Foundation.framework */; };
 		21ABB59D4CF6010E3745B8E7EDB57A3A /* QuickConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92321CEC968DCD4908350231D8D17509 /* QuickConfiguration.swift */; };
+		22442745BD844B200A41DC4DA920052F /* CGPoint+Translate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26381AEAF3A5B85195A7735518CDE616 /* CGPoint+Translate.swift */; };
+		22A2650B6135BB8176F20103DC4EF15F /* buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = E3990458C340AF97F1CC940D19CA7E33 /* buffer.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		22A6661D0F35E259CC5ECA2DB13E8017 /* Pods-SourcePointMetaApp-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D77A03561086450FB789E8ED754256 /* Pods-SourcePointMetaApp-dummy.m */; };
-		2322461C644F8F05973A87E91489495C /* Flow.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CAAC5927463AA87FB034761B3595C1D3 /* Flow.storyboard */; };
+		22EC895FECE39417402FC3F9B58FC42A /* SPFocusableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E573C7AF82B5C83EFF10C961801B705 /* SPFocusableTextView.swift */; };
 		237915FFFDA90EF0F995E5366C0390CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
-		2431F09F8A90D48F9B3A930199CA78E6 /* UIFont+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E649623D9E40861B378DBDEF1928D7 /* UIFont+Traits.swift */; };
+		2390AC255AE12FF8D9C7BA1975B1C594 /* GDPRPMConsentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB8E8EC78E12CB5BD98D6EB510185B /* GDPRPMConsentSnapshot.swift */; };
+		23B10358111EC6D5FE9F2A5E0F696477 /* DownCommonMarkRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92814138089BED333E2B2E1E6F205E9D /* DownCommonMarkRenderable.swift */; };
+		246DD1A4D6824A1CE39A2792F9A7CCF9 /* MessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD3F2BD4D00E9574790ACC3405E443 /* MessageRequest.swift */; };
 		2486AF84D6A25E1140D936D1A5E74BD8 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81ED03AB7884B5D1101A89F720BF884C /* XCTest.framework */; };
+		24DC0F49BF32ECCF761EEDDD22BE2BED /* DebugVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000240FF12FC9FA921A32193478CC476 /* DebugVisitor.swift */; };
 		24EC44FF102C2635A476CEF7567F89DA /* IQPreviousNextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285BE3E66975DB446D5F1D0A93CE222F /* IQPreviousNextView.swift */; };
-		24F19F394D71926EED9AB00D96E8BC7F /* SourcepointClientCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CFDECC0F12E3CBBFFC8D027D853DC /* SourcepointClientCoordinator.swift */; };
-		250B702BA60FB06FBF93E50CD518CAF4 /* IDFAStatusReportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D3727C4F0FA35173C80EB3C59DDF49 /* IDFAStatusReportRequest.swift */; };
+		2501B029AF5C193D5B5931EBAE475399 /* SPURLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989D2B471579A3D696A1F3418778EFCA /* SPURLExtensions.swift */; };
+		25783A7DFCCB81461D52E72DDACB48A1 /* AddOrDeleteCustomConsentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA59492BB5FDCC898516A27C6F6D2AD /* AddOrDeleteCustomConsentResponse.swift */; };
+		25CAC1A49C16BE629312D4FFFDB4BBDD /* NSMutableAttributedString+Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96FDBF32869B4E9BEA3EBC65DE5F273 /* NSMutableAttributedString+Attributes.swift */; };
 		263106EA3D8265BD84AA81C2FAA702E4 /* CustomHTTPProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3B561010BE2A4F21A3F0268ABDC331 /* CustomHTTPProtocol.swift */; };
+		264839A6926F4FECAEBB893CAF725770 /* images in Resources */ = {isa = PBXBuildFile; fileRef = 581B8A297C5BCB99513CA8A43ABE49C6 /* images */; };
+		26ED9FB09E70ED33680A8916C483263C /* SPCCPAManagePreferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F685AD4AB412458C5FB0A7E92CFEBD48 /* SPCCPAManagePreferenceViewController.swift */; };
+		27137825057CCED38D757693FA700513 /* LongButtonViewCell.xib in Sources */ = {isa = PBXBuildFile; fileRef = B6392C301C609DA6F69C097BFF04872A /* LongButtonViewCell.xib */; };
 		272A704D036A486A84D49D7D7D2F00FD /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2250D5EFB0AB8081F75296DB53AFB6FD /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		28492CB04C8DE23C3B0475B73FC83EFE /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DD0E705B347629A8710A02B8299359 /* config.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		28FD58F41CD639AFC86219D80CF06BC5 /* DebugVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000240FF12FC9FA921A32193478CC476 /* DebugVisitor.swift */; };
-		294C85F84E5A95020A88CB438371FBCE /* ConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19CF649845DEF2B829FB7FD5B787243B /* ConnectivityManager.swift */; };
-		29527709CA5EF3517107CD5B752C171A /* TextTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6B579B6E7CFE017499BB1FEBEB94CD23 /* TextTableViewCell.xib */; };
+		27EC61F6ED7DED5ECADD4B1AA138AAF4 /* TextTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6B579B6E7CFE017499BB1FEBEB94CD23 /* TextTableViewCell.xib */; };
+		28A15FC60516AB1F98A846C1FFF756D4 /* SPCCPACategoryDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48059975E6928B40F98CE48EC7CE2DFB /* SPCCPACategoryDetailsViewController.swift */; };
+		290547E5F5F5B21D667FF8011E027FF9 /* javascript in Resources */ = {isa = PBXBuildFile; fileRef = 3DF8F244296F4E68BEBAFF70FBE0C89C /* javascript */; };
+		297CE1761AF7549659362BAE7C5037BA /* cmark_export.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C1EAD5CBF0790B3DDBF1971FE4A926 /* cmark_export.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		29FCD0F3710299C348498F25F48D1332 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3459EB4E85FE56BAB2781890A10BA3BC /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		2A80D07BE978DB7541BFE0D3916D54E4 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DF058A61D708AF2FB75A61C5C773A8 /* Document.swift */; };
 		2A829741AB03253BCCE514EE72543B24 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25554D9FAA26AE20BF956E70CF34111D /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		2AB2AC5B637B752863F200356945143A /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 22D6C8EDA33C564DE94EEA2C5A9F0E49 /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2B45CC6028262EDFC605F642E095F886 /* Pods-NativePMExampleApp-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 79B3A869D1182177E19095C737657B2A /* Pods-NativePMExampleApp-dummy.m */; };
-		2C5B1C337BC1477ED5C321B394E30900 /* SPPrivacyManagerTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8480E5D04F34D740E0BF306B6EFFC /* SPPrivacyManagerTab.swift */; };
+		2C186CEADD9054019C84DE8230A79746 /* Bundle+Framework.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BBD33A69B5A2C3CAC2538722F871505 /* Bundle+Framework.swift */; };
+		2C49C38789D067D97963BC55E3E5D6B3 /* Down.h in Headers */ = {isa = PBXBuildFile; fileRef = B65C472BE17C0D3E1326DCDB50A7EF8E /* Down.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2C62052DCFAAA9C5DA2BB5619C4ED110 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCCB7E13844141792F26DA17E9F2A88 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		2C6DC86A0753F14DA9A89AEEECDD270E /* PMVendorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3020AB2EC042108B6C1E9EF8E7259B08 /* PMVendorManager.swift */; };
+		2C7C34A83AD21BF2905D76C63CDC65FE /* parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C8CC7E8FC942BEC4A1E73BD846E9D6 /* parser.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2C8047EE96EA6D25E430FE1D171CA0E8 /* CustomConsentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312B839222265C5ABB21AEF7BDE52787 /* CustomConsentRequest.swift */; };
+		2C84B2D85D1C7E0DF22B56E6A0B34B61 /* cmark_version.h in Headers */ = {isa = PBXBuildFile; fileRef = F11A37CBB808CEE0FF299BADBF67DE39 /* cmark_version.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		2CA0B3B43A972DF3AD79F58092E3403E /* IQKeyboardManager+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E4103920DAD41207C515376538B5A2 /* IQKeyboardManager+Internal.swift */; };
 		2CA14A63B721C39634397F49A17E5E43 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B97C385536ECA9485526486DC990ECF /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		2D31916F48142A95810C372542ABC102 /* ConsentStatusMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDAB65BE94ACA7C2A6E08E2D4FB5425 /* ConsentStatusMetadata.swift */; };
+		2CBF339DBF53B3597A88BAB1F18CA7DA /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442A98950A08DA1804EF7DDB733517E7 /* Node.swift */; };
 		2D4A4D18AC6DE990B350196BF5623061 /* JSONTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41417D017600B7A6C80E0DB98E70C384 /* JSONTreeView.swift */; };
 		2D88D6A79862A326D5702110DD10AD56 /* Wormholy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22757A3DD0FCCB8D93C46FBC5F9AC8EF /* Wormholy.swift */; };
-		2D8BB332ED1AE1656513D2B5D1305F86 /* OSLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314BF0457A28BB12F453112044DD385D /* OSLogger.swift */; };
-		2E2E46176FB303F284C50259597D2A1F /* SPGDPRPartnersViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = A785D33B369746C28846A1B67D6AFEC0 /* SPGDPRPartnersViewController.xib */; };
-		2E3C41BFD60716B25E41688EA2EA83D2 /* GDPRPMConsentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A030B14F4462FC48F3E107A0BBD2279 /* GDPRPMConsentSnapshot.swift */; };
+		2D943B287E36674D25AD106E04B424E5 /* ColorCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20C28362BE5898EDE4FEE6C967AF566 /* ColorCollection.swift */; };
 		2E4A5DBE53521CDF32DE3F02D18BD0AB /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770DD20F6C81CA75AD5242593462D0AB /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		2E5138271A6C79BDA3C0835F2596219B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94A1E9385C6926655A13C51E80576339 /* UIKit.framework */; };
 		2E63C920D2A491ECD6880A95D1542401 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = A62B616AE6A6F954362F28DD8D88366B /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2EC96162DD6740ECE67FF38B8400A7C5 /* IQKeyboardManager+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E11F0BA49C7755489AD82C54034C9 /* IQKeyboardManager+Debug.swift */; };
-		2EE484BA6D443A36480400E51A432C7C /* SPUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A036380E05F52DB23AA8871BB06A4DC /* SPUserDefaults.swift */; };
 		2EF70FE262C4E0EEE8FE1325733DFCFE /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9D36A3F5DA5E98DB86DF08477AE877 /* World.swift */; };
 		2F1105C49C25F8276ACF74C96CB8FAEB /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 5641AE647FA56F350066C84F00C50112 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2F331B1D69FCC3AC28A80D244D58EC90 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0CC2596F659DEE896423741846BCDA /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		2F4B5D450E6A770940E25CE6F654A143 /* IDFAStatusReportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D3727C4F0FA35173C80EB3C59DDF49 /* IDFAStatusReportRequest.swift */; };
 		2F7268B63ED1A1C9F9F8F6AD5415FF35 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 904C94CF67C84BF6E4E596BFF070663F /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2FD7B8FF456B0D1E5589E2F1E1D0876B /* JSONCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65757B11E6D99E944207C7CF13BC8187 /* JSONCell.swift */; };
 		2FF42BD55316BC55BB5758D32F1377BD /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B719545A6909C9264D7360E140E74 /* World+DSL.swift */; };
-		30820BF2A62C49555E4911838D972E0C /* ParagraphStyleCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD9D4878151357A0A32FC57B0B6B9FE /* ParagraphStyleCollection.swift */; };
+		30227E26AE6FE9B95E8C96E463C4055F /* inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 77DBEBDC400AAA8661412D2C950CDE90 /* inlines.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		30D3F6DB4ACEB43EC870D0644E56875A /* Nimble-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B953B8D624CEB234E8380E1D61EB7C5 /* Nimble-tvOS-dummy.m */; };
+		31923FAB43928DA9AB0DE311F13C3EDF /* houdini.h in Headers */ = {isa = PBXBuildFile; fileRef = 9344639DEC28DF6C91B12F94A3FF74C8 /* houdini.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		31B520279493FABB299F8DF2323D2F96 /* ChoiceAllResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F238701ED3EDA2C5FEF40EBD01B0FC /* ChoiceAllResponse.swift */; };
 		31E3EFCB3AA348C7932638746A9CA317 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3A7F1CDBF86AAF8BC24D91BB329589 /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		329D1E331CFDE43F39F2F27277A2AF55 /* WormholyConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = 2934A524A3B3835F09EF2ECF8337CE24 /* WormholyConstructor.m */; };
-		331E5066AE76FCE90662CCBEF7181D88 /* SPDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF42833ED704F1D08E1588247A04BD1A /* SPDate.swift */; };
-		338ADA4DD7C6D6D5DA47242779C055A7 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D175523BA47204A774F770AA3C336D7 /* Constants.swift */; };
+		33D3ACBC8D75923729D62AC5DF6E387D /* ErrorMetricsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4F80DF4A9707BD0EE7C79298BE4E51 /* ErrorMetricsRequest.swift */; };
+		33D5376DD1888F3949FE3FDF3305C5E6 /* iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BBD1477BD8D482C9915EB8096D1F4E4 /* iterator.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		33F7F677CB51838EC7294E8150C92114 /* BlockBackgroundColorAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412EEDB4587FF3FBE3B0FA5D464BA14B /* BlockBackgroundColorAttribute.swift */; };
+		341D14E14B366AEEDB7A1E1A5677BE03 /* SPCampaignType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34866691E75484824EC739581DCD053 /* SPCampaignType.swift */; };
 		34555F287FDB6C87E11FCDE6FE7EEE06 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07909ED5D1C014D7B149EB7F691CBF93 /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		34C39BDBFE7A2CC585787F5AFCA39FDE /* IQUIView+IQKeyboardToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C621160453E58A808103CD9384B2AD4E /* IQUIView+IQKeyboardToolbar.swift */; };
-		34C8AB7A4BBB8FBEB85696DC7C98AAB1 /* SPCCPAPartnersViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = BEB4710F72E37782F211DAD8B4C712FC /* SPCCPAPartnersViewController.xib */; };
+		357BB00E097D83F924FBA7FB6167C78F /* SPStringifiedJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9375B3FF39FE8E647DEF816E4A4BA4B /* SPStringifiedJSON.swift */; };
 		35A7D34489E1D3963D6F0BCEFBEF00C0 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 42CBB759E4790435EC90368AFB4CFCF5 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		35FB9BA0CF8DDC0FE5B140424288DEE5 /* SPUSNatConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB725A064558DC098766E7C83944569A /* SPUSNatConsent.swift */; };
 		363B23DCB65E101320FE55BD7059FB50 /* Pods-SourcePointMetaAppUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B583A85EEA77DA2A44A2FEF3AFEC3A67 /* Pods-SourcePointMetaAppUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		374E83DFB990DFCDCC68285A04120EA2 /* AttributedStringVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E445224324EA4EC853DC4DA7AF760 /* AttributedStringVisitor.swift */; };
+		3762EDDE73A0B22200C88E4D9A16CE52 /* SPCCPANativePrivacyManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA419A4B9A95901AE93A15465F93F46 /* SPCCPANativePrivacyManagerViewController.swift */; };
 		37AA4A1FA94A1641E73EC8DA6053940A /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF234D7502CABD3ECCE3DB47C14619FE /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		37C241264893C04ABFCB123FB86AB2FD /* WHLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2766E728CD9592E3A30878EBA5AF776 /* WHLabel.swift */; };
 		38994215E32BC2C62181AC2733E723B3 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E0156BBDCAA49BAAE07A1878819159 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		38F8D5CF6D4733844DF58FCB4607BC89 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2250D5EFB0AB8081F75296DB53AFB6FD /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		3908D5A3F69A7F521721DA6EF8B6DB87 /* WHBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9840C2E2FAEF98DDD565CE6D3440E98 /* WHBundle.swift */; };
-		39FFD4E6BDB35DB077E124AF519A4CCC /* SPUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F01F54D5755E2A41C32B8A844B29DD /* SPUserData.swift */; };
+		3A19003F71EE68C99B916DB62D58C5D4 /* SimpleClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91027530C899F224F03C827FEBFC0B2 /* SimpleClient.swift */; };
 		3A41A286973A42FC6998DF11D92C212E /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770DD20F6C81CA75AD5242593462D0AB /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		3AA3CE7AEFF8C6E932E00AAACCCB0843 /* references.h in Headers */ = {isa = PBXBuildFile; fileRef = 51039E4EFFDF22E0695ED52DB077E0A6 /* references.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		3ABAA6CC644E61C7EB43B54498A3FD18 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27E7590E21F4CF0EF3F520B93B1FA63 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		3AFBE35E03C4CF0F8F962EBD9CA94DCF /* LongButtonViewCell.xib in Sources */ = {isa = PBXBuildFile; fileRef = BA78A05C69F29E2CA0169D67110BCBE7 /* LongButtonViewCell.xib */; };
+		3B1A5E6FD278BAAE3A401ACB04FAF59A /* SP_Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 2F13DD6087C28E86B9C1788E8C496A78 /* SP_Icon.png */; };
 		3B2B15092D3E22A93C2395DD90E2A660 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8595FA58C64090133B1404C303988C /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		3B6B3C0C41A99EC63454B43521F4A4EA /* SPPropertyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6487BE0AA27BF693E70D2321C14F25D8 /* SPPropertyName.swift */; };
+		3B5ED478EB10076C1870E27575DD3B10 /* Bundle+Framework.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BBD33A69B5A2C3CAC2538722F871505 /* Bundle+Framework.swift */; };
+		3BF4911AE5CE7678F12948A79905E60A /* DownStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30BC4A2BB02509CD9B6921D29507A79 /* DownStyler.swift */; };
 		3C0E9E5820E0E66C6A809ADFCBD3DE1C /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22868D7C990287D519469FED4DA72B95 /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		3C16AE323E394B78AE148637D4506E26 /* Pods-NativePMExampleAppUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D463E95BBD33777E282E9ACA1764722C /* Pods-NativePMExampleAppUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3C720D27E298BA2471CFCCEEB841E57F /* MessagesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A4828FB21F6D40312306A0E841E96D /* MessagesResponse.swift */; };
 		3C807B46079270152880FCC0CEDF7A43 /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137E03F5404ED389DB217A87950DE3D4 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		3CC7DCFF763A7EE70193887DD9C15E81 /* SPUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B85178157AB7E9CEB0F8DFD7359AE5 /* SPUIColor.swift */; };
+		3CB826EB2CB8348BE42A3B6BABD3CBF9 /* SPGDPRPartnersViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = E58B299E95E357B2AFB44800057B0F15 /* SPGDPRPartnersViewController.xib */; };
+		3D3F8A26343E290C4A83C53C909DF03B /* SPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F643506E178F3E11AFFEBC84FF28857 /* SPError.swift */; };
 		3D96722FFAFA9FFFA92796DEBDF60DB1 /* WHDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A8DB62DF77D798B329646BD66F6239 /* WHDate.swift */; };
 		3DA83EA42CD23CB31F43A83CDCABF147 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6779492234D4F962E2CF571B2C94019D /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		3DC98E541E81E5357EAE204E4599AEDD /* CodeBlockOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356F7EAAD72C8F7AF7B705E00487476F /* CodeBlockOptions.swift */; };
+		3DD5056A375E1C6851CD8CCCB31F87E8 /* SPAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BFF4525B8E99AC8AA9682A0AD5096C /* SPAction.swift */; };
+		3E7EC75E6ABD43F08C68163C2248F634 /* SPPrivacyManagerTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CB7EF4A828D46D4F0255622811021B /* SPPrivacyManagerTab.swift */; };
 		3E9EC5E741D104D87387618F660244D6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
 		3F01EED6380B596E1D0C1497CBCF9B95 /* IQUITextFieldView+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3463540E81501C1B8A2E50EB8B788F45 /* IQUITextFieldView+Additions.swift */; };
-		3F1671B1DB317554BB57EA7FD02CDA37 /* ChoiceResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8F37E1246867F64DA19CD63664C7A2 /* ChoiceResponses.swift */; };
-		3F4887A4ED72D03CA05C90CE19016B61 /* Down-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBE73DB45AB94762EE68960C907A094 /* Down-dummy.m */; };
 		3F5649C2948BF533FFF15431891B7B27 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B7ECBC48D5A4C7558411E8764C9E1F /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		400C7AE826CDAEB8321CC822E9C0D2CC /* InputStream+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65671B772731C7D68ADCBDE962B9D0E /* InputStream+Utils.swift */; };
+		4036A9966FECAB42F09A8922475DB5CC /* DownAttributedStringRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135E1342AB961BE0D0B71A03B9EDAA81 /* DownAttributedStringRenderable.swift */; };
 		4046282B2EA1A8066B9B98E1A04F7976 /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A315A7B6ECBF785825BD78B7BB6D04FC /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		40F7F486B3CE88CF189172177C198F3C /* SPAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5475A5AA0068B5C7E68B5F416E428AA8 /* SPAction.swift */; };
+		415B9BA2AD785521ABB441C819AB3D06 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DD0E705B347629A8710A02B8299359 /* config.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		41A2FCA5CB1C7E65BD30A0D8ABF1DC31 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8915805A6E3A56ECCC93195CA0E17A /* SuiteHooks.swift */; };
+		41CB5F295C39BC0A161C44538A83134B /* LongButtonViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F197E4956D85BA7097F61D3662960B7F /* LongButtonViewCell.swift */; };
 		41CD40F5713CD71AD5AB1471E81C97E1 /* IQBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2D21D6421A7ED9A1EABC6BC6965D44 /* IQBarButtonItem.swift */; };
-		421DC21727A2DBCC94113C27DC0044BA /* ConsentViewController-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DA590E70E93C5C8B5D4DEEB30EEF269 /* ConsentViewController-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		41F4D479CA27981C28EEF72D3148F32F /* SPCCPAVendorDetailsViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = F17FBA5182E772BCA2F3B3F55002CD78 /* SPCCPAVendorDetailsViewController.xib */; };
 		42B8D19739F67E4818160EAAB9C5066F /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9663275D36F2DF8F24EE7DBC70A4F7 /* ExampleMetadata.swift */; };
 		42E711D1F160C2C6F2DA60860B586160 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A21A8A668B97E7B42405AC8FFD20999 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		44050ACEAB658A2658E6E147115189CF /* SPURLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989D2B471579A3D696A1F3418778EFCA /* SPURLExtensions.swift */; };
+		4435EF38448930954E398C7A32207707 /* Down.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD36E655D8EE068EFF50A0757E1F193D /* Down.swift */; };
+		44EE3543B07D25F00B68CF01DCE0FD15 /* ThematicBreakOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7081DF63F8F7C26E5449D03D6A28AEE6 /* ThematicBreakOptions.swift */; };
+		457D5CAF8CC7BE998AC498AF47F7D5F3 /* SPMessageUIDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47EDE3AA6C6E1DE2C97AC3AA44619B43 /* SPMessageUIDelegate.swift */; };
+		4593A9CB2D295781A44F23A3DC40C3D7 /* SPNativeUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1EE4614D5D401C3ACDAE634299A561 /* SPNativeUI.swift */; };
 		45E208809C318C2D9021C7BE75A4E132 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCCB7E13844141792F26DA17E9F2A88 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		4600EE97D03EA80B64934FF6C53F09B3 /* NSAttributedString+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = D789344B063B6B4798D349FDDA21D27C /* NSAttributedString+HTML.swift */; };
+		460D0B15CAF9C135CB8DFBE91416D00F /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5459D9ADE3F53D06B748B04037F00167 /* Text.swift */; };
+		464683B2F95000AA0ABA9801A4155A14 /* SPPublisherData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA768698B1E6F086512B8C99BF5A2F1B /* SPPublisherData.swift */; };
+		47093A5FC229C3C23722103BDAB005C4 /* SPAppleTVButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958F48A6FBB82F23052D20A0602AA77F /* SPAppleTVButton.swift */; };
 		471AD48DA44F33E6A845DF0A054750AA /* Quick-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CBC03C3431802F9F218104BDFB237F7 /* Quick-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		47214B85A1771FA93729FD086EC2FE8D /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FB2C2EAA650057FDB80218C9538C18 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		475C865F110F37C7C4F3ED4256E5CF1E /* SPPropertyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6487BE0AA27BF693E70D2321C14F25D8 /* SPPropertyName.swift */; };
-		47901C9002F7CF448654C32699FEC2D4 /* AddOrDeleteCustomConsentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B1AD04671BC2FBFB399E31BB49509A /* AddOrDeleteCustomConsentResponse.swift */; };
-		490DAA441F268480896F4FD662E92BAC /* CGRect+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D30DD3C99D443D22DE81C3C4225D05 /* CGRect+Helpers.swift */; };
-		4A58FE28C0FF13DC8325F189A709C1EE /* MessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28EA9FB3734CAE2118135175D98F1D20 /* MessageRequest.swift */; };
+		47EAF250030F4625D9BDA674E2BFA251 /* SPMessageLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19400978A8768F2D99CDF5E905392611 /* SPMessageLanguage.swift */; };
+		4A28FDC458580086A2D593743B1B4C0B /* SimpleClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91027530C899F224F03C827FEBFC0B2 /* SimpleClient.swift */; };
 		4A7EAA2B0EB864235C3948F4337DFBBC /* Pods-ObjC-ExampleAppUITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A29A77F9DF18C7CD65E01B28F6BD859 /* Pods-ObjC-ExampleAppUITests-dummy.m */; };
-		4AE3B08FC074AA60A4507B0AB4A45B47 /* SPCampaignEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF54F2D66863A21794692394B4DE853 /* SPCampaignEnv.swift */; };
 		4BA4814575EB8ACAEB44F16D0F3CBB00 /* Wormholy-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F4D5CD9F1F8FF97FC14E75387B62A87 /* Wormholy-dummy.m */; };
-		4C162963061CFD67294B64643ED1C997 /* PrivacyManagerViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229CC510F53FF3126C395D3E16A734D0 /* PrivacyManagerViewData.swift */; };
-		4C6101B7E73BFAAA9F71C7BE0FE8F36B /* SPWebViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA771D5B9941FAE0033994DCAA0DFD0 /* SPWebViewExtensions.swift */; };
+		4C17480C7A8F330241EB05D345091F65 /* SPDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB015AFF56EBB905B160D80CADCE889 /* SPDelegate.swift */; };
+		4D6E4754AB85CA38A43B5E82124ABF31 /* ChoiceAllResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F238701ED3EDA2C5FEF40EBD01B0FC /* ChoiceAllResponse.swift */; };
 		4DF348941BBF37C8BE2B161BB830E946 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = EA0192695DA1B280F4BAF140ACD24C02 /* QCKDSL.m */; };
 		4F396AAA9310A5C272F8B32223746908 /* Quick-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2442FE4F068F207E66D30731905E72C0 /* Quick-tvOS-dummy.m */; };
-		4F4ECBFF3F7F80C5721F0FF85BD6F87C /* LineBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2216707DE7A34766E9BA9524A4506770 /* LineBreak.swift */; };
 		4FB356B14A64937D37E9D6E64F481487 /* Pods-ConsentViewController_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C45FE0ACA89D6EAC73605EB0429AB073 /* Pods-ConsentViewController_Example-dummy.m */; };
-		4FDBEEF1C6A4540DD71717BB0E58FBCD /* SPUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B85178157AB7E9CEB0F8DFD7359AE5 /* SPUIColor.swift */; };
-		50BB76696D2116DD435912E89F5145EB /* SPDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC16C315EDCAE62E1828446CBE23901 /* SPDelegate.swift */; };
-		513D0266B7F58B696A551CE08EF39D55 /* SPJSReceiver.spec.js in Resources */ = {isa = PBXBuildFile; fileRef = 24B9714020F6EE241E4029F9D71FB4DD /* SPJSReceiver.spec.js */; };
-		525ACE768CAC3C088BC1AC6E53858151 /* SPJSReceiver.spec.js in Resources */ = {isa = PBXBuildFile; fileRef = 24B9714020F6EE241E4029F9D71FB4DD /* SPJSReceiver.spec.js */; };
-		52D1F2E2CC97F10ADDDD59D9CFECF641 /* SPCCPAManagePreferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276C04F2B5F9EFF3F61284610B09A1B1 /* SPCCPAManagePreferenceViewController.swift */; };
-		5371212E33F88DD66308C6316874B0FA /* SPCCPANativePrivacyManagerViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = B3ED46B71DB1362B2152B842E734FC2D /* SPCCPANativePrivacyManagerViewController.xib */; };
-		53863EEAC6EC04A953C94868FEC49F2A /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460C615AE163149149EF5A26844398ED /* Collection.swift */; };
-		53A76A58A63D85865F11BC763D65AC8E /* Barcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 44F462EFF078F36D350AD3131AC159D5 /* Barcode.png */; };
-		540EFD0374C18608750A36CBC3D7919E /* man.c in Sources */ = {isa = PBXBuildFile; fileRef = 44CD8A72F3A29EF02EE34B2A6EFB7EE9 /* man.c */; };
+		502D2B240BAFE04257C1AE312CBC035B /* cmark.c in Sources */ = {isa = PBXBuildFile; fileRef = 4255A9684099CC057C80BE7B5F8CD7FB /* cmark.c */; };
+		50598D15AC2CB1F0B60B45DF97EBA407 /* HtmlBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9E52F42BBF10055CE335DF2CAD2D96 /* HtmlBlock.swift */; };
+		5231ECCEFE0AF39E275B1CD76A7A2B9C /* SPIDFAStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4B07460B142B84CA2496287FE5E036 /* SPIDFAStatus.swift */; };
+		5270DB357AFF6DA9F377A505CD18EF5C /* QueryParamEncodableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8BE80A9F24548A9A2102421EADEB0 /* QueryParamEncodableProtocol.swift */; };
+		530EE7E16B6827ECDDAC474F8F9CB296 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282733731A4D5C723DF051F47E92B452 /* Collection.swift */; };
+		53145D761CDB31738F2591FB046AF10C /* RequestTitleSectionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1FF9490F64DC44BA5A308995182E951C /* RequestTitleSectionView.xib */; };
+		53BF06C3D448557F92ADC12BDD149A38 /* SoftBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484341D87F3E64B2D025EE94BCB11781 /* SoftBreak.swift */; };
 		54A6F5339FB00609AEAB163061A512B9 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 11860DB62CCE2A12727931490CF86F58 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		551B7FA521CC47FA121B5F593EDF8B12 /* ListItemOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D24D181ADD549C9848DE3C8A48A2426 /* ListItemOptions.swift */; };
-		553AA0BEA4D073BE1F117CBABFFC68D0 /* NSObjectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2F6FF780EF05D13850B9B75F93F9BB /* NSObjectExtensions.swift */; };
+		54AEFDE26531E02177BC55BCC95C7B03 /* PrivacyManagerViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1E7CBB8B76FFA6C6435F1483999E54 /* PrivacyManagerViewData.swift */; };
+		55676308D153806856AA8DD5BCD89F82 /* String+ToHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27721A433338F97FF04F8BE5D90C9FBD /* String+ToHTML.swift */; };
 		559D953A9516B0617A3A3F45D6EA6BAC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
 		55D62EE4B2E04CB746D2272E1AC0BC95 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F14AA232F04EB7627811BC6CD5E590F /* Foundation.framework */; };
-		5735E3C808A76B68719E149CD381834D /* render.c in Sources */ = {isa = PBXBuildFile; fileRef = 4070BC13DFC74E11C100FD3411A6AAD5 /* render.c */; };
+		56928CF0AECE7181603DFC4FEF5DDB24 /* Barcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 70C9EEB9C55E8BEEED132AC3B3DFE809 /* Barcode.png */; };
 		5761914AF2638F1E6407F7FA8E56FE05 /* Nimble-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D635DB9163CAD1427C26932646DACCE /* Nimble-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		588356B78FD84642364005940C671F2A /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A64B69F9CAA574619498002BA3ACC /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		58A6D73356334421A6C43FECB157B8B6 /* DeleteCustomConsentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964546ECA7E3236864DBFDC9EA1375CC /* DeleteCustomConsentRequest.swift */; };
-		59E8717947DC925959565344B7D69CB0 /* references.c in Sources */ = {isa = PBXBuildFile; fileRef = 6CD786494CC6EFDC2693FBE7DDAFE2F5 /* references.c */; };
+		5972BB823E058083C30D0D3505A5744B /* SPCCPAPartnersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D01FB303A63A86DA0C36B82086B1F40 /* SPCCPAPartnersViewController.swift */; };
+		59CEE89F72F04FA135449D94290F0F06 /* PrivacyManagerViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1E7CBB8B76FFA6C6435F1483999E54 /* PrivacyManagerViewData.swift */; };
 		5A44234D16E66A73450BE2E8491E7204 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DB72A698D4BB26E79A8534A15FD073 /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		5A9F467AE7A955AD13D98CCE15184229 /* DownDebugTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3AC354F5A08216CE0ED780E5B2B82C /* DownDebugTextView.swift */; };
 		5B0FEAEB0385C632E303BFABAF6AA156 /* RequestCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF9B0F4B24AC371456E88A2A3DC4027 /* RequestCell.swift */; };
-		5B12B0D9D7B1DF75F853A1CE0CE97A5C /* DeleteCustomConsentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964546ECA7E3236864DBFDC9EA1375CC /* DeleteCustomConsentRequest.swift */; };
-		5B4F7258D2856FBAE9189EB74B8CBA25 /* MetaDataRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223B68882D1E8F05E8747949943DC53F /* MetaDataRequestResponse.swift */; };
-		5C50C3C28DD5C282DA692C6E6C450ABF /* SPPMHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71FA3D73199D169754EE5F6261861AA /* SPPMHeader.swift */; };
-		5D58790EA320A5623330E04749C40348 /* Barcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 44F462EFF078F36D350AD3131AC159D5 /* Barcode.png */; };
+		5D12D6B14023E37E8382331FDB5256F2 /* SPUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F074F2CF5D98F1FE8054275E5A9B75 /* SPUserData.swift */; };
+		5DB676033E48338FA32945F7141C111D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F14AA232F04EB7627811BC6CD5E590F /* Foundation.framework */; };
 		5DD5374A58D82E2A3B62203B72631ECD /* Pods-AuthExample-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E9B9DE8BE49CD9DD2D6D3F6A9B633732 /* Pods-AuthExample-dummy.m */; };
 		5DDE274FF0CD1DCE229F8974D243723A /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FD40774BB0C4CD4661550DCF7B90F9 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DF674AF1663283EA99F786EA8A8CADD /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = EA0192695DA1B280F4BAF140ACD24C02 /* QCKDSL.m */; };
+		5E28679BD2E2D435C596F3DED21E17A5 /* render.h in Headers */ = {isa = PBXBuildFile; fileRef = 10473F9F34E076F4BC8C76A0EDE622BC /* render.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5E4404282CFB99E1F359BE2578EAB7FF /* DownLaTeXRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CEFC6A0CC6A008931AFEBBB9BB993F /* DownLaTeXRenderable.swift */; };
 		5E72D2F709A7F6968F99E7BDD0E93A5E /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B404CBE40EFC7C7BDE894D329EDD7C2 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		5EAF04CF96998480A0CB77B3F9BB72D6 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7329FE8B6F03A482CB9D887F017505 /* Filter.swift */; };
 		5EDAC6C338E6FEB547A08C927C869BF0 /* Nimble-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0059947722F656B119FD60C97AC833F6 /* Nimble-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5F283C1BFF5A0F6DA7BAA8C5CF49FC2F /* IncludeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74C9B99E79D5B4E81470F0EE516B998 /* IncludeData.swift */; };
 		5F80346C24851584369CBBF6B8FEA980 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B85932749565B4906CC95F83538C516 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		5F9D7DE3EE4D15A837B1A0A203C11443 /* MetaDataRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223B68882D1E8F05E8747949943DC53F /* MetaDataRequestResponse.swift */; };
 		5FCDE329C45C447A8189F5E431CFA144 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F16564FBAA0831A0474BCEA8CEFC281 /* Behavior.swift */; };
-		604CB62A0892654E295E49A4FE2CD0A9 /* inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 77DBEBDC400AAA8661412D2C950CDE90 /* inlines.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		608230CE3076E22421A182FFF5D215AF /* SPWebMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB4FA61B354A7E3F028418E57FDCE43 /* SPWebMessageViewController.swift */; };
 		609D2A292455C3C5B2B90737DA27E6A2 /* Pods-AuthExampleUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 641478048A05018FE96D042EAB9E67ED /* Pods-AuthExampleUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		60B6EADD129B1B8C8391FA0449D7D8D7 /* ListItemPrefixGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152016598FEB9AF219872CCA45E20932 /* ListItemPrefixGenerator.swift */; };
 		60C6606FF8176EE5A38870CFD9F649C8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
-		61174EA572FE86EB7B00F68C5DFEC09B /* Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701793AE80F8D38D3B7EE579EDC49DA2 /* Link.swift */; };
 		6152AF6B5E1053E4E7BDADCE0CF309A7 /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 5641AE647FA56F350066C84F00C50112 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		620A537A8204B357A2992C13EB6F9C52 /* SPJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA775630FBF5F32F26304E7C14ECA75 /* SPJson.swift */; };
-		6217155C5A605D397280CE5B9DC0D01B /* SPCampaigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6B5593EE61980CC9C62A1AF03D4990 /* SPCampaigns.swift */; };
-		62BC72E6C069F7BD1C7254D7122AC4A5 /* SPPrivacyPolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5995A7529476DDF73A9A8296514C860 /* SPPrivacyPolicyViewController.swift */; };
-		63071412245CF56B5CE56A3E2C638D2D /* SPStringifiedJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4047D4CAC50B2C75E9F18BF861468108 /* SPStringifiedJSON.swift */; };
-		6487DEEF57EF7BED67AD9F04CCD26869 /* jest.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 5B5D7BE97D7E130364D1F4057289EC03 /* jest.config.json */; };
+		61F2A42BAE6CE57BDF6CDA92A176F037 /* jest.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 0DB88029D7BE239F468C617AC20AB271 /* jest.config.json */; };
+		629410D6D03FEA413114278E368C6D29 /* ThematicBreakAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F309820BB3F1570708091996EE72057D /* ThematicBreakAttribute.swift */; };
+		630A9ECD902A86C90BB5F50A929EB68E /* GDPRPrivacyManagerViewResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1EABC4D216660430106609E2635E94 /* GDPRPrivacyManagerViewResponse.swift */; };
+		64A9334E350FFE9D9889A8B39B057300 /* SourcePointClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436C422929BBF411EE802DB972F2A7B4 /* SourcePointClient.swift */; };
 		64B890C31CCB4DBBE350F747DF9ABBE9 /* Pods-NativeMessageExample-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 556E2CB0C8EF0A8C8FFC3432D8CFF6C9 /* Pods-NativeMessageExample-dummy.m */; };
-		6532738946D9652862953EB33E0AA551 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86895502D7A8FBC36517193F928B85D7 /* Item.swift */; };
-		659DF7C642C1F930F4110C850A8B621E /* images in Resources */ = {isa = PBXBuildFile; fileRef = 3AE019D4EEC4EA171857F56855464099 /* images */; };
 		65C76C00DA55D5BDCED24E6C46DE438D /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D12FD1A71B7E99F4104E07B92F8758 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		6627FD3615933A6F6E8FAA73B14C7D52 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A64B69F9CAA574619498002BA3ACC /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		666C27518DBB4159C3231FC64FE9A775 /* IncludeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7FCD5D97E9C44DD791C95F75D527DF /* IncludeData.swift */; };
-		668AFC3458ED8948609653936EE3D18A /* iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BBD1477BD8D482C9915EB8096D1F4E4 /* iterator.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6786CB42766CCC8BA3B556505A70D4B6 /* RequestCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 67CF98B34415888CFCC0A3919A234894 /* RequestCell.xib */; };
-		67EBB57EF74768C9EF00EA3607448A80 /* SPNativeUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CCECA6D5136305C7844F2F7745605E /* SPNativeUI.swift */; };
-		68005740F28FFAB7BE6F8654FE278491 /* SPNativeScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BF89AC326EB7E5B953753088D331E4 /* SPNativeScreenViewController.swift */; };
+		669936F75787126F76507A08427C4935 /* DownDebugTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3AC354F5A08216CE0ED780E5B2B82C /* DownDebugTextView.swift */; };
+		6977FC153C068B016A6BBDFA08940BD4 /* ConsentViewController-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 82778513C28C2866957936898CDA602D /* ConsentViewController-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		69877731D446D478E77F831796170652 /* QCKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07138E598D41B9BE88401A889CECB6E1 /* QCKConfiguration.swift */; };
-		69FB27E97F03C973280695C70789DE02 /* SPGDPRNativePrivacyManagerViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 9758CD86F35317EAE38A562A3630A7B3 /* SPGDPRNativePrivacyManagerViewController.xib */; };
+		69CBA346A2E47632591DF9ACCE1FF22C /* OSLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6381389B408CDFAAA455A7A3F74F3B13 /* OSLogger.swift */; };
 		6A04C6F316F2E6E5CF2DEBC372446F31 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187BE1A69563332FBCC49B18DF193F85 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		6A62C440ED464F190FDA98B4842B4679 /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827079B1C799620ADA70CFBA806FA7AA /* HooksPhase.swift */; };
-		6A7362A684F7BE2C6C8FCA63B86D3A5D /* PrivacyManagerViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229CC510F53FF3126C395D3E16A734D0 /* PrivacyManagerViewData.swift */; };
 		6A795EC73F636B5EAAA443CD1A666277 /* WHBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE8B12B56BE2A03693BE1AC03EC2C77E /* WHBaseViewController.swift */; };
-		6AF47148A20E6CB979968091A9C0161D /* SPDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC28310BA7EB1F7DA1CFFCEC65E22D7F /* SPDeviceManager.swift */; };
 		6B1EF12CCDCD267F071A46FB0D6BE545 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE089073D68EF0B27AEA02CF5701263 /* QuickConfiguration.m */; };
 		6B421785FB93A62F28C74AC21643B130 /* BeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09FB9514C706BAC0D25E445FCF3BDCA /* BeResult.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		6B6291FE4807E5AC8F430C56CFC67F7D /* NSObjectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94BB776D3E20372DDF92F05076640AE1 /* NSObjectExtensions.swift */; };
 		6B7775A0C31ED4C9B773FFA63DCFF403 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0CC2596F659DEE896423741846BCDA /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		6B93D43FF02D429A7068EC17FB268238 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = C97CD2F577668AFD8F544447A6328493 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6BCCFE746DB02792CCC5F450A9BB8F9B /* SPSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99F1367AA419AD39BA004551C43D993 /* SPSDK.swift */; };
 		6BF5C75C0D27DD9500C0EE9651635238 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4146F9ED6938E0E6704A42EFD6DD2A5F /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		6D071377AC6EB2B041BE51D7B5749A92 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B8B62FA761D8BEA52D7DEFA8EC55C6 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		6D59F2D5D39B292A18949307E7E90158 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
 		6DAEBB3D8408B977BE548B5FCE4A06B1 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4146F9ED6938E0E6704A42EFD6DD2A5F /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6DE206C1B7F851D6C588599EBDDCBB0D /* CGPoint+Translate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26381AEAF3A5B85195A7735518CDE616 /* CGPoint+Translate.swift */; };
-		6E108CC76E2DD1A2D93D368EE0E463A9 /* SPCampaignEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF54F2D66863A21794692394B4DE853 /* SPCampaignEnv.swift */; };
-		6E28509635573545BEB20E69E6103F2E /* cmark_ctype.c in Sources */ = {isa = PBXBuildFile; fileRef = DFB18C136DCE99B90FF7D411931EB2F4 /* cmark_ctype.c */; };
-		6E7082F3BB1398254C7FFC89CA3FFB84 /* MessagesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E669610B15E89D68A59B4ADA6046934C /* MessagesResponse.swift */; };
+		6DD9CA4DB36FD8FC37608F6B7EF67B34 /* cmark_ctype.h in Headers */ = {isa = PBXBuildFile; fileRef = C3B6F134DE0CE4BE0763FBD533D71D0A /* cmark_ctype.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6E38FACA38CCF85418A91EDEF28708DB /* DownGroffRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E8A5142B09DB9B65C84189E4515DC5 /* DownGroffRenderable.swift */; };
+		6E43E34E335B8966AC96E645E442F68B /* ConsentStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2210A1777A462D1AE0916CFFD28EC9E5 /* ConsentStatusResponse.swift */; };
+		6E70E106BDFCD6703C01165DCAE45B16 /* ChoiceResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB8C0E307B1A76FB7D46C8227CA208CB /* ChoiceResponses.swift */; };
 		6EAC8C719A6BE4073B55DA45A5275E11 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0E3CD9E2006DAAB5710802CD11B6D7 /* Callsite.swift */; };
 		6EC7DC62BDAF027121003FD09B4329A1 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE2FFF1CB533C6879E27F92F3A0195 /* Section.swift */; };
 		6F04A7B593B195D28F21C9D8B3254DE2 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7951F1410E7686BC8E5151576CDB2B08 /* Colors.swift */; };
+		6F43D0A23731EB50170C6A910F9A5FA8 /* GDPRPrivacyManagerViewResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1EABC4D216660430106609E2635E94 /* GDPRPrivacyManagerViewResponse.swift */; };
+		6F4EB6A5C1174E1F2E271B4DFE91DBF3 /* SPUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8D3AB99F3203C5A3038F0B05514618 /* SPUserDefaults.swift */; };
+		6F7589302207C3BF844F724C10934253 /* IDFAStatusReportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6F7D1208E608AAE2535D9ECDFE3259 /* IDFAStatusReportRequest.swift */; };
 		70422EA21A3F3B21F491921FEC32C7E8 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FB2C2EAA650057FDB80218C9538C18 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		707F4B8B2CAB1C7F1CA840EC36F501D3 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8915805A6E3A56ECCC93195CA0E17A /* SuiteHooks.swift */; };
+		708A420FD17F797F725B08FE89D0F418 /* ConsentViewController-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 76BCC1DD257B4A37FA77F484801024DF /* ConsentViewController-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		708C65AC8DEA19B924ED06A72D869EE5 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DE98D8DF2002DAC3ACD4A54956E4DE /* Config.swift */; };
+		716053D6A4A6671EAC2CECFF1387BE3E /* Paragraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B06ABE9E1342072D5858485F4F012E /* Paragraph.swift */; };
 		71870D0CDDC4D4378047022A83DAE2E8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F14AA232F04EB7627811BC6CD5E590F /* Foundation.framework */; };
-		71FCD6EF16284AE8802D8752A07045D7 /* DownGroffRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E8A5142B09DB9B65C84189E4515DC5 /* DownGroffRenderable.swift */; };
 		720D17097D4F0CDDE89C4B21C0553355 /* RequestDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5881840E2FF0269E7DF0EBD5796161CB /* RequestDetailViewController.swift */; };
-		723EDA59DDE39E557925C0632B9EFFE7 /* html.c in Sources */ = {isa = PBXBuildFile; fileRef = 117041B8647E513963A6BA13266955A3 /* html.c */; };
 		72BEDE948ACB5D6AC168C50D740904C2 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D12FD1A71B7E99F4104E07B92F8758 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		72C1FC4DADA10FF2BDFE32FBD41DAE1A /* SPString.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F5A4C0E23281A4DE22DF8D3A07CF2F /* SPString.swift */; };
 		72ECCADCD31B5FF8248C042F40A164BF /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9B524B32EBD31EBE91A65B1AEAE2B4 /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		73181F85B5C9FE5A94E1BC461FA020D9 /* BaseNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92617F51470C15CAD521741390A422E /* BaseNode.swift */; };
-		735519602608DC4235E44F314F35EBFF /* CodeBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7AEE99DB02A4428037B0864E9F8D711 /* CodeBlock.swift */; };
+		72F431C0F668F4EBA12EF5F4A8D9E9DE /* SPJSReceiver.js in Resources */ = {isa = PBXBuildFile; fileRef = BFECB5A821926764458845FF526DDA6B /* SPJSReceiver.js */; };
 		739323ADE67F0BF0DE02202786C47364 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8CF835B395E0A0C4CD245C5DC019AD /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		7420768A5792D40A5122083D0D58E2C2 /* QueryParamEncodableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5134E1744DB502EB07BE7CA2D0739398 /* QueryParamEncodableProtocol.swift */; };
-		74AFB49333A351F46FD30C0C55E2C9DC /* images in Resources */ = {isa = PBXBuildFile; fileRef = 3AE019D4EEC4EA171857F56855464099 /* images */; };
-		74BCC3CF3DD4DD4845FB5DE9A37ED3A8 /* AttributedStringVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E445224324EA4EC853DC4DA7AF760 /* AttributedStringVisitor.swift */; };
+		73CEC25F2BC403C72098BB47F50212B8 /* MessagesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B12C4D3E7CECEC700CF63C90E14D9A /* MessagesRequest.swift */; };
+		73DC5F451204E312CF6A4C08EF4F1096 /* SPGDPRCategoryDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B808D0A304860016288A645F95B37A47 /* SPGDPRCategoryDetailsViewController.swift */; };
+		7406E0A5B4C79A1A880E0E8E5F6CEB0F /* SPJSReceiver.spec.js in Resources */ = {isa = PBXBuildFile; fileRef = 25C3EBF0B637984D46D2172610B3F786 /* SPJSReceiver.spec.js */; };
 		74BF16160537FCBEBE26A6A757044CB3 /* WHTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BFE60FE731C6D6454BC1248F62E5B5 /* WHTextView.swift */; };
-		75F5F7EFC8EE3DF5B8F9B96C6BEEA965 /* SPCCPANativePrivacyManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00F8E0AE9705B47C4A9A184BE46431A /* SPCCPANativePrivacyManagerViewController.swift */; };
+		75889DA49EEEA94B39802361F494E86B /* SPCampaignEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F151B5C0933D8A655A7DF020970178 /* SPCampaignEnv.swift */; };
 		76088A9E146E3F76CCD6CBF36941E2AA /* BeWithin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E108468363DC7CF9494FD4110912EF2 /* BeWithin.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		762C4E617CD7E6CA375224992F74AEC1 /* CodeBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7AEE99DB02A4428037B0864E9F8D711 /* CodeBlock.swift */; };
+		763F87624BAF3474A58F999C478347C6 /* html.c in Sources */ = {isa = PBXBuildFile; fileRef = 117041B8647E513963A6BA13266955A3 /* html.c */; };
+		764A557A402309001947003CFF43D49E /* SPConsentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6874BBA7D9E7AE21FD890E2B7584FEF0 /* SPConsentManager.swift */; };
 		775CF794D2C5999FD67AD04291ED88E5 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BBB585B354A0FBE99C21B1C36D35A1 /* Closures.swift */; };
+		7781CA98B88D4A50BD3F53074BC3E3D3 /* SPJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099AE19CF3B7A3159AED28EE53DE3229 /* SPJson.swift */; };
 		77B56EF1F92DDF143E3BB0D4FD6CA35F /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = C97CD2F577668AFD8F544447A6328493 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		78788187454EFD5ED97487765BE0F639 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = C3C5C29210CD22378C6D7E9483EB41BB /* buffer.c */; };
-		78D6B123DA01816CFCD9F79F514EE624 /* SPMessageLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B803807F52ECA8CB5C7409EB5668EC /* SPMessageLanguage.swift */; };
+		77EF9CE1E63EFC64B7516E355015D71A /* jest.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 0DB88029D7BE239F468C617AC20AB271 /* jest.config.json */; };
+		78EA62EAB73961146F2D5E081C2CE072 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282733731A4D5C723DF051F47E92B452 /* Collection.swift */; };
 		792EF21DE18F4303DB1C58006809F125 /* Pods-ObjC-ExampleApp-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CD6B894B1009A4ECEB2DCAEDF78291F8 /* Pods-ObjC-ExampleApp-dummy.m */; };
-		79A4FF16EEDEEAFE8681125984DD5C75 /* cmark.c in Sources */ = {isa = PBXBuildFile; fileRef = 4255A9684099CC057C80BE7B5F8CD7FB /* cmark.c */; };
-		7A1E2FF2A212CB72E0F46FB68737DFEC /* Strong.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB437DC66245AD0C2BDC0A5C302AB1 /* Strong.swift */; };
-		7A576C0C9A569B0D2138F5D484E44B2E /* ThematicBreakOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7081DF63F8F7C26E5449D03D6A28AEE6 /* ThematicBreakOptions.swift */; };
-		7A67AB44F013A515B5AA5804FEE2BA53 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F14AA232F04EB7627811BC6CD5E590F /* Foundation.framework */; };
-		7A749D37729C4AEF34CAF7B1149C4F4F /* Heading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE3BDD2E631E61ED3520A5CC751820 /* Heading.swift */; };
+		7A3A4BC49DA83964A1F6A19E36E59909 /* BlockQuote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BACDA6E277E5B39C910B6A290643E0D /* BlockQuote.swift */; };
 		7AC995F567A776FC1A80A9FA0733F3D1 /* IQNSArray+Sort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB0FC247E2A3101C90428EA40F1F0E6 /* IQNSArray+Sort.swift */; };
 		7B0B008DD4BF428580CC3F387B4123B1 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0032D232FB89AF247FB539CA7C6F645 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		7B17F4B5967B85BAE618AB57FA9DF981 /* Pods-SourcePointMetaApp-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E41025D27A8A28123FBC9E5303F176B5 /* Pods-SourcePointMetaApp-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7B7BCC772B2DE38DFB7C66B651E9B406 /* Styler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3A5BCA07FC62773D3782117F0871384 /* Styler.swift */; };
 		7B89FD72FBA5CE466611C144C0061384 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC34A396EA216E294416AD4721B04981 /* ExampleHooks.swift */; };
+		7BD92510C39AF145700E112D3536A5E2 /* SPWebViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024869A0C07426817DF3CC3AD024EDF1 /* SPWebViewExtensions.swift */; };
+		7BDE2231296BD7DFDD9114F435A1CABB /* SPPrivacyManagerTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CB7EF4A828D46D4F0255622811021B /* SPPrivacyManagerTab.swift */; };
 		7C7E120B059999C139934554F32E0555 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 904C94CF67C84BF6E4E596BFF070663F /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7D0FFFC1862CC36177BF8E255B98BE55 /* SPGDPRVendorDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C8DFC548F02D6D13136EFF52E51AA /* SPGDPRVendorDetailsViewController.swift */; };
-		7D2E38129B017AF996FC5248BBDACF16 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460C615AE163149149EF5A26844398ED /* Collection.swift */; };
+		7D20BEDB64C86638BAE3BF993179ED86 /* MessagesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B12C4D3E7CECEC700CF63C90E14D9A /* MessagesRequest.swift */; };
 		7D43F95A1C4F36F3E370CD863E1E8AFE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
-		7D5B9413C851E75B68D60D434F291050 /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5459D9ADE3F53D06B748B04037F00167 /* Text.swift */; };
+		7D64C1187D721F971D7CEA9C671A19E2 /* SPQRCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42400389E67139027FDA2C6F1F479A8C /* SPQRCode.swift */; };
 		7D67AC2988F82E6B0F72FC1A967F92C3 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0032D232FB89AF247FB539CA7C6F645 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		7DE9B69135B46AE042CB7A607BA70243 /* SPNativeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CB6B9880FD351B6C08374FBDFD7C6D /* SPNativeMessage.swift */; };
-		7DF5F5CEF81E55F0916AAF4294C74310 /* SPDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF42833ED704F1D08E1588247A04BD1A /* SPDate.swift */; };
-		7E357ADB2FDC66157C93F6984ECE9419 /* PvDataRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F84A4260597992E19579D6359EBAB94 /* PvDataRequestResponse.swift */; };
 		7F33DD9E4E0361A19DA61E6BBBDD8565 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B9C691E324AE9E7F94E1561C96C4D8 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		7F55D5A4F3167CD7C32644D98F72C86F /* SPGDPRNativePrivacyManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C78C391518840A8E7006022EAF57E80 /* SPGDPRNativePrivacyManagerViewController.swift */; };
 		7F6AE748D5997EBC6658A6636FD2303B /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 264E52F029884E3FDBAA8282ACAAEF3F /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F73D710BD42B6865538F5F6A03EFA0C /* SPCustomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FCB144D77EC7A1406130899FADA337 /* SPCustomViewController.swift */; };
 		7FF4011775A6621749EBF58B9F3B37E5 /* Postman.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D6CFC5D7270163DB4FC94DF015D4FB /* Postman.swift */; };
 		7FFD891479B94B7809A95D260C78FB40 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B8B62FA761D8BEA52D7DEFA8EC55C6 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		804C860FFE4A6F77660003F2D54F2996 /* SPIDFAStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC21ED487A14977C49B886AC04D349A /* SPIDFAStatus.swift */; };
 		807E2AC1FCB241BB30AB4855BC0D062F /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6299AFFC345696A42141091DCDB1341 /* ExampleGroup.swift */; };
-		80813FC563F4055FC16DBA87936BF74F /* DownLaTeXRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CEFC6A0CC6A008931AFEBBB9BB993F /* DownLaTeXRenderable.swift */; };
-		80A7E6B00A37846EB3181DA74EC61EF4 /* SPFocusableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A809A545BBF7F5ACCE142F3DEFC24B82 /* SPFocusableTextView.swift */; };
-		80FD9BD89B2866DDACA4C3C74302D1AF /* SPGDPRVendorDetailsViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = F7D014C17997C779CCF417FC64A00A45 /* SPGDPRVendorDetailsViewController.xib */; };
 		813AE3D5F07A3CD245691C50DD09E8F1 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = E797A7DB019FE3394A969E7B42A29D4B /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		814DAA1C5F02924F9AAB2FEE3CD52528 /* xml.c in Sources */ = {isa = PBXBuildFile; fileRef = 329F04CD8054B9D66AD1907605155E24 /* xml.c */; };
+		81DD0F4D82B89C06EAF09944B8BE8526 /* scanners.c in Sources */ = {isa = PBXBuildFile; fileRef = 43A59EFF147B151F00B68CC489EF1F61 /* scanners.c */; };
 		82A39E5EA67419BEC50788B8DE8D4562 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6350587403D45403E667216ECE104468 /* XCTest.framework */; };
+		8330E5383CE8995EE6267B19A4635E76 /* MetaDataRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD271375B4B91D1F7C3304B8FEEA781 /* MetaDataRequestResponse.swift */; };
 		83C60180EEA0FD6B7F22FF74E2DCAFC6 /* WormholyMethodSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FE896ADE3757DF3DEA87A9165AFD77C /* WormholyMethodSwizzling.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		83C81D9CA03CAEE5B03DADBBA48EF249 /* javascript in Resources */ = {isa = PBXBuildFile; fileRef = 6DE94D7CBAABAB291F7AE4A21CE48D66 /* javascript */; };
-		83D8205655CADBFC20F48C577A0E018E /* Barcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 44F462EFF078F36D350AD3131AC159D5 /* Barcode.png */; };
 		841BC9A6B15C2D0EB73A2645E9CC0021 /* RequestResponseExportOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4AA5CC1F2A2D60B5832E735EC0B968 /* RequestResponseExportOption.swift */; };
+		84513EC042577E76F5137AD44FABF822 /* SPCCPAManagePreferenceViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 71899FA654FC2A36F8FC057719CE8B3A /* SPCCPAManagePreferenceViewController.xib */; };
+		845BCF73C4721034FE3DD25CC7D1A93A /* cmark_ctype.c in Sources */ = {isa = PBXBuildFile; fileRef = DFB18C136DCE99B90FF7D411931EB2F4 /* cmark_ctype.c */; };
 		847C7C3CD29EB417A78C7B934F18B399 /* BeginWithPrefix.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C11695EE5B193D1F0D8BF72B9C9AA7 /* BeginWithPrefix.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		84D054917897C212417B148A8A28F542 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28AC251F58EA3598F307B0408E60056 /* NSBundle+CurrentTestBundle.swift */; };
 		85F13B069B06ADF2B6DCA622E4645110 /* IQKeyboardManagerConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A769B7B07BFE25CF2F46555EA8C33F /* IQKeyboardManagerConstants.swift */; };
-		86499B6FCED84C2FA58BE2E66F66B2A6 /* Bundle+Framework.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C52023C0BE5895911B529281CFA8D3 /* Bundle+Framework.swift */; };
-		867116FDB336D20E8EBF9DB9395350BF /* SourcepointClientCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3CFDECC0F12E3CBBFFC8D027D853DC /* SourcepointClientCoordinator.swift */; };
 		86A03DE9366D1BE94EB99AA387EACD1F /* IQKeyboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E41F9E4F7F59DF33A7450045E91FAC /* IQKeyboardManager.swift */; };
-		86FB16502A47B9D02069F0A82FAF84F6 /* SPWebMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A492BCA73059A5069E9F8278726E515F /* SPWebMessageViewController.swift */; };
-		87302388AFE5A784F26AA2A1334875EA /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DF058A61D708AF2FB75A61C5C773A8 /* Document.swift */; };
+		872C0736B2C331825C3253AB20FF60C7 /* SPUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E6A455FB1B245997F231B89D2C082A6 /* SPUIColor.swift */; };
 		87AC8D36A1A7EE308DEBE9AB25FF6711 /* Quick-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 721B0C7C51FF28CEFB75F3941BA81EA6 /* Quick-iOS-dummy.m */; };
 		881732A282391F32DD8A6C99941DE098 /* ElementsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = C376E206D0D66370BA9AB1F8832BD3B8 /* ElementsEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		8897BB2703B7BB4B4760294FE4EBF293 /* cmark.h in Headers */ = {isa = PBXBuildFile; fileRef = 260AEB7610E3844784B70DD9972E25A0 /* cmark.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		88E4C9596C5CAB21C9EEC710C50BC2CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F14AA232F04EB7627811BC6CD5E590F /* Foundation.framework */; };
 		89079DF3A275518BE5DB85B9BFC6DDC4 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD71BF64D33A5EE5A322826A6D0E381 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		896E09D9B62EB8F948A00F0546467D07 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25554D9FAA26AE20BF956E70CF34111D /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		899C875767DFEDDCFB588BC1406D3F76 /* PvDataRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C09866DE5BD008CCCB89F1F635DA621 /* PvDataRequestResponse.swift */; };
+		89A1347E8651438D9A102629547C39AC /* ConsentViewController-tvOS-ConsentViewController in Resources */ = {isa = PBXBuildFile; fileRef = 20A4710BBD2EE3CFC496E3AF134BD4FD /* ConsentViewController-tvOS-ConsentViewController */; };
 		89A237F1777DC9FB7FC7616350F48793 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A21A8A668B97E7B42405AC8FFD20999 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		89AD53FD6F377D272B66C26B57779B75 /* Pods-SPGDPRExampleAppUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E735ADF04B48BEEF187FCD9E0BEC9586 /* Pods-SPGDPRExampleAppUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A4186AC05EE822B66C6D3BB6D7C8316 /* JSONView-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E31D965307FE75500537823A0BB4E322 /* JSONView-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A492E15AC13DD3A4832B77238057EB2 /* WHTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157FC1A2B09B5196FB27B65EAEB31FCE /* WHTableView.swift */; };
 		8A7A1BC68F5CF770015DBDC7631E677F /* BodyDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED53C7A7A4F09274BBF9FF96AB04E6B5 /* BodyDetailViewController.swift */; };
-		8AB2FF6177D3AA81CF0BFA955E23E2CC /* SPCCPAVendorDetailsViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 127EE88A356B276B186DC57DB052B67D /* SPCCPAVendorDetailsViewController.xib */; };
-		8ACA380FF967DE43952AF57B4B61002C /* SPPrivacyManagerRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5595D26CD0CE5203994A89F8AB1F68FF /* SPPrivacyManagerRequestResponse.swift */; };
-		8AE7C717B6908A2D296F9B92EA3CDA84 /* BlockQuote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BACDA6E277E5B39C910B6A290643E0D /* BlockQuote.swift */; };
 		8B35E817BB01F2DD7EDC5863523A81FF /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFAFF577444917A6AE859D33710B94A /* QuickSpec.m */; };
-		8B743D0B6631FD228CE634D33513613F /* commonmark.c in Sources */ = {isa = PBXBuildFile; fileRef = F17AD4E54096E2D9DB39C7DB4E565F8A /* commonmark.c */; };
-		8BAE42566E46970C56FB4A23F9FC44AE /* utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = BD31644DADCD4A243771D8DD47442F62 /* utf8.c */; };
 		8C3E5369B3EEE38A1F3E71AF0D562A66 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F9CE199E7234100943A082F7090697 /* XCTestSuite+QuickTestSuiteBuilder.m */; };
+		8C86806B3F489AFA1B6C8745D9938422 /* SPJSReceiver.js in Resources */ = {isa = PBXBuildFile; fileRef = BFECB5A821926764458845FF526DDA6B /* SPJSReceiver.js */; };
 		8CD80D320A437048D1469AA382719CED /* Wormholy-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 97744050CD3BA0B1EC4B29A1FBC3E186 /* Wormholy-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8CF0093BCB53496A0810EDE254414BD5 /* QuickObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = 932965E644537AC076786ECEF9097623 /* QuickObjCRuntime.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8D9B74A3CBF6D662311147AF53153856 /* cmark_export.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C1EAD5CBF0790B3DDBF1971FE4A926 /* cmark_export.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		8DF6F61CE787B463382222BEA41A7237 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CEF68E4C3B5CF489641AF1F5B0FF6D /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		8E24C3D0089C812F269AF79ADE7AC921 /* DownStylerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF200C29F5757D84AB72546365956279 /* DownStylerConfiguration.swift */; };
-		8E5764C4EDA1880EF50F24941B52963A /* SPCustomViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = E4B90D884A1E8F6702545EEA3217C6DB /* SPCustomViewController.xib */; };
-		8F85AB8F972DF0D6694D9CF035A063CB /* SPCCPAConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA01C3D38F1284A8C46DC024B42B4A6 /* SPCCPAConsent.swift */; };
-		8FBAC81908883C735F2F05A79A3DA72E /* SPJSReceiver.spec.js in Resources */ = {isa = PBXBuildFile; fileRef = 24B9714020F6EE241E4029F9D71FB4DD /* SPJSReceiver.spec.js */; };
+		8EE95A80F1D826DED5758C19E615FC23 /* AddOrDeleteCustomConsentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA59492BB5FDCC898516A27C6F6D2AD /* AddOrDeleteCustomConsentResponse.swift */; };
 		8FBF46C321A343806F66994ABE672723 /* DispatchTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878715BE17B7F8EEE0EE94835AE58C98 /* DispatchTimeInterval.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		9000003347A315E78EFE8CF6B485FCAA /* FileHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA329714BAC4D98AC0B97306AA80D9B4 /* FileHandler.swift */; };
-		90A2005F795598B6A27C01839D728F06 /* GDPRPMPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D65378A1B8E46EE5F67210393414B57 /* GDPRPMPayload.swift */; };
-		90C6CB8159AD28A3CC83B65246147390 /* SPGDPRPartnersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514C4E9A23F6AD1DB6E7310AE8C77F8C /* SPGDPRPartnersViewController.swift */; };
-		916B094B72533396023C75425753E6BD /* SPCampaigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6B5593EE61980CC9C62A1AF03D4990 /* SPCampaigns.swift */; };
+		902ED6C92F8CF929990C4E5B84B63D42 /* SPGDPRNativePrivacyManagerViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = C995D751887BE3C8F691C0C521442AD2 /* SPGDPRNativePrivacyManagerViewController.xib */; };
+		904FF4FC9BC800F4C72FBC66144C4188 /* SPMessageUIDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47EDE3AA6C6E1DE2C97AC3AA44619B43 /* SPMessageUIDelegate.swift */; };
+		90798214EE317569F8A7B526D0201747 /* MessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD3F2BD4D00E9574790ACC3405E443 /* MessageRequest.swift */; };
+		9089E53D806C98C50756CBACEFACBD43 /* inlines.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49BC421FEE8709A52890556B3E6197 /* inlines.c */; };
+		91415A20AE03DD72D55CD2B112090A14 /* SPNativeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5104F5ECF953CA5841925A2E54FCD1BB /* SPNativeMessage.swift */; };
 		918D1D7917B9405308843EC8B956DBF1 /* Pods-NativeMessageExample-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AC0A39714B6C57DA8F69184FA513363 /* Pods-NativeMessageExample-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9222093084E7BBEBF89F6CF578716E76 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3A7F1CDBF86AAF8BC24D91BB329589 /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		9225ED7EDF8C310923271879CEBEBF21 /* chunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 3072869E17E16DC8447F4923925AF669 /* chunk.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		924C71BBF57628EA66A0C0BFC355A796 /* ConsentViewController-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 584FD3F4B671BF7B2DD12426DEE51951 /* ConsentViewController-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		928DFD8734B81911B0089FEE3EF9DE6E /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC4EC8308E462115E693E5966185CA7 /* Code.swift */; };
 		92A105AA5C80BD8FCF22FEA93A39D2B4 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28AC251F58EA3598F307B0408E60056 /* NSBundle+CurrentTestBundle.swift */; };
 		92AEA0919DDEB8D5E611B74E63837C58 /* QuickObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = 932965E644537AC076786ECEF9097623 /* QuickObjCRuntime.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		92D2CAA5FE5AA3F1382AEE48126B32D2 /* buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = E3990458C340AF97F1CC940D19CA7E33 /* buffer.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9302E300C0C1C23664687B27ABE5751D /* DownAttributedStringRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135E1342AB961BE0D0B71A03B9EDAA81 /* DownAttributedStringRenderable.swift */; };
 		933816828605B35FB7305AFFA071B6D0 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 1B83C1EF010747D15760FE6A52D72BE7 /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		93432A6A0D31937859A4156AB1B5AC3E /* SPJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099AE19CF3B7A3159AED28EE53DE3229 /* SPJson.swift */; };
 		9348B34237AE2975E20AA8D604F1423D /* WHString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D5B80ADB162722509684E405FE6437 /* WHString.swift */; };
 		935557E2ED1490E3CE73179D1E175332 /* TextTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C2AD4FAEBDF5E270D3D8E565589880 /* TextTableViewCell.swift */; };
 		9385F903C1A926E203BCA6A9BA192CAA /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0E3CD9E2006DAAB5710802CD11B6D7 /* Callsite.swift */; };
-		946ED9BD634516DF7281FE094881C779 /* ConsentStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC74D56FDDCCD5DBDF2F603F5BEB55C /* ConsentStatusResponse.swift */; };
-		94A1F85585D28C1246CE68DAA85A7A85 /* cmark_ctype.h in Headers */ = {isa = PBXBuildFile; fileRef = C3B6F134DE0CE4BE0763FBD533D71D0A /* cmark_ctype.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9518BAACDC444D786764F90A8B251678 /* ConsentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B252B8E80DCE0FD094FA558FCB0B5320 /* ConsentStatus.swift */; };
-		9554144B844C867CADE860A5473F120C /* iterator.c in Sources */ = {isa = PBXBuildFile; fileRef = FA53C49EE9E47CCD7458E36103D8D8B4 /* iterator.c */; };
+		9497CA192F7C7080878C32A58FF985F0 /* node.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FEC456ADDF2069AA24CA59D508A3A65 /* node.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		94B37DE5E5628A32F37F019C44DF07CA /* iterator.c in Sources */ = {isa = PBXBuildFile; fileRef = FA53C49EE9E47CCD7458E36103D8D8B4 /* iterator.c */; };
+		94D0C783B1CF1327931668352744024E /* SPCampaignType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34866691E75484824EC739581DCD053 /* SPCampaignType.swift */; };
 		960B6871BAA93D1364063477780ACC2D /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = A62B616AE6A6F954362F28DD8D88366B /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		966D04150537604CEF1C2F45E00880BC /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD7D4A1D044FA2204A01761C94CF067 /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		96AD1EECD396BAE6524F91EDD78883E9 /* jest.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 5B5D7BE97D7E130364D1F4057289EC03 /* jest.config.json */; };
 		96AE6B66CB0F164B3FA8E697FFA3F4D2 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BBB585B354A0FBE99C21B1C36D35A1 /* Closures.swift */; };
 		9754A17BC760F8D3A4B538DAE9944CCE /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 53830D02039DE43B2FFBF8AF6FF4A78B /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		976D52BBD81E46FDA07DE277B62CFD23 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 1B83C1EF010747D15760FE6A52D72BE7 /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		976EA059E6F511587739516514C36A27 /* SPLocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A79E6E7F82594FE03ED849144F29C8A /* SPLocalStorage.swift */; };
-		976EDA6710BA2115FFA3CE341DE6085E /* SPJSReceiver.spec.js in Resources */ = {isa = PBXBuildFile; fileRef = 24B9714020F6EE241E4029F9D71FB4DD /* SPJSReceiver.spec.js */; };
 		9784B80307CF03C9139A0F2F901DE486 /* Pods-ObjC-ExampleApp-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A2E4695922171AB0B0A489E7FE4127B0 /* Pods-ObjC-ExampleApp-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		97BAD5386DB86E57C8121DC5BB9EB7EA /* NSURLSessionConfiguration+Wormholy.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D21FEF1C9571A8DBCA6B3EC4628EBDB /* NSURLSessionConfiguration+Wormholy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		97BF6421BC7C5EE4DD8B70FBCEB3F7A5 /* SPGDPRManagePreferenceViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 8E26BF4E53CA96AEA636343BD452394F /* SPGDPRManagePreferenceViewController.xib */; };
-		9832DA7FCDBAB8700C62D3B1F16963F2 /* Bundle+Framework.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C52023C0BE5895911B529281CFA8D3 /* Bundle+Framework.swift */; };
-		98CEBB2DF52F87B152F7ED154C0239FA /* SPPrivacyManagerTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF8480E5D04F34D740E0BF306B6EFFC /* SPPrivacyManagerTab.swift */; };
+		98080A0910BBE8094E4F3152C0D9B4FD /* SPCustomViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 978E3F03E764292B1C1A142E4636C0E8 /* SPCustomViewController.xib */; };
+		98AE8F228AF19CBBA11E48F190C3E83D /* SPString.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55659631F09CC0006809BF9DFAB5EEA /* SPString.swift */; };
 		98E831815093E1E4775BC85A092FCDC8 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E63CD0945B9D178FF0CC2AF2751C72B /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		99D0A3F07DD28D2CA895094E581408EB /* jest.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 5B5D7BE97D7E130364D1F4057289EC03 /* jest.config.json */; };
+		99928BCF42A6CE2741DD6D38425381B2 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC4EC8308E462115E693E5966185CA7 /* Code.swift */; };
 		99DCB7412F69FD36A8D8B4685994268F /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFAFF577444917A6AE859D33710B94A /* QuickSpec.m */; };
+		9A3465AB8088C8D6AF6EC4347A53935D /* CCPAPMConsentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C76D8D0D249A6C90C926901BC2B964 /* CCPAPMConsentSnapshot.swift */; };
 		9A3B2C0A35401EF3EC592A121BD22EC9 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A772930289BCF3CAA8EA3D19487AA1 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		9A549E583981974B03714BB2141D7110 /* DownStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30BC4A2BB02509CD9B6921D29507A79 /* DownStyler.swift */; };
-		9A781B27DCBB7CD11039F7328F8A77C9 /* LongButtonViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD53F1406CCCEB589874F2718A8E25A /* LongButtonViewCell.swift */; };
-		9A894773ACFD99AA2B0FDDBAD579E51F /* SPGDPRCategoryDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4477BB8570CEF4A854228B7BAB01F423 /* SPGDPRCategoryDetailsViewController.swift */; };
-		9AA177B1BAA2610F9EDD1A04074C72F7 /* scanners.h in Headers */ = {isa = PBXBuildFile; fileRef = D21A71AD36A279984DFE6049180C8C4E /* scanners.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9AA8871DBE7C5BE0F2DF1108978DB971 /* DownErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9C04673231C48B2E6ED42A2AB6D34E /* DownErrors.swift */; };
 		9ADD01EE9D1A8C50707D5D0B1300B909 /* QCKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07138E598D41B9BE88401A889CECB6E1 /* QCKConfiguration.swift */; };
-		9AF321AEE67E178172712CA532AFA464 /* ChildSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FA610780C15C414C40385861A21ED4 /* ChildSequence.swift */; };
-		9B6143547566F8822F4BB9869AE649E6 /* SPURLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820FF5AFD0E80C8C6941CC7EF4CAAF40 /* SPURLExtensions.swift */; };
+		9B4D5E6F4798A9C650889A60F2A46057 /* SourcepointClientCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB34657D9ED942AFDD2DA7839D04063 /* SourcepointClientCoordinator.swift */; };
+		9B71663F4E03E95AC94FB72F202C83F0 /* DownTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F15ADA74D492BAC76AB3EDB6C12D3D /* DownTextView.swift */; };
+		9B7F6BF8A77460752215D1B682592A9B /* SPJSReceiver.js in Resources */ = {isa = PBXBuildFile; fileRef = BFECB5A821926764458845FF526DDA6B /* SPJSReceiver.js */; };
 		9B88AA76329E860E4A37E8158CC5654A /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3459EB4E85FE56BAB2781890A10BA3BC /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		9BD1C0C3923D85BDD91B6BFFDE1697B9 /* cmark.h in Headers */ = {isa = PBXBuildFile; fileRef = 260AEB7610E3844784B70DD9972E25A0 /* cmark.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		9C0F0AFD947258D58EA69FFD981333FB /* QuickConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92321CEC968DCD4908350231D8D17509 /* QuickConfiguration.swift */; };
-		9CF4C91C6DC02CF7DDC33C24E6697720 /* SPUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F01F54D5755E2A41C32B8A844B29DD /* SPUserData.swift */; };
-		9D1D83DF14B08E72FB5DD615E7EF6B6B /* ChoiceRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439477ADCB521D4280C2A22395DF57E6 /* ChoiceRequests.swift */; };
-		9DF9367380F8A98CF61697B9AD38A79E /* ErrorMetricsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F230947DA34DF18BEB412F130148E3BB /* ErrorMetricsRequest.swift */; };
+		9C3419F7D6EBEEA3FE766862BC874FBC /* references.c in Sources */ = {isa = PBXBuildFile; fileRef = 6CD786494CC6EFDC2693FBE7DDAFE2F5 /* references.c */; };
+		9C904643C59D92581D0C6965C880907E /* MetaDataRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD271375B4B91D1F7C3304B8FEEA781 /* MetaDataRequestResponse.swift */; };
+		9D21A6CECFB4371ED6F7C61BA4880FCE /* ConsentStatusMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0C0D6E820FBB1090FFA6175AC9BDFD /* ConsentStatusMetadata.swift */; };
+		9DD145209E8401E578C11B49F5F3D65A /* ChoiceRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE5CB34B4AB1F63B2555EF3D87038CC /* ChoiceRequests.swift */; };
 		9E02BF83DC5E871EA1D3B28994B0A1A6 /* Pods-SourcePointMetaAppUITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E99BDED1E6FA8CEF01BF1ABCAC4C475 /* Pods-SourcePointMetaAppUITests-dummy.m */; };
 		9E36D6BC753F4D70CAF6053C9A0A4D6D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
-		9E835293723B9CAD4F0D75B3415B1A06 /* SPURLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820FF5AFD0E80C8C6941CC7EF4CAAF40 /* SPURLExtensions.swift */; };
 		9EFF7898F3B4E26D1E6C793BFFE7A5E5 /* Pods-SPGDPRExampleAppUITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3341F72CA9008F857FDC21E11D28934E /* Pods-SPGDPRExampleAppUITests-dummy.m */; };
-		9F5648C1C017255F2FD736726A11E230 /* blocks.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FA81AA6EA32A93532A7594E869D3299 /* blocks.c */; };
+		9F24C8046C399338FCBFD4A5B0F46F0D /* SPUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E6A455FB1B245997F231B89D2C082A6 /* SPUIColor.swift */; };
+		9F2D48F1E9FDDEB061A3062D2F6A499B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
 		9FB5B8C302F44E02838C5F51A98F0DB2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
+		A008ACB4CB8284C84ABDC6A5B7002B45 /* PMCategoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB50DECADBBA55B54D01AD8F6EBA0106 /* PMCategoryManager.swift */; };
+		A09F4829078460DEB3A2118670176016 /* SPDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB015AFF56EBB905B160D80CADCE889 /* SPDelegate.swift */; };
 		A0CCB3898B7BBFC7C201B7BBCF7245BC /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D5368B55EA84908DB0B3619DA8A1F9 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		A0D4186E891AE76EA0525F9B91757851 /* DownRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617BC5E5ED6957F2FE55CFA65E0A023A /* DownRenderable.swift */; };
 		A0DFD37B68319A82ACB6988C64761A8B /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46FD5A5C89B78C89056BED3CC9CC1D74 /* ErrorUtility.swift */; };
 		A20ABC648777D13FA9492E559D1498A3 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC34A396EA216E294416AD4721B04981 /* ExampleHooks.swift */; };
+		A234648CFA7A1BE7A8D2F818F08D06B2 /* SPJSReceiver.spec.js in Resources */ = {isa = PBXBuildFile; fileRef = 25C3EBF0B637984D46D2172610B3F786 /* SPJSReceiver.spec.js */; };
 		A23E22F3E05399C7390833D742980647 /* Pods-NativePMExampleAppUITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 720650416794F9CDFA5986D3D05CFBEA /* Pods-NativePMExampleAppUITests-dummy.m */; };
-		A340E0D7878F6653B071D12A01665673 /* SPCampaignType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E84631157C0FF4981393CCAC765E14C /* SPCampaignType.swift */; };
+		A378B1A3798BA87FEE35A01DD116F59C /* SPPMHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57396400EE00521565E70F98E6BDFD1 /* SPPMHeader.swift */; };
 		A41C6A275D182D7DD0E6F852A9EFF182 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15ADC04FF459E84C6ABC2BDB65630B5 /* DSL.swift */; };
+		A41CCB2072B85EDF6D386871628C677E /* SPStringifiedJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9375B3FF39FE8E647DEF816E4A4BA4B /* SPStringifiedJSON.swift */; };
+		A4609C4B7BFD9A2C09FDF30879ADA62C /* SPUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8D3AB99F3203C5A3038F0B05514618 /* SPUserDefaults.swift */; };
 		A4982B494F2E3CB066938970D6F3F9E1 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD3571F06BA6522D948405B220E90283 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		A4BAEE317BFF650DCC888FC67BFBF7EF /* IQKeyboardManager+UIKeyboardNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2450198951C7A04D49D9EC3D4796A23 /* IQKeyboardManager+UIKeyboardNotification.swift */; };
+		A4C6E5A326A59304CCCC6D310B0A368A /* Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701793AE80F8D38D3B7EE579EDC49DA2 /* Link.swift */; };
 		A4C9EB97F20B7C24E713C0050829D6E2 /* Wormholy-Wormholy in Resources */ = {isa = PBXBuildFile; fileRef = AA92ED38E716E03D3FC758C810953B95 /* Wormholy-Wormholy */; };
 		A4F92CC3E00382BFA18D255FBBDE9D97 /* Pods-AuthExample-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9003A744024FE2D5F4EA717E4524F872 /* Pods-AuthExample-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A57CA2963EA88D543295B6EE5B8FBCC0 /* BeginWithPrefix.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C11695EE5B193D1F0D8BF72B9C9AA7 /* BeginWithPrefix.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		A58CDCAAB593C24FCB3F22F67BE1E512 /* node.c in Sources */ = {isa = PBXBuildFile; fileRef = D796E9E3C0C9CD2EEB46A54519800192 /* node.c */; };
 		A63E618214C11DFD86BEEB5D2DFD0355 /* WHCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED0566FE4F1AAD73E29261F2647D4CF /* WHCollectionView.swift */; };
-		A6F29B7818C52B9B212B4ACFF122C20C /* SPCCPAConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA01C3D38F1284A8C46DC024B42B4A6 /* SPCCPAConsent.swift */; };
-		A761BE20CB64A5564A842655829C2410 /* javascript in Resources */ = {isa = PBXBuildFile; fileRef = 6DE94D7CBAABAB291F7AE4A21CE48D66 /* javascript */; };
-		A7A3781A754F0948602AC660113594A8 /* houdini_html_u.c in Sources */ = {isa = PBXBuildFile; fileRef = 3733B89950161339721CBE2E1CBE2E10 /* houdini_html_u.c */; };
+		A6DC7F64713840FA60274AE9613B5233 /* DownHTMLRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C443E6DD1ADC19142B5667B7378C9880 /* DownHTMLRenderable.swift */; };
+		A7DD3307F3623C072E3F3335076DEDCB /* SPSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B69A493B5BB16AFB91A94CCF3EC370 /* SPSDK.swift */; };
 		A8171E010521F550403CAEDF4B9A48C1 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = E797A7DB019FE3394A969E7B42A29D4B /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		A8AD0AB5B168687BA30BE7980BB12A83 /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B925A01B46DC4576D5A7DCEDDB5DD6C6 /* URL+FileName.swift */; };
+		A8B2D6EB18BAF46E9D8FB1D7AB6B9E73 /* IncludeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74C9B99E79D5B4E81470F0EE516B998 /* IncludeData.swift */; };
+		A8E84039664DB68EE8348F5E4AA6EB13 /* SPCCPAConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845B339986C9074BC7AE11FF95931123 /* SPCCPAConsent.swift */; };
+		A8F1911B92C8DC791862BCFFFB4DFBD3 /* IDFAStatusReportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6F7D1208E608AAE2535D9ECDFE3259 /* IDFAStatusReportRequest.swift */; };
 		A947E91D304F0EF7932F96962316067A /* Pods-ObjC-ExampleAppUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAFEE9F8D9EE1D309453F1F7B3350B6 /* Pods-ObjC-ExampleAppUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9F77D665A03B2E7C46E6C60CA440FFF /* NSMutableAttributedString+Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96FDBF32869B4E9BEA3EBC65DE5F273 /* NSMutableAttributedString+Attributes.swift */; };
-		AAB454A021CE70A3CD26D3B37AB03F7F /* QuoteStripeAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7A51BA7B38F5001CC54F7CB031B708 /* QuoteStripeAttribute.swift */; };
-		AADAC7E56A73377EEEA94C3E3BF7BB51 /* SPConsentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85151050329E96D5DDA93AA7EB8A335 /* SPConsentManager.swift */; };
-		ADDAFFE0640B80CFF4F4C81845DDD9BD /* SPLocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A79E6E7F82594FE03ED849144F29C8A /* SPLocalStorage.swift */; };
+		A977EFBD9CE3B017F34846445977CBB3 /* QueryParamEncodableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8BE80A9F24548A9A2102421EADEB0 /* QueryParamEncodableProtocol.swift */; };
+		A999E109423B69F02514DD3F08A48463 /* SPLocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71857B94D3E4661FABC88C0FAF764D2C /* SPLocalStorage.swift */; };
+		AA225BDA4F05E65D9ACE403D92EB79CE /* SPCampaigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64B56D57B02D8D11C91C959BA4069BC /* SPCampaigns.swift */; };
+		AAC01F68DF3685494BB8867779D2607B /* SPPrivacyPolicyViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = EED581AAA5B3AA02FA8C571320995C16 /* SPPrivacyPolicyViewController.xib */; };
+		AB84C91DF3E9E56CB1A3105EB89F705E /* SPJSReceiver.spec.js in Resources */ = {isa = PBXBuildFile; fileRef = 25C3EBF0B637984D46D2172610B3F786 /* SPJSReceiver.spec.js */; };
+		ACB44957980530398957F0D6AB878E74 /* ActionableTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C511053A4578911005F325403FEDD36E /* ActionableTableViewCell.xib */; };
+		ACC02B294165533FCB1B4E27FBC3F457 /* man.c in Sources */ = {isa = PBXBuildFile; fileRef = 44CD8A72F3A29EF02EE34B2A6EFB7EE9 /* man.c */; };
+		ADDC2150CAEC49C690D21243C5327A67 /* SPMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F803628BFA08F2F555342D92731F3B /* SPMessageViewController.swift */; };
 		AE029A1BF86B6DEE65A9ABF28A6AA3F6 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 264E52F029884E3FDBAA8282ACAAEF3F /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AE1479E3CF561968A01BC2DE9C913901 /* PvDataRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F84A4260597992E19579D6359EBAB94 /* PvDataRequestResponse.swift */; };
+		AE5BCDC323EB202AD39FA6870D0B9506 /* DeleteCustomConsentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BBBBE57C72E2AC7FBD58BF6D0D9246 /* DeleteCustomConsentRequest.swift */; };
 		AEB01D60E93B68F656DF1738469F7E3D /* Pods-NativeMessageExampleUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B70E31B5F5D148C1410F07F7C6C78ED /* Pods-NativeMessageExampleUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF0D01E35D8991A658FFE2D29EE5A2DD /* SPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F643506E178F3E11AFFEBC84FF28857 /* SPError.swift */; };
 		AF28067741ECE83C1292C78A71936835 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27E7590E21F4CF0EF3F520B93B1FA63 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		AFB61058B5B66AE981CF5A6FD4B1E137 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = C51645FD8897485F1D69445B38DAE43C /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		AFCD36B21854863CECCE408D12580A08 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
 		AFCE325B306DACC57EF5A1536645237F /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB25B07CCBB900612F3038AA46140FB /* Example.swift */; };
 		B07F8454F9834C4F22811EB690451E3C /* String+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9A2702875DD2CA1970105832580D39 /* String+C99ExtendedIdentifier.swift */; };
 		B084D59A01F325CB6C69DA6A718B98B6 /* Pods-NativeMessageExampleUITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E5B52CFD39A36F161C1EA59074B519 /* Pods-NativeMessageExampleUITests-dummy.m */; };
+		B09C6D88BEF9C62007DC43A74194FCCB /* PvDataRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C09866DE5BD008CCCB89F1F635DA621 /* PvDataRequestResponse.swift */; };
+		B09E6225A40EF72B5FF01BF0F6F16EF5 /* utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = BD31644DADCD4A243771D8DD47442F62 /* utf8.c */; };
 		B0D7A167010E5F743C6C16911F1085F0 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80168F271651A604523035FD37B31496 /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		B160A0817E30FC9E70F2EF074B1154A0 /* DownCommonMarkRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92814138089BED333E2B2E1E6F205E9D /* DownCommonMarkRenderable.swift */; };
 		B18E85E5F234FDA6B5842B7E8EF6FF6F /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9B524B32EBD31EBE91A65B1AEAE2B4 /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		B1A9A84E7EAB0ACAE20A023BC7AFEFDA /* MessagesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33D1CA7157620140646E3E0564ED248 /* MessagesRequest.swift */; };
 		B1B6A2491AC437909DABE20C71BECDBC /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19110D21508DAB9D98C4C5D0BAF23535 /* CoreGraphics.framework */; };
-		B4299CF17A30E51B3E2E3317D9C97895 /* SPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177DD5FB31148C2407BA8D43A0902DB7 /* SPError.swift */; };
+		B3AD072C342B6E0035E3ED822A556DF9 /* CGRect+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D30DD3C99D443D22DE81C3C4225D05 /* CGRect+Helpers.swift */; };
+		B43A31F53F1C1F92146F22D1D9D81FDA /* ErrorMetricsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4F80DF4A9707BD0EE7C79298BE4E51 /* ErrorMetricsRequest.swift */; };
 		B44E7EEF87BF99B3A42C85119DF0AC63 /* RequestTitleSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE728651825B45170142762B9F92BC /* RequestTitleSectionView.swift */; };
-		B475266C0902180E7292ED319A7835CC /* scanners.c in Sources */ = {isa = PBXBuildFile; fileRef = 43A59EFF147B151F00B68CC489EF1F61 /* scanners.c */; };
 		B49A110C61CA445E3EC8F5B4D91652D0 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CEF68E4C3B5CF489641AF1F5B0FF6D /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		B4E64303527304E86FB4ADD043672E62 /* SP_Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 0C5FF8AFF5BB78C11B41EDBDA9311585 /* SP_Icon.png */; };
-		B5C625AC4C8CE0EC448E55AC5AFBF387 /* SPPrivacyPolicyViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 7ABC8ABDA6DCCEDAB9FC6D033BF89939 /* SPPrivacyPolicyViewController.xib */; };
+		B4F1A277A9599866A749FE9286D3A4C0 /* SPJSReceiver.spec.js in Resources */ = {isa = PBXBuildFile; fileRef = 25C3EBF0B637984D46D2172610B3F786 /* SPJSReceiver.spec.js */; };
+		B54165E4F839BD6F802366F75434B0BD /* DownStylerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF200C29F5757D84AB72546365956279 /* DownStylerConfiguration.swift */; };
 		B5CCAA12D451B5A2DA163D5697787FA1 /* NSURLSessionConfiguration+Wormholy.m in Sources */ = {isa = PBXBuildFile; fileRef = CF4B3B28EE8125F595325B427398FB51 /* NSURLSessionConfiguration+Wormholy.m */; };
-		B5CE746A2078B0E7CC783A7705D3AB5B /* SourcePointClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFA6B36ABC056586579FFA6D736DA71 /* SourcePointClient.swift */; };
 		B615632E352E40C168446F677530A789 /* Pods-ConsentViewController_ExampleTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 180EA410C8CD013748DA27C8F91AE330 /* Pods-ConsentViewController_ExampleTests-dummy.m */; };
-		B625825A470502B6724CB0AF4CF0732E /* jest.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 5B5D7BE97D7E130364D1F4057289EC03 /* jest.config.json */; };
-		B6600B5C8406E69D582ABB7E5C145824 /* SourcePointClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFA6B36ABC056586579FFA6D736DA71 /* SourcePointClient.swift */; };
-		B692D5045153FA7C9C447646E37C43CA /* NSObjectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2F6FF780EF05D13850B9B75F93F9BB /* NSObjectExtensions.swift */; };
 		B6B43B1B78EC0E52CC08F82841A22A31 /* IQKeyboardManagerSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B1F086384F6B2F848A9A1256E8E74A58 /* IQKeyboardManagerSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B6EC6D40823E66D5B389ACEAC9FD7AAE /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A0A4F9E0A88F1089D54ECAE44A14BD5 /* QuartzCore.framework */; };
-		B6FE19F9F52705600639607CD2069277 /* SPPublisherData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6EF1ACD40341510CD18A00EE40C2E3 /* SPPublisherData.swift */; };
 		B8361637C4E133D9B4C21E3382F47001 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AF8C147B159EAFD671BEA2D92724E7 /* QuickSelectedTestSuiteBuilder.swift */; };
-		B8C3927244EB12B8512F2D8721EA0996 /* SPMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C97914BE77B99E39621A9EC7E58C21 /* SPMessageViewController.swift */; };
 		B8D7D1AE055873AEC92D89A74C2B99D2 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B719545A6909C9264D7360E140E74 /* World+DSL.swift */; };
+		B905B8EEB641E3F1B1A8F42A7A95BD97 /* SPPublisherData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA768698B1E6F086512B8C99BF5A2F1B /* SPPublisherData.swift */; };
+		B95C29E1A4087CD21DA8A0B6FC7AF8EB /* ThematicBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CBFD733E83362BED7DF5FDB665DF8C1 /* ThematicBreak.swift */; };
+		B9AD66EC489D2782D044A71BE1A777F8 /* ChoiceResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB8C0E307B1A76FB7D46C8227CA208CB /* ChoiceResponses.swift */; };
 		BA746FE274B45095BFCF1FFF7A7E0A9D /* CustomActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C3960918EE14D8B5928FFE66526DFF /* CustomActivity.swift */; };
+		BA7FE50DC34F53E27740658FEF006A58 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F278F01ABEA6ADF72283305E88470CB /* Image.swift */; };
 		BA87A402244EE14A5D467FF041EBCD22 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
-		BA9DA2608A60B5DF65DDFA0CAB75AC96 /* SimpleClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C4F96A0A4D2D507766ED2F935595C6 /* SimpleClient.swift */; };
+		BAB2F872ACA3F3B23E208391120201E4 /* Heading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE3BDD2E631E61ED3520A5CC751820 /* Heading.swift */; };
+		BAC8F3C3EE7585CF12BFEE5A5266F4DA /* DownOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45116B4FE9CE942C3675B2BF08E8A83D /* DownOptions.swift */; };
 		BB0D91D4BB4AC207CAA1121122C2B2C7 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50225E4C9D676A71008537AD2B84789E /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		BB424E97D02713C904D3B48A015983DF /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6779492234D4F962E2CF571B2C94019D /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		BB482FE6C806F364A01CF0BC29F6FF44 /* CustomInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = E105D4CE3E1294C57780FD40F1B18C84 /* CustomInline.swift */; };
+		BB48D5C6D386BAAEFEFC45D26C075595 /* SPUSNatConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB725A064558DC098766E7C83944569A /* SPUSNatConsent.swift */; };
+		BB95436609A369652D77141F398E5AC3 /* QuoteStripeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F122B45B33E4C2924F2A6034B7D35605 /* QuoteStripeOptions.swift */; };
 		BBB34288DA32EC91B33C6C258039770E /* WHNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8031B5B0076AE14A6CF9249DF40286 /* WHNavigationController.swift */; };
-		BBE7465AC7E7B7C3E0C081508A483712 /* ColorCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20C28362BE5898EDE4FEE6C967AF566 /* ColorCollection.swift */; };
+		BBD2FBF5B86B651224C79E6755F6823B /* CodeBlockOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356F7EAAD72C8F7AF7B705E00487476F /* CodeBlockOptions.swift */; };
+		BC6380E551F282A9798DC9BDA76566CD /* SP_Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 2F13DD6087C28E86B9C1788E8C496A78 /* SP_Icon.png */; };
+		BCF6D09EC7068DD8338B9A997F86D718 /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520B9EDE9D4F5F035EFC7486AE11716 /* List.swift */; };
+		BCFF0F00C56D14AE70D7E702477A3B32 /* DownXMLRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFEFC792F717489E1D0033C41385017 /* DownXMLRenderable.swift */; };
 		BD2CD3F77641785F878E909173E28C5D /* Pods-NativePMExampleApp-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B8D19EC5179D7698B6F32F7EABAC1DD /* Pods-NativePMExampleApp-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BD2F145C060A99BEDDFBD727B0789C50 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FD40774BB0C4CD4661550DCF7B90F9 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BDE773EB7BA73CAE5FF58588B01D2140 /* RequestsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D2D1A2EC4B0FEEF03C642D6B99C06E /* RequestsViewController.swift */; };
-		BE0DB525EBBE421DD59F12B9A09BA1D4 /* IncludeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7FCD5D97E9C44DD791C95F75D527DF /* IncludeData.swift */; };
-		BE184262DC08FEC8D8DC11FDEECD17DD /* SPJSReceiver.js in Resources */ = {isa = PBXBuildFile; fileRef = F4C1045E7B11276558ACCB7A723DF82B /* SPJSReceiver.js */; };
-		BE6DB1C1B054E914D27FD31F314B1C31 /* DownErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9C04673231C48B2E6ED42A2AB6D34E /* DownErrors.swift */; };
-		BF2A8CD1F872B325917CA2331698F10F /* SPGDPRConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2784307EA07123E8572C4FF93F3917CE /* SPGDPRConsent.swift */; };
-		BF31B4C2C120F9CC18C7AA93A18046F7 /* SPCustomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0315852DCBAEF8931C5E1F069E419DF /* SPCustomViewController.swift */; };
 		BF4E21721F7D6538BF70A304B405D411 /* String+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9A2702875DD2CA1970105832580D39 /* String+C99ExtendedIdentifier.swift */; };
-		BF9FFDCBDEC2419464E26F13EF7C4E0C /* SPNativeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CB6B9880FD351B6C08374FBDFD7C6D /* SPNativeMessage.swift */; };
-		BFB9198E41960C3F9F1FE3D4C4271F43 /* CustomConsentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7971F90764CADB78812440A92DA746C6 /* CustomConsentRequest.swift */; };
+		BF9DFD7DA496B721F2BB68607FCBF02F /* Strong.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFB437DC66245AD0C2BDC0A5C302AB1 /* Strong.swift */; };
+		BFE2859DE4107099DAE512C447F21ED0 /* houdini_html_e.c in Sources */ = {isa = PBXBuildFile; fileRef = 1DFB52D0BAC06E2A28FC6B18D1216BF0 /* houdini_html_e.c */; };
 		C00933487B1D7020CAF7583930C66E64 /* Equal+Tuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5CC00FA31E003434C6D65DF8F3DA91 /* Equal+Tuple.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		C0678987BD8FEDA131A9F5C49E6D9A47 /* node.c in Sources */ = {isa = PBXBuildFile; fileRef = D796E9E3C0C9CD2EEB46A54519800192 /* node.c */; };
-		C118C9AC089D5730EA3B42F8B939F7F8 /* SPMessageUIDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCEC17591F80FCF182482B83F37421A /* SPMessageUIDelegate.swift */; };
+		C039A397C057FEB20C5E09312123E21C /* SPNativeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5104F5ECF953CA5841925A2E54FCD1BB /* SPNativeMessage.swift */; };
 		C15B7C50B3A6B4E0906117E2B81A331F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
+		C1BFBFFE18828308C1B9B894ECAF2DB7 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = C3C5C29210CD22378C6D7E9483EB41BB /* buffer.c */; };
+		C1F89F1DC075564975055B271662A222 /* FontCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE22DD310BE71ABD5D88DAC8018A4401 /* FontCollection.swift */; };
 		C2192627E8A23CF9DDD245F89D8953F7 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF285887327E7FE6B84864165C52641 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		C2295D3A9296079498EF6831DD064EA7 /* WHView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADA402AD2C0DC196800D6D7DB4E8B11 /* WHView.swift */; };
-		C257A3DA14300EEAFADD46655CBB5211 /* FontCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE22DD310BE71ABD5D88DAC8018A4401 /* FontCollection.swift */; };
-		C27ADD338FBDDD52230D69EA2FAFFCF1 /* HtmlInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2538445DADB67C90695102ED9F35D0AA /* HtmlInline.swift */; };
-		C2B16AA4A8846C4BE6448E8AEC14D1E5 /* CustomConsentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7971F90764CADB78812440A92DA746C6 /* CustomConsentRequest.swift */; };
-		C302ABE9EBF0D07C9749847A03F2A49D /* SPQRCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30193087B41266CA96A7E86E3AC6EFDB /* SPQRCode.swift */; };
-		C357449D18157BA3C305EB5CC921EB92 /* SPGDPRNativePrivacyManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60693B6637959F079E0D340EFE645C2 /* SPGDPRNativePrivacyManagerViewController.swift */; };
-		C3F91227A537AA9079F4AC7DA5FE342F /* DownASTRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4945FF7912982C4A68DC3DDC77BBBC8D /* DownASTRenderable.swift */; };
+		C27B4C3A93F38237F95F74C4B6A5FA62 /* SPCCPAPartnersViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 88D763EF8AB338EB770555D5677D48C0 /* SPCCPAPartnersViewController.xib */; };
+		C338FBF1F3178269570E5F512C96665C /* SPPrivacyManagerRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76662C1EFF87E0368232723B3733766F /* SPPrivacyManagerRequestResponse.swift */; };
+		C3A03D6AC955DDE630F61F2162B41093 /* commonmark.c in Sources */ = {isa = PBXBuildFile; fileRef = F17AD4E54096E2D9DB39C7DB4E565F8A /* commonmark.c */; };
 		C40412F36EB8293BF2D0BA6E322FDFAA /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AF8C147B159EAFD671BEA2D92724E7 /* QuickSelectedTestSuiteBuilder.swift */; };
-		C48C46E7121011EF6E81B22C817BBC79 /* DownTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F15ADA74D492BAC76AB3EDB6C12D3D /* DownTextView.swift */; };
-		C6261C7DEDBD4F357C8BEBF0759425A4 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBF2460FDA962B0B444FA81DEE9E5F2 /* Date.swift */; };
-		C6CE4A8E6EA9DCAB0DF84EB0BD32072B /* MessagesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33D1CA7157620140646E3E0564ED248 /* MessagesRequest.swift */; };
-		C75DEED0D21A9C6199486A007E2DC265 /* QueryParamEncodableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5134E1744DB502EB07BE7CA2D0739398 /* QueryParamEncodableProtocol.swift */; };
+		C653C18B722A016A3F6124944ED9CBEE /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9D6BED32E513A0AA13D9C78512A40B /* Date.swift */; };
+		C676707E15772A1F7FDF5003DFD4D747 /* utf8.h in Headers */ = {isa = PBXBuildFile; fileRef = C4FC37CE1C465F65FBF6CC8565C0EFE4 /* utf8.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		C807AFD3C8CEA675C531EB456BF335F8 /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827079B1C799620ADA70CFBA806FA7AA /* HooksPhase.swift */; };
 		C81CB3B5D25BDBCB6D3A3632BE408229 /* IQKeyboardReturnKeyHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F30C92BBD1CC27CB0971D9E9D0897BF /* IQKeyboardReturnKeyHandler.swift */; };
-		C8FDB68E98949FAA6EB7457F40A8175F /* SP_Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 0C5FF8AFF5BB78C11B41EDBDA9311585 /* SP_Icon.png */; };
-		C91C9E658F587B3DA2DB0A7E70DBD92F /* GDPRPrivacyManagerViewResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2203991CF87910BDD063D65ACD1EBE /* GDPRPrivacyManagerViewResponse.swift */; };
-		C937572239E5833B9BD3F989A0EC7AC5 /* ConsentStatusMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDAB65BE94ACA7C2A6E08E2D4FB5425 /* ConsentStatusMetadata.swift */; };
+		C87CC6D043D906ACB7938D2DDE7F1F7F /* DownLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340BD7B6229112CF361278C3D4A29AC1 /* DownLayoutManager.swift */; };
+		C964BE80ABCD10341DFFA654893FE068 /* SPMessageLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19400978A8768F2D99CDF5E905392611 /* SPMessageLanguage.swift */; };
+		C99E780D999B238956481EDB1B312E88 /* SP_Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 2F13DD6087C28E86B9C1788E8C496A78 /* SP_Icon.png */; };
 		C9A1460F2A16077DDB1980B34633C95F /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AB079CF093527A4CFFAB09421335E5 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		CAAF8A9D1168E908BB109846664E441D /* ThematicBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CBFD733E83362BED7DF5FDB665DF8C1 /* ThematicBreak.swift */; };
+		CA958C9774B63DC9AFAD8A419ADBC851 /* DeleteCustomConsentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BBBBE57C72E2AC7FBD58BF6D0D9246 /* DeleteCustomConsentRequest.swift */; };
+		CAD0D61DC9D59BEDAF2DD1A249D07877 /* ConsentViewController-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7518233A0C485853B9D0C17CD235064B /* ConsentViewController-tvOS-dummy.m */; };
 		CAD529C03DE828C7F4BE2D80590835A5 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9663275D36F2DF8F24EE7DBC70A4F7 /* ExampleMetadata.swift */; };
-		CB1DD602F26D11ABB3B6D13F42D279A6 /* GDPRPrivacyManagerViewResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2203991CF87910BDD063D65ACD1EBE /* GDPRPrivacyManagerViewResponse.swift */; };
-		CB70A94948381ACC5ADD15166975274A /* utf8.h in Headers */ = {isa = PBXBuildFile; fileRef = C4FC37CE1C465F65FBF6CC8565C0EFE4 /* utf8.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CB8BCF2EEA07ACA3399100F0D4506C87 /* chunk.h in Headers */ = {isa = PBXBuildFile; fileRef = 3072869E17E16DC8447F4923925AF669 /* chunk.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		CBF5AB34B6558EFDB14CCEE043C1DFEB /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B925A01B46DC4576D5A7DCEDDB5DD6C6 /* URL+FileName.swift */; };
-		CC5052CD69BEACB16A6BA9935C7CC8A9 /* houdini.h in Headers */ = {isa = PBXBuildFile; fileRef = 9344639DEC28DF6C91B12F94A3FF74C8 /* houdini.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CD0E429547094F9FE50023394FD66417 /* SPMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C97914BE77B99E39621A9EC7E58C21 /* SPMessageViewController.swift */; };
-		CE1C52E4B6568E30BAF4C21DCD09B59E /* SimpleClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C4F96A0A4D2D507766ED2F935595C6 /* SimpleClient.swift */; };
+		CC19C766CD197D8487E0F7A08A2A4EAE /* LineBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2216707DE7A34766E9BA9524A4506770 /* LineBreak.swift */; };
+		CE424338DBC5F1FC2DF166B8583BFEB4 /* SPAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BFF4525B8E99AC8AA9682A0AD5096C /* SPAction.swift */; };
 		CE7A5BE80C7E8800D831F3481B0E4A8C /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 11860DB62CCE2A12727931490CF86F58 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		CE7ED2447FFAFB3FFF753586E35B4B1F /* ElementsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = C376E206D0D66370BA9AB1F8832BD3B8 /* ElementsEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		CFD2B8954682EF0D7B595FECE9ED38C2 /* houdini_html_e.c in Sources */ = {isa = PBXBuildFile; fileRef = 1DFB52D0BAC06E2A28FC6B18D1216BF0 /* houdini_html_e.c */; };
+		CEFF650E7F137FC4CE0E5861452AB6AA /* SPGDPRPartnersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41538B082DCBAC311B391D62F9F77575 /* SPGDPRPartnersViewController.swift */; };
+		CFFE3020232CA1F65BF227DAE90DF70E /* SPJSReceiver.js in Resources */ = {isa = PBXBuildFile; fileRef = BFECB5A821926764458845FF526DDA6B /* SPJSReceiver.js */; };
 		D0C5835E533BA7232753E371D3599F10 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B404CBE40EFC7C7BDE894D329EDD7C2 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		D225EA80210E2C74DDA4FAA4E1C24206 /* ActionableTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C511053A4578911005F325403FEDD36E /* ActionableTableViewCell.xib */; };
 		D22B1B6048FF533A75EE3C02858F01F8 /* Wormholy.h in Headers */ = {isa = PBXBuildFile; fileRef = C5161DB129928CB0A61582027AFBBAE1 /* Wormholy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D24971AA9F9B7030C14D5878B8F8C495 /* ConsentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B252B8E80DCE0FD094FA558FCB0B5320 /* ConsentStatus.swift */; };
 		D2AF02DF619F4E671CCBEE28604E97F1 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A38F8E2410D3E9C3AC2CD42833BDBA /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		D2D4025BA80DC4621D765C1B12181B97 /* ConsentViewController-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A1A05DB1E1978F1BA2CA1919E3C47AE9 /* ConsentViewController-iOS-dummy.m */; };
+		D2CCACA8DE98902878CAD9D8193913E4 /* SP_Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 2F13DD6087C28E86B9C1788E8C496A78 /* SP_Icon.png */; };
 		D31356D54A39420DB91C892502CFFD57 /* IQUIViewController+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76BA69EF675BA3E104496E798C3E72E /* IQUIViewController+Additions.swift */; };
 		D354178A2D87874F491F036C2426658B /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = C51645FD8897485F1D69445B38DAE43C /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		D35F05294F99BCAF81088909895D6F3A /* SPUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A036380E05F52DB23AA8871BB06A4DC /* SPUserDefaults.swift */; };
-		D37A8B154CA9A574EDDE845933D55ACD /* SPCCPACategoryDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1471C6980E34597F9E9F0C7914CDE4F5 /* SPCCPACategoryDetailsViewController.swift */; };
+		D3B7A7A30A5124A60D39E6FFBCAAF77F /* blocks.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FA81AA6EA32A93532A7594E869D3299 /* blocks.c */; };
+		D3FCF53C796DDB5A5526325A7CD5F37D /* SPDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E351CB99D1D27B7B5A640849BD98C91 /* SPDate.swift */; };
+		D412C356EF48368DCB6CAC48622EB5FC /* SPPrivacyPolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361136B705C356E2C8AD0865F060756E /* SPPrivacyPolicyViewController.swift */; };
 		D475921FD42C5F9AF0CDC4A5F4FE4055 /* ActionableTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D87A12BCF55C5BA2030A543F13E5BED /* ActionableTableViewCell.swift */; };
 		D4AA83B55907BAFF61483A404992A6E2 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D966529D260DF33A0925C56470DCABC /* Storage.swift */; };
+		D4B3AB1E5772B04FF2A30042FAC84DB7 /* houdini_href_e.c in Sources */ = {isa = PBXBuildFile; fileRef = 39D407912C0402B1D7380AB3F91D2C37 /* houdini_href_e.c */; };
 		D4B3C890621F3ABA395DEAB2BB9CDACF /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65431F2B1B767C6E562F451F5E6624CC /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		D507F428ACC29464177D7B86ECC27237 /* MessagesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E669610B15E89D68A59B4ADA6046934C /* MessagesResponse.swift */; };
+		D4C92BA48B345DBAEF28ED196BF6A6ED /* QuoteStripeAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7A51BA7B38F5001CC54F7CB031B708 /* QuoteStripeAttribute.swift */; };
 		D5E503BC73688B8E5D467A8AA03B1E5F /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8595FA58C64090133B1404C303988C /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		D61323F83C4A0903570331C1F8D9D06D /* Flow.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CAAC5927463AA87FB034761B3595C1D3 /* Flow.storyboard */; };
 		D6516B5451008BF1ABA150E6482F6325 /* IQKeyboardManager+UITextFieldViewNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99011D6DC0752191B6C0D0AAE03B10F /* IQKeyboardManager+UITextFieldViewNotification.swift */; };
-		D6F12DA3A1B9775C902A2315E95DB90A /* SoftBreak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484341D87F3E64B2D025EE94BCB11781 /* SoftBreak.swift */; };
-		D79E0021F121850662D4F1F8C530A3EA /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBF2460FDA962B0B444FA81DEE9E5F2 /* Date.swift */; };
+		D6571C5DEB2A1112A8FDC111B40D5754 /* SPNativeUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1EE4614D5D401C3ACDAE634299A561 /* SPNativeUI.swift */; };
 		D7AE28ABBC2FD1C8BBEEF79BEB4FEE11 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 933A5B5638160E5921D63A4C3364E25F /* QuickSpecBase.m */; };
+		D807FE52D528E567A8AC0A101EF02118 /* NSAttributedString+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = D789344B063B6B4798D349FDDA21D27C /* NSAttributedString+HTML.swift */; };
+		D80B6001077BC3C35C161105C8AC55E3 /* SPGDPRVendorDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A18D2D21DFD35D6FF2027BBC658D50 /* SPGDPRVendorDetailsViewController.swift */; };
 		D8595B8E8834C755E76CDB31DD6144B3 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9D36A3F5DA5E98DB86DF08477AE877 /* World.swift */; };
-		D89C1C641FF808B729CFC47AF3DBF24B /* SPJSReceiver.js in Resources */ = {isa = PBXBuildFile; fileRef = F4C1045E7B11276558ACCB7A723DF82B /* SPJSReceiver.js */; };
-		D8D01A415641F8D4D7E57267A4EDB0A5 /* SPGDPRConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2784307EA07123E8572C4FF93F3917CE /* SPGDPRConsent.swift */; };
 		D90D16EF93B572D25E56C6EE47A4E675 /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A315A7B6ECBF785825BD78B7BB6D04FC /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		D92907AB3D55185C170A983A2FFA7C90 /* SPGDPRManagePreferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69175CFEF4241C2C231F6D7D430FAD6 /* SPGDPRManagePreferenceViewController.swift */; };
-		DB668BB8EC15FCB5A8935BD3EE2838B7 /* ConsentViewController-tvOS-ConsentViewController in Resources */ = {isa = PBXBuildFile; fileRef = 20A4710BBD2EE3CFC496E3AF134BD4FD /* ConsentViewController-tvOS-ConsentViewController */; };
+		D9FFE888F27B42E092644AAAE2C61540 /* SPGDPRManagePreferenceViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 052F0758AB741230E72561BDC7A22ACA /* SPGDPRManagePreferenceViewController.xib */; };
 		DBAE5513BEBB9E893393B956C842759E /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4BF4A2CD5B5CB6EA8A7C9B0F662CD6 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		DC6C984069F0A3CDC8A5556F07A7B449 /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520B9EDE9D4F5F035EFC7486AE11716 /* List.swift */; };
+		DCD3D9B2C7CA90E0BA9460680A8BC59E /* SPUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F074F2CF5D98F1FE8054275E5A9B75 /* SPUserData.swift */; };
+		DCF53F364214141BC1C8D6391B4AD82E /* ConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1F1E83882B9DE7318ECFE065AAC229 /* ConnectivityManager.swift */; };
 		DD171E88D71E4D298F57702F80C4FEC8 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD3571F06BA6522D948405B220E90283 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		DD5B74BE316833CED3D2194B3CECA967 /* SPSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99F1367AA419AD39BA004551C43D993 /* SPSDK.swift */; };
-		DE0A0E0B1FA6A17ACBDA377879CE53CF /* SPStringifiedJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4047D4CAC50B2C75E9F18BF861468108 /* SPStringifiedJSON.swift */; };
+		DD6502A4F5B42F89D8459CDD59C7C2DA /* ConsentStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2210A1777A462D1AE0916CFFD28EC9E5 /* ConsentStatusResponse.swift */; };
+		DDEC2BBD2FD13E2C8994D4D20AC1EC79 /* SPCCPACategoryDetailsViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 439412BBD46371B4CF713AE48CEF7520 /* SPCCPACategoryDetailsViewController.xib */; };
 		DE22F7508DF761458B093784C6C8721F /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473A7C3CEFD5E9479DB337765E09E0A7 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		DE285101EB3FA168A5B0851334865706 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B97C385536ECA9485526486DC990ECF /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		DE3F2F06DF59924DE4221370E9335C36 /* HtmlBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9E52F42BBF10055CE335DF2CAD2D96 /* HtmlBlock.swift */; };
+		DE531ADD98163CD8CCBA59C475E5000C /* latex.c in Sources */ = {isa = PBXBuildFile; fileRef = 48E45CD63519977DBF1E2AADE772CA21 /* latex.c */; };
 		DEAAF1DB35FB3F9FDAB6CACC90B882E3 /* WormholyMethodSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = 65CEBD3C5DD66F386216F48FD505F889 /* WormholyMethodSwizzling.m */; };
-		DF12FFE3D048FC3B0A3BB02BE3EF9815 /* inlines.c in Sources */ = {isa = PBXBuildFile; fileRef = CD49BC421FEE8709A52890556B3E6197 /* inlines.c */; };
 		DF33C3DE068D6116B3F551B0453ACD23 /* IQUIScrollView+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBD3480792BC2F46E97894268A8D1FC /* IQUIScrollView+Additions.swift */; };
-		DF79562E24A857FA5A6EE71925B81A7D /* SPPrivacyManagerRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5595D26CD0CE5203994A89F8AB1F68FF /* SPPrivacyManagerRequestResponse.swift */; };
 		DF96E81119E1C2438C0C2798C06857AC /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E52D2EDA2417EA4BA098CEFF6FAFE64 /* QuickTestSuite.swift */; };
-		E0319CB65CD76E214AD48EEFFCC03AD0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F14AA232F04EB7627811BC6CD5E590F /* Foundation.framework */; };
 		E03C605C2CBB4A45A75BF4D025CA737A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
 		E04E3D7F93A2C91B6C4D3FDFA999108F /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF285887327E7FE6B84864165C52641 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		E0769788C6C3A712A151D917A2D7A569 /* DownHTMLRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C443E6DD1ADC19142B5667B7378C9880 /* DownHTMLRenderable.swift */; };
 		E0AE9F39817F153D747CBE65C6314824 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50225E4C9D676A71008537AD2B84789E /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		E16364CCCC2EC3A2C88B551399A3C067 /* CustomBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79EB69639263444FE6B71A857954296D /* CustomBlock.swift */; };
 		E18684D2AE1F329CE63DD6038EA38351 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B7ECBC48D5A4C7558411E8764C9E1F /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		E280E382FA8CCBFA7C6874D11F0FED05 /* SPConsentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85151050329E96D5DDA93AA7EB8A335 /* SPConsentManager.swift */; };
 		E2B420D62D86CB7B9EFDF45F295935CE /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB767417D1BC5296166C6D8CE24685 /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		E2F968BF17202092C3C81E139035DD38 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15ADC04FF459E84C6ABC2BDB65630B5 /* DSL.swift */; };
-		E2FC266B367D859383ECF728B35422BA /* references.h in Headers */ = {isa = PBXBuildFile; fileRef = 51039E4EFFDF22E0695ED52DB077E0A6 /* references.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		E310AEF625A50C9ABF605F7DD4AE4290 /* SPCCPAVendorDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D94A8C188A429D5BD2D620A801F5A5 /* SPCCPAVendorDetailsViewController.swift */; };
-		E37FDD1AC10710E7D25B224CBF62727D /* ConsentStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC74D56FDDCCD5DBDF2F603F5BEB55C /* ConsentStatusResponse.swift */; };
-		E44201B57DCEA6180C7E82DA23317840 /* CCPAPMConsentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDF85FFB061EC5C8D497766DF9D44A5 /* CCPAPMConsentSnapshot.swift */; };
-		E4870FCFE27776304FBD2507F76514A1 /* Barcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 44F462EFF078F36D350AD3131AC159D5 /* Barcode.png */; };
-		E4D5475F434519D9B3813F103C29BD4C /* BlockBackgroundColorAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412EEDB4587FF3FBE3B0FA5D464BA14B /* BlockBackgroundColorAttribute.swift */; };
+		E34320762BB97AF2F63942DAA4E4B4E2 /* RequestCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 67CF98B34415888CFCC0A3919A234894 /* RequestCell.xib */; };
+		E34D689905647B6DF5F13C42B371749E /* UIFont+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E649623D9E40861B378DBDEF1928D7 /* UIFont+Traits.swift */; };
+		E480795C524BF8B41E2DFE2DFD8D8EBF /* SPCCPAVendorDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140B936C01A9D028032A703B1C792C02 /* SPCCPAVendorDetailsViewController.swift */; };
+		E532FE64532159F6B60F3753A2AE99AA /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86895502D7A8FBC36517193F928B85D7 /* Item.swift */; };
+		E5997F970E4A1C3B6D632A64B45E4885 /* SPNativeScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0058A14E36B563CE681060B13CEDE40E /* SPNativeScreenViewController.swift */; };
 		E59F22B87A79D44586B6537D559CAF96 /* BeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09FB9514C706BAC0D25E445FCF3BDCA /* BeResult.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		E5E835680A5684F466C41556A0999D16 /* houdini_html_u.c in Sources */ = {isa = PBXBuildFile; fileRef = 3733B89950161339721CBE2E1CBE2E10 /* houdini_html_u.c */; };
+		E5EBBFC642D110FCDDF73912CA25C71A /* DownASTRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4945FF7912982C4A68DC3DDC77BBBC8D /* DownASTRenderable.swift */; };
+		E6282CF44C2FCD77CC9E439D29E9DDF0 /* jest.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 0DB88029D7BE239F468C617AC20AB271 /* jest.config.json */; };
 		E62A1DCDD86B9C777DB96E86C83C2AC8 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 933A5B5638160E5921D63A4C3364E25F /* QuickSpecBase.m */; };
 		E6586DDB5046E2129E73593F2657BBE4 /* BeWithin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E108468363DC7CF9494FD4110912EF2 /* BeWithin.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		E665718896A9811A51B4946563237EC5 /* JSONView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503FCC970CD1073CF89DAE091834D6D3 /* JSONView.swift */; };
+		E6676E13D2C9C0535F566C089D3F8E96 /* SPMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F803628BFA08F2F555342D92731F3B /* SPMessageViewController.swift */; };
 		E72E1BDDFF31003BD089544FC112FAAC /* IQTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE249B34809CAE3033328C1268A59433 /* IQTextView.swift */; };
 		E77105048A615F865801AA953CFD6FD8 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7CFFF9CE15070521A2CA8C209A9889 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		E780282B64A06FBE5267AA2B9E4416FA /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137E03F5404ED389DB217A87950DE3D4 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		E80310BC93907F55D72E360DCD75AD49 /* SPCCPAPartnersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828C8315C59EC0C8EFF52E652E944AB8 /* SPCCPAPartnersViewController.swift */; };
-		E82DF2A876881A12235BDD18181C53B9 /* Down.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD36E655D8EE068EFF50A0757E1F193D /* Down.swift */; };
+		E7A593D0BB2DCD32F2F75055AF558526 /* SPGDPRVendorDetailsViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 7FC1638981BCC1F808D6DC2560841524 /* SPGDPRVendorDetailsViewController.xib */; };
 		E93552A79FB5F3C728D2F9F22F70F555 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14D9A75C6D0D148766A787E6DAEEEA2 /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		E9900F8BEFE534EB228A6C2FF7B7BDBB /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B85932749565B4906CC95F83538C516 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		E994D96E0FB49B4BEAE991E2B3817794 /* Emphasis.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFACA9FCCC8A1B367EF4F8611D73E3A2 /* Emphasis.swift */; };
+		E99BBA31AF5D1267E890E866F733C2DE /* SPPropertyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966B2E914EEE28ECF349826319E685A0 /* SPPropertyName.swift */; };
 		E99F0BD431752BE43D65B633FB7A0FBB /* Quick-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F57CF95A5BD30FB7562C976EA29963FC /* Quick-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E9ACD22D1C5BCF7A42EED6A352D3DCDD /* ConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19CF649845DEF2B829FB7FD5B787243B /* ConnectivityManager.swift */; };
+		EA006FB2601136BBE759E8E63E1C40DE /* NSAttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8151422F4D119BA7AFF87AE9863192 /* NSAttributedString+Helpers.swift */; };
 		EA7D1D13BC9B35541192B22962B338F9 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A38F8E2410D3E9C3AC2CD42833BDBA /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		EA957DDA58BA0B531038858EC33011B4 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65431F2B1B767C6E562F451F5E6624CC /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		EB008DD97C1D847691A11641B33BE064 /* houdini_href_e.c in Sources */ = {isa = PBXBuildFile; fileRef = 39D407912C0402B1D7380AB3F91D2C37 /* houdini_href_e.c */; };
-		EB846114F6A4C80FEF6ECBBA928BD872 /* ListItemParagraphStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7885C864C246711D62F40EC398C873 /* ListItemParagraphStyler.swift */; };
+		EB23D7F14E3596854E5E0710DFF48A1E /* SPCCPANativePrivacyManagerViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 62ABE444F807061001F52E578A329E7E /* SPCCPANativePrivacyManagerViewController.xib */; };
 		EB9EF0E3B54A86C66280138322A0C68E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F14AA232F04EB7627811BC6CD5E590F /* Foundation.framework */; };
 		EC0E6FBB41C9736034FE0083D6B2FE97 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD7D4A1D044FA2204A01761C94CF067 /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		ED8DE56F1AC45F19170DFBDCDCEFFB35 /* ChoiceResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8F37E1246867F64DA19CD63664C7A2 /* ChoiceResponses.swift */; };
+		ECADCA8CED9142EDBB07CF08B5CE5201 /* ConsentViewController-iOS-ConsentViewController in Resources */ = {isa = PBXBuildFile; fileRef = 4BEAC88AF84CC484F55B8A6C048444D9 /* ConsentViewController-iOS-ConsentViewController */; };
+		ECE909A942B0364E0D241E631CBAEEB5 /* SPGDPRCategoryDetailsViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 6A9DE8572B70C4AEF2D400E28ECDF7AB /* SPGDPRCategoryDetailsViewController.xib */; };
+		ED2080DA867F4027D45F1D63CF95668F /* HtmlInline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2538445DADB67C90695102ED9F35D0AA /* HtmlInline.swift */; };
+		EDA108C1B69DBF67A663C703D0BD2853 /* SPGDPRConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8192A816EE8F9CE7ED6486B77A00624C /* SPGDPRConsent.swift */; };
 		EDF35B5AA3A54E2BD75B132B0A96E3A1 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB25B07CCBB900612F3038AA46140FB /* Example.swift */; };
+		EE3008C2F60F5D0B08B0E0519CF3D3E4 /* SPGDPRManagePreferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C10539449E25FDBA3FE13D3ECB2ACB0 /* SPGDPRManagePreferenceViewController.swift */; };
 		EE4893F69340C6E86A16C72F2C3002B1 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187BE1A69563332FBCC49B18DF193F85 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		EE5DD0A9AE8CAF1BB17419ED7D09A807 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 70294F2D3496502D0176E56BD5A0E1D9 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EEC45B0314FE2938D7FB0E005C43B9EB /* BaseNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92617F51470C15CAD521741390A422E /* BaseNode.swift */; };
 		EECEAA3B9C98217F8D866DBF4B5A3CB8 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17190541F56BBA8694F01E6811EE3421 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		EF9084B7EE5E1F9F06D57728CFBB5341 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB767417D1BC5296166C6D8CE24685 /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		EFC7FD11601486050FF36BFD7F3312F3 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 70294F2D3496502D0176E56BD5A0E1D9 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F01CED6D3E752AE216478C834571F36A /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22868D7C990287D519469FED4DA72B95 /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		F04C526AFFE6E909BBCCE30AEBE0C408 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7329FE8B6F03A482CB9D887F017505 /* Filter.swift */; };
-		F08A4E01FBD0757A33CC516335F7DE4E /* SPPublisherData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6EF1ACD40341510CD18A00EE40C2E3 /* SPPublisherData.swift */; };
 		F0A7815326717B681D1902DA0D8578B8 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31606EA9B6F472B81F34078D7AC51CB /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		F0CE4F381F4C0518029D6DFE95469BD4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
-		F10D3CB8B1AC2B271EDE12A75091D79B /* ThematicBreakAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F309820BB3F1570708091996EE72057D /* ThematicBreakAttribute.swift */; };
 		F1324FF77DEB9C6692F36958DD895309 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F5B34976A38DE6F144DBC79B173B19 /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		F13E2E3A6C6D6A7D4238F7BB006D235B /* AddOrDeleteCustomConsentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B1AD04671BC2FBFB399E31BB49509A /* AddOrDeleteCustomConsentResponse.swift */; };
 		F144429820E529577783D4326317E304 /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4753479FB8DCD331A98162618B938BDC /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		F1EB1A581846A6E2C042DA786B30E617 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = A2951E938C866691A0A2B9D510DCC6B0 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F249F186E29D6A40E5E3485AE1C68D3A /* ChoiceAllResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A817DE3655D89F8A82DE70045E8F51 /* ChoiceAllResponse.swift */; };
+		F21B1C964636D5D25015B06E6ED331AF /* SPDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E351CB99D1D27B7B5A640849BD98C91 /* SPDate.swift */; };
+		F2290581DD9F60496D925BECB69A3DAF /* SPString.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55659631F09CC0006809BF9DFAB5EEA /* SPString.swift */; };
 		F2B1C1D70C629AE19C0D5121B1BBA891 /* IQKeyboardManager+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CDEAF94251001BA1B79F2F99403933 /* IQKeyboardManager+Position.swift */; };
+		F2D59B5653BDBF8B9D8BE35F976082C3 /* SPPrivacyManagerRequestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76662C1EFF87E0368232723B3733766F /* SPPrivacyManagerRequestResponse.swift */; };
+		F341ECC83957A8BA336392104EFBABAB /* Barcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 70C9EEB9C55E8BEEED132AC3B3DFE809 /* Barcode.png */; };
+		F36AC8AE97D0EFFD0C107095E92EE13D /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A9FAAF3CDE683DCE7F80696E3E1780 /* Visitor.swift */; };
 		F4C03CC2D104CB9E1197308E121E3210 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */; };
-		F4FBB4968531BE984382F9A851FEDED5 /* SPCCPAManagePreferenceViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = 3C2239F7E2BEC75150EB0EDE80F422F1 /* SPCCPAManagePreferenceViewController.xib */; };
-		F531C25CA962CF3430D3D202951561C1 /* PMVendorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A26AC79EFF2DDBD6DBD8F7972F2293A /* PMVendorManager.swift */; };
 		F57643DA151EEA28F893B0DEDE1A4320 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31606EA9B6F472B81F34078D7AC51CB /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		F5C68980310A8B5D35F6A0C2887127DF /* SP_Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 0C5FF8AFF5BB78C11B41EDBDA9311585 /* SP_Icon.png */; };
-		F60312A3EEF16A1F171D651461229C5B /* latex.c in Sources */ = {isa = PBXBuildFile; fileRef = 48E45CD63519977DBF1E2AADE772CA21 /* latex.c */; };
-		F655B5F0DADC94B7960635FF6D2D05B8 /* SPString.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F5A4C0E23281A4DE22DF8D3A07CF2F /* SPString.swift */; };
 		F65683DB5B553662A6B2A88E39C1B1CE /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4BF4A2CD5B5CB6EA8A7C9B0F662CD6 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		F685D519C078629826C7A81C2F22B184 /* QuickTestObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D5605B91235BC3C8C2EBAC0ECBB279 /* QuickTestObservation.swift */; };
-		F68DFB3A02A4443B87ECCF1C62D97826 /* cmark_version.h in Headers */ = {isa = PBXBuildFile; fileRef = F11A37CBB808CEE0FF299BADBF67DE39 /* cmark_version.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		F747BCC57B4F3BDE66813DD7A274A4A0 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F16564FBAA0831A0474BCEA8CEFC281 /* Behavior.swift */; };
-		F7DEEC0F902DF9325D2F32E22F2B7F78 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442A98950A08DA1804EF7DDB733517E7 /* Node.swift */; };
+		F7487ADCC00375F9AA16BC2D363BD026 /* DownDebugLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142CB463E6DC28D50FDFB70636557B4E /* DownDebugLayoutManager.swift */; };
+		F7545F5D5E094AC99F468F923916DD58 /* ConsentViewController-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DB08B381B740C27856D4153B7167A89F /* ConsentViewController-iOS-dummy.m */; };
+		F7DA64A51CFC3C3B5D89BEBFA7CEF5A3 /* SPDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F105951FFBC9DB3F80D0818CDC74E2CA /* SPDeviceManager.swift */; };
 		F8730329CCB538604FA7D82D81A30F7B /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F5B34976A38DE6F144DBC79B173B19 /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		F8C1660DB82A169D6F855FA0EE0C1DB1 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07909ED5D1C014D7B149EB7F691CBF93 /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		F924967BE18FCCF7C6AE4B4AE17B4F1D /* NSAttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8151422F4D119BA7AFF87AE9863192 /* NSAttributedString+Helpers.swift */; };
-		FA5EF53CA48DE99EE8304DE06540E4EA /* PMCategoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9B15B0D15EF898E424E727B2E9A01C /* PMCategoryManager.swift */; };
+		F9283547E3E308B3001409180E5C96B8 /* Barcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 70C9EEB9C55E8BEEED132AC3B3DFE809 /* Barcode.png */; };
+		F9A987306E48537B8C9D3D866044EAFF /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9D6BED32E513A0AA13D9C78512A40B /* Date.swift */; };
+		F9DB0B757AB75ED7948C8679C48BC8C0 /* Down-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DBE73DB45AB94762EE68960C907A094 /* Down-dummy.m */; };
 		FA72DB4D291ADF29E96C3BEC2560573C /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD71BF64D33A5EE5A322826A6D0E381 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		FAD5280B8B8D43F440EA73E6E7E546D4 /* SPMessageLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B803807F52ECA8CB5C7409EB5668EC /* SPMessageLanguage.swift */; };
-		FB6330BC0E667A3977232DDBC1A99DD3 /* SPJSReceiver.js in Resources */ = {isa = PBXBuildFile; fileRef = F4C1045E7B11276558ACCB7A723DF82B /* SPJSReceiver.js */; };
-		FBAA4BFC298CF11AB4ED3C2161787AE6 /* ConsentViewController-iOS-ConsentViewController in Resources */ = {isa = PBXBuildFile; fileRef = 4BEAC88AF84CC484F55B8A6C048444D9 /* ConsentViewController-iOS-ConsentViewController */; };
+		FAD032C117F13D23749BAB24C4EAD3B1 /* scanners.h in Headers */ = {isa = PBXBuildFile; fileRef = D21A71AD36A279984DFE6049180C8C4E /* scanners.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FB451EB68912EEE4C258221B2C4C5189 /* SourcePointClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436C422929BBF411EE802DB972F2A7B4 /* SourcePointClient.swift */; };
+		FBA399357D1AD1DD8369B3740472D2FC /* SPDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F105951FFBC9DB3F80D0818CDC74E2CA /* SPDeviceManager.swift */; };
+		FBD9E446D29BCB831E4800D7CF780DE5 /* ConsentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DC7F0FB1838294BA74E9BFDB30157D /* ConsentStatus.swift */; };
+		FC7C883BCCD82FDE500C1C03C7157EB5 /* OSLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6381389B408CDFAAA455A7A3F74F3B13 /* OSLogger.swift */; };
+		FCA904EE37B68ECFB34E73B5BE23E9C8 /* Styler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3A5BCA07FC62773D3782117F0871384 /* Styler.swift */; };
 		FCBE3B9829F2DDA6D4DBC1D8E5F51228 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DB72A698D4BB26E79A8534A15FD073 /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		FCEAE9A7D86C0E939EF783A36816511A /* SPDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC28310BA7EB1F7DA1CFFCEC65E22D7F /* SPDeviceManager.swift */; };
+		FD26BBAD91F0DB0EA68C9FFFFD9EE82A /* SPIDFAStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4B07460B142B84CA2496287FE5E036 /* SPIDFAStatus.swift */; };
 		FDF81807A5BBED3B3536A29B8B4E9AFF /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46FD5A5C89B78C89056BED3CC9CC1D74 /* ErrorUtility.swift */; };
-		FE2C505D02DA5D5E14F1F8AF91EBB580 /* RequestTitleSectionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1FF9490F64DC44BA5A308995182E951C /* RequestTitleSectionView.xib */; };
+		FE69273359AA25FC8636F04B9D38662C /* SPPMHeader.xib in Sources */ = {isa = PBXBuildFile; fileRef = A9D6BAFBBE5B76401E897D8280933836 /* SPPMHeader.xib */; };
+		FEBB13047E3229648187FA07A6141FE6 /* NSObjectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94BB776D3E20372DDF92F05076640AE1 /* NSObjectExtensions.swift */; };
 		FEDE6A7C6FA4B6A785042EB946F0CD93 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D5368B55EA84908DB0B3619DA8A1F9 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		160DA45EB7E3B5AFE7FEAE476FCAC691 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 07B93100044EF37C3FEE234DF77D3C11;
-			remoteInfo = "SwiftLint-tvOS";
-		};
-		17ADF9B50F46F144DF3792C6B8BE1C6F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B4575FF01775E963E58050542C9A4E7A;
-			remoteInfo = Down;
-		};
-		1F3C231D6B13D5DE5E0A9EC365069B65 /* PBXContainerItemProxy */ = {
+		0651035C2449812536FB714428B5F2E1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 3AAFED87F58BAA2AC3177A35C2CF5B23;
 			remoteInfo = "Nimble-iOS";
 		};
-		2D19851531AA66A331D25160F0854368 /* PBXContainerItemProxy */ = {
+		0EB16C9D93A0950B058513E5BE395A35 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3E73ED39761329414C06DD4486C5058E;
+			remoteInfo = Wormholy;
+		};
+		0EEF8927DE90936A9CCDDB7C4E0FA23B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
 			remoteInfo = "ConsentViewController-iOS";
 		};
-		2EDAAF5E7485CD89B2E1E52E6C4C94CE /* PBXContainerItemProxy */ = {
+		1E6DB739C36D41A4F1483E8B1D2F3CAA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2B03D5FD26A26B7D62142EA4492AEB83;
+			remoteInfo = "SwiftLint-iOS";
+		};
+		229D5C703D169B3366C093324420CF54 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 3AAFED87F58BAA2AC3177A35C2CF5B23;
 			remoteInfo = "Nimble-iOS";
 		};
-		2F5D352CA1E241788AC7956372ACC713 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
-			remoteInfo = "Quick-iOS";
-		};
-		3981021BAE6DDB2CED3031CD875B1C97 /* PBXContainerItemProxy */ = {
+		25342608FE1929AA4B56E7AE30A09E66 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
 			remoteInfo = "ConsentViewController-iOS";
 		};
-		4068E76DA8866A0A00CA3EF6A870C455 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B4575FF01775E963E58050542C9A4E7A;
-			remoteInfo = Down;
-		};
-		41C44B10C37CAD3B796060AC4982F7A9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2B03D5FD26A26B7D62142EA4492AEB83;
-			remoteInfo = "SwiftLint-iOS";
-		};
-		5C1694DC4AF56225D6C8435D8A4FDA3D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 94DAD332BFFC672BBE92726504A716F8;
-			remoteInfo = "ConsentViewController-tvOS";
-		};
-		6500B4468F2188530EC7A44FE7116AC4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
-			remoteInfo = "ConsentViewController-iOS";
-		};
-		665D4055195737200E37AB1FDDC6E530 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3E73ED39761329414C06DD4486C5058E;
-			remoteInfo = Wormholy;
-		};
-		68F16B978DBB330A624A46882F55ECF6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B490E7485944099E16C9CBD79119D1D4;
-			remoteInfo = IQKeyboardManagerSwift;
-		};
-		7142DE2902FF3476C02A8A5944E03F03 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
-			remoteInfo = "Quick-iOS";
-		};
-		716504E32A837C4DDB3D19C0D7FA8C0C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 28BE3303E3F4ECC2BDF79B1D886D2E74;
-			remoteInfo = "Quick-tvOS";
-		};
-		7319D8A605BF362249B260F728C6A27B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
-			remoteInfo = "ConsentViewController-iOS";
-		};
-		74DB6E2F7A9669C10C100A14575F23CF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3E73ED39761329414C06DD4486C5058E;
-			remoteInfo = Wormholy;
-		};
-		7608F9B295C7813537752A00FF08D602 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
-			remoteInfo = "ConsentViewController-iOS";
-		};
-		77332E9B14AC24397A1F5EB54495A2D3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
-			remoteInfo = "ConsentViewController-iOS";
-		};
-		7FC1E7F40EBB1ED2DAD826E9C3F480F5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3E73ED39761329414C06DD4486C5058E;
-			remoteInfo = Wormholy;
-		};
-		849E8755F5041D971F3A43E03A368BA0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3AAFED87F58BAA2AC3177A35C2CF5B23;
-			remoteInfo = "Nimble-iOS";
-		};
-		851BF360487D67C059F1289AC3BA4655 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2450D89327C2F3947256DE8768B4B9B9;
-			remoteInfo = JSONView;
-		};
-		8D8FDFDEC91C6BD6F531796521D63437 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2B03D5FD26A26B7D62142EA4492AEB83;
-			remoteInfo = "SwiftLint-iOS";
-		};
-		964C2703089A64E332846FE9BAA4CE8C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 94DAD332BFFC672BBE92726504A716F8;
-			remoteInfo = "ConsentViewController-tvOS";
-		};
-		9F3C60976E05B34067101C6905388FA2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
-			remoteInfo = "Quick-iOS";
-		};
-		A3C758576C043E615550FDDCB27C6C9C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2B03D5FD26A26B7D62142EA4492AEB83;
-			remoteInfo = "SwiftLint-iOS";
-		};
-		A5926497343F913E5972E50D9AA79AD0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B4575FF01775E963E58050542C9A4E7A;
-			remoteInfo = Down;
-		};
-		A6902F039426B910CB3E424649ADA3B0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
-			remoteInfo = "ConsentViewController-iOS";
-		};
-		A7DE4E6A2521C0665905019E6805BB72 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 93CEC7FFB57A497DE49471C5D9517C13;
-			remoteInfo = "Wormholy-Wormholy";
-		};
-		B0B102E5BEC1506B21469EC79383B8DD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
-			remoteInfo = "Quick-iOS";
-		};
-		BAAB2BA6E798603AFF76C312C6545A69 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
-			remoteInfo = "Quick-iOS";
-		};
-		D07EF2D8482B9AE84165AF445223CCC6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
-			remoteInfo = "ConsentViewController-iOS";
-		};
-		D0A6F9A00BE76C59625B593065F562E6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
-			remoteInfo = "ConsentViewController-iOS";
-		};
-		D6F0CECEDF1BD87AEA0D8EBFEA41916F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2B03D5FD26A26B7D62142EA4492AEB83;
-			remoteInfo = "SwiftLint-iOS";
-		};
-		D84E7950FD5950F95424229E03FB50B9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3E73ED39761329414C06DD4486C5058E;
-			remoteInfo = Wormholy;
-		};
-		DA69B6B9170DB3C1CE40EB4F81112C14 /* PBXContainerItemProxy */ = {
+		2BE2349261F6DCFC6ABF8B1629ADDB0C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = F9B2C41D8F3FCEB2256091CF2667D600;
 			remoteInfo = "ConsentViewController-iOS-ConsentViewController";
 		};
-		DB09F8DB9B987E2BFA2F0BC8CF7ECF04 /* PBXContainerItemProxy */ = {
+		2FD7695B7399015B1EAE65CD7FC87CDD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
+			remoteInfo = "ConsentViewController-iOS";
+		};
+		33C6F846C372CD1410735885705FF51C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2B03D5FD26A26B7D62142EA4492AEB83;
+			remoteInfo = "SwiftLint-iOS";
+		};
+		3EFD0DA2D60C5E8962D5214512D41CC0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
+			remoteInfo = "ConsentViewController-iOS";
+		};
+		46704566BA8FE276ED864B18CEAA2292 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2B03D5FD26A26B7D62142EA4492AEB83;
+			remoteInfo = "SwiftLint-iOS";
+		};
+		502CB354C59C7F8FE0032A29DC071D20 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 3AAFED87F58BAA2AC3177A35C2CF5B23;
 			remoteInfo = "Nimble-iOS";
 		};
-		DDC91AC0937E58E1AF50AE9EAB476DB5 /* PBXContainerItemProxy */ = {
+		5616F39BEAFDE287E670B9E628749E64 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 93CEC7FFB57A497DE49471C5D9517C13;
+			remoteInfo = "Wormholy-Wormholy";
+		};
+		58F80337938A5DCE37BD1E57AAA210C3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B4575FF01775E963E58050542C9A4E7A;
+			remoteInfo = Down;
+		};
+		5B9075E549AC7D9F7E2DB6E432E08F90 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3AAFED87F58BAA2AC3177A35C2CF5B23;
+			remoteInfo = "Nimble-iOS";
+		};
+		821BEF280C2F14783681D05F2BA439AB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
+			remoteInfo = "ConsentViewController-iOS";
+		};
+		86B3F5254DDDF14F38C28DF828FF01CD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B4575FF01775E963E58050542C9A4E7A;
+			remoteInfo = Down;
+		};
+		8B00ABAF7623D3023E779479836CE01A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
 			remoteInfo = "Quick-iOS";
 		};
-		E30890D50B629A51F163C20FB9561E5A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5D0718052BFEE502C9D9BEC44BDCFA76;
-			remoteInfo = "ConsentViewController-tvOS-ConsentViewController";
-		};
-		E66548A20731577D8A2083227C16C235 /* PBXContainerItemProxy */ = {
+		901AFDAAE712CA40A3B61387EB2EA645 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
 			remoteInfo = "ConsentViewController-iOS";
 		};
-		E854AD53877B879B12DD7690F85CD7CB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
-			remoteInfo = "ConsentViewController-iOS";
-		};
-		E9CD623118892B6A1DF2DC05E5FAD7A2 /* PBXContainerItemProxy */ = {
+		90A13DB2B3DD2D1C29091EF2B566CCF5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = A897D2D55F6D87795224F846F8ED3A36;
 			remoteInfo = "Nimble-tvOS";
 		};
-		F336E1CABE76013355A971615C0FB7CD /* PBXContainerItemProxy */ = {
+		98983E4558C9437DF6E83AA6D3825A83 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
+			remoteInfo = "ConsentViewController-iOS";
+		};
+		9F7615A0C882490334863C77A7071E0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3E73ED39761329414C06DD4486C5058E;
+			remoteInfo = Wormholy;
+		};
+		9FBBB4AD5E8BDA2CBFDFCCBF3D786162 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2450D89327C2F3947256DE8768B4B9B9;
+			remoteInfo = JSONView;
+		};
+		A16C4725D26014A305F0FF849BF43E82 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3E73ED39761329414C06DD4486C5058E;
+			remoteInfo = Wormholy;
+		};
+		A1923F91BD1183F3A724B4D0B25A3136 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 94DAD332BFFC672BBE92726504A716F8;
+			remoteInfo = "ConsentViewController-tvOS";
+		};
+		B34E818879775E5CA86BC97DE3AD1D4A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
+			remoteInfo = "Quick-iOS";
+		};
+		B51E6CE363832D3922F3ECBFE5B61E49 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 07B93100044EF37C3FEE234DF77D3C11;
+			remoteInfo = "SwiftLint-tvOS";
+		};
+		B5E6FB98604B14402B21577689ACAF40 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 94DAD332BFFC672BBE92726504A716F8;
+			remoteInfo = "ConsentViewController-tvOS";
+		};
+		B806FB04FCD51974D1F8C6B58B201417 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 28BE3303E3F4ECC2BDF79B1D886D2E74;
+			remoteInfo = "Quick-tvOS";
+		};
+		B8DD3AB4756D360B5A592180D30433FC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
+			remoteInfo = "ConsentViewController-iOS";
+		};
+		BD749A9F459A72C355F483A0217FA836 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5D0718052BFEE502C9D9BEC44BDCFA76;
+			remoteInfo = "ConsentViewController-tvOS-ConsentViewController";
+		};
+		C1A46E0188AB1346A1B7114FB6B87674 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
+			remoteInfo = "ConsentViewController-iOS";
+		};
+		C382818C5B0380876C791CAB0046244F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
+			remoteInfo = "Quick-iOS";
+		};
+		C51F702BEAC827482CFE4B7B2A9D3751 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
+			remoteInfo = "Quick-iOS";
+		};
+		CABA4DF7BC11EEDBC646ED0663B75337 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2B03D5FD26A26B7D62142EA4492AEB83;
+			remoteInfo = "SwiftLint-iOS";
+		};
+		CEDB05DD946DD30B08CEE06608262538 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
+			remoteInfo = "ConsentViewController-iOS";
+		};
+		D1A57FD56DC1BA996073B927D990D016 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B4575FF01775E963E58050542C9A4E7A;
+			remoteInfo = Down;
+		};
+		D910B25BA337221BF00A503BA7512B1E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 3AAFED87F58BAA2AC3177A35C2CF5B23;
 			remoteInfo = "Nimble-iOS";
 		};
-		FE22FFBBBCE76E91A82574D671FB4068 /* PBXContainerItemProxy */ = {
+		DAD44AC88A8FD4AF7A7C66B9823898E6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
+			remoteInfo = "Quick-iOS";
+		};
+		DC8530C67103BB9859BA58346A2238E4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 89B29D1C701EFC639B36BC482FE72F13;
+			remoteInfo = "Quick-iOS";
+		};
+		EC1DEF749FDAC7AE58073DD1198B55F8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B490E7485944099E16C9CBD79119D1D4;
+			remoteInfo = IQKeyboardManagerSwift;
+		};
+		F779F5BC881B23107D19A4D140B73FD0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3E73ED39761329414C06DD4486C5058E;
+			remoteInfo = Wormholy;
+		};
+		F87A63B38C5CDDF85AA817B102700E1D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 3AAFED87F58BAA2AC3177A35C2CF5B23;
 			remoteInfo = "Nimble-iOS";
+		};
+		F92EC957ED3B918DECA4CA74CF133E97 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84E1147DCA59477E2E390B109585DCAF;
+			remoteInfo = "ConsentViewController-iOS";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		000240FF12FC9FA921A32193478CC476 /* DebugVisitor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DebugVisitor.swift; path = Source/AST/Visitors/DebugVisitor.swift; sourceTree = "<group>"; };
+		0058A14E36B563CE681060B13CEDE40E /* SPNativeScreenViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPNativeScreenViewController.swift; sourceTree = "<group>"; };
 		0059947722F656B119FD60C97AC833F6 /* Nimble-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-iOS-umbrella.h"; sourceTree = "<group>"; };
 		00A6150EF71F7EC4E9DF1B20FBE31654 /* Pods-NativePMExampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NativePMExampleApp.release.xcconfig"; sourceTree = "<group>"; };
-		0155E52FC425A331422920A5DA08BA3C /* ConsentViewController-iOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ConsentViewController-iOS-Info.plist"; sourceTree = "<group>"; };
 		018DA24A8E9AEDD7D76CB1BBD69D4BF6 /* Pods-NativeMessageExample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-NativeMessageExample.modulemap"; sourceTree = "<group>"; };
+		024869A0C07426817DF3CC3AD024EDF1 /* SPWebViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPWebViewExtensions.swift; sourceTree = "<group>"; };
+		02BD6CE30EDAF3FEB1C5954BA4614E2E /* ConsentViewController-iOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ConsentViewController-iOS-Info.plist"; sourceTree = "<group>"; };
 		031947E70928BEC10305773FD583AF03 /* Pods-SPGDPRExampleAppUITests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SPGDPRExampleAppUITests-Info.plist"; sourceTree = "<group>"; };
 		0344CFA79C2E0C50029085BAAEE4530F /* Pods-SourcePointMetaApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourcePointMetaApp.debug.xcconfig"; sourceTree = "<group>"; };
 		0390D0D2ECC2B32F9AA8AF682E64F7E5 /* Pods-NativeMessageExampleUITests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-NativeMessageExampleUITests"; path = Pods_NativeMessageExampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -985,26 +989,32 @@
 		03E5B52CFD39A36F161C1EA59074B519 /* Pods-NativeMessageExampleUITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-NativeMessageExampleUITests-dummy.m"; sourceTree = "<group>"; };
 		03E6DD0FCA9C5A4862739B575FA5EC61 /* IQKeyboardManagerSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IQKeyboardManagerSwift.debug.xcconfig; sourceTree = "<group>"; };
 		03FB2C2EAA650057FDB80218C9538C18 /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Sources/Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
-		042F1D1EFBC0EBC3551A937778F1BBE0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		047053BC498C04B9C5A54C9248EA470E /* Pods-ConsentViewController_ExampleTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-ConsentViewController_ExampleTests-umbrella.h"; sourceTree = "<group>"; };
 		04A2FB97CD45DDF88E3278E1BE55BF7D /* Wormholy-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Wormholy-Info.plist"; sourceTree = "<group>"; };
+		052F0758AB741230E72561BDC7A22ACA /* SPGDPRManagePreferenceViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRManagePreferenceViewController.xib; sourceTree = "<group>"; };
 		05E89BF4BC7BB0DEC5F47D84C677BBC5 /* Pods-SourcePointMetaApp.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SourcePointMetaApp.modulemap"; sourceTree = "<group>"; };
 		06AF8C147B159EAFD671BEA2D92724E7 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
+		06F803628BFA08F2F555342D92731F3B /* SPMessageViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPMessageViewController.swift; path = ConsentViewController/Classes/SPMessageViewController.swift; sourceTree = "<group>"; };
 		07138E598D41B9BE88401A889CECB6E1 /* QCKConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QCKConfiguration.swift; path = Sources/Quick/Configuration/QCKConfiguration.swift; sourceTree = "<group>"; };
 		0758C78A136FF46598392E3AC4DF0F9F /* IQUIView+Hierarchy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQUIView+Hierarchy.swift"; path = "IQKeyboardManagerSwift/Categories/IQUIView+Hierarchy.swift"; sourceTree = "<group>"; };
 		07909ED5D1C014D7B149EB7F691CBF93 /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
 		08C21BB1D865A9409170888F294A9126 /* SwiftLint-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "SwiftLint-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		09339EFDCB488877772DA5F965A30C89 /* ConsentViewController-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "ConsentViewController-tvOS.modulemap"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS.modulemap"; sourceTree = "<group>"; };
+		099AE19CF3B7A3159AED28EE53DE3229 /* SPJson.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPJson.swift; path = ConsentViewController/Classes/SPJson.swift; sourceTree = "<group>"; };
 		0A8915805A6E3A56ECCC93195CA0E17A /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
 		0B7329FE8B6F03A482CB9D887F017505 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
+		0BBD33A69B5A2C3CAC2538722F871505 /* Bundle+Framework.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bundle+Framework.swift"; path = "ConsentViewController/Classes/Bundle+Framework.swift"; sourceTree = "<group>"; };
+		0BD271375B4B91D1F7C3304B8FEEA781 /* MetaDataRequestResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetaDataRequestResponse.swift; sourceTree = "<group>"; };
 		0BE089073D68EF0B27AEA02CF5701263 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
 		0BF285887327E7FE6B84864165C52641 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
-		0C5FF8AFF5BB78C11B41EDBDA9311585 /* SP_Icon.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = SP_Icon.png; sourceTree = "<group>"; };
+		0C10539449E25FDBA3FE13D3ECB2ACB0 /* SPGDPRManagePreferenceViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRManagePreferenceViewController.swift; sourceTree = "<group>"; };
+		0C7B86DCBBC1489611E4530C9CDEB342 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = ConsentViewController/Classes/Constants.swift; sourceTree = "<group>"; };
 		0CC4EC8308E462115E693E5966185CA7 /* Code.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Code.swift; path = Source/AST/Nodes/Code.swift; sourceTree = "<group>"; };
 		0D24D181ADD549C9848DE3C8A48A2426 /* ListItemOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ListItemOptions.swift; path = Source/AST/Styling/Options/ListItemOptions.swift; sourceTree = "<group>"; };
 		0D68F2DD4656E2DC0F28ED037671461F /* Nimble-tvOS */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Nimble-tvOS"; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D87A12BCF55C5BA2030A543F13E5BED /* ActionableTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ActionableTableViewCell.swift; path = Sources/UI/Cells/ActionableTableViewCell.swift; sourceTree = "<group>"; };
+		0DB88029D7BE239F468C617AC20AB271 /* jest.config.json */ = {isa = PBXFileReference; includeInIndex = 1; path = jest.config.json; sourceTree = "<group>"; };
 		0DCCB7E13844141792F26DA17E9F2A88 /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
-		0DCEC17591F80FCF182482B83F37421A /* SPMessageUIDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPMessageUIDelegate.swift; path = ConsentViewController/Classes/SPMessageUIDelegate.swift; sourceTree = "<group>"; };
 		0E4356254470C38ADFCF81BF50F4EFE8 /* Quick-tvOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Quick-tvOS-Info.plist"; path = "../Quick-tvOS/Quick-tvOS-Info.plist"; sourceTree = "<group>"; };
 		0FA81AA6EA32A93532A7594E869D3299 /* blocks.c */ = {isa = PBXFileReference; includeInIndex = 1; name = blocks.c; path = Source/cmark/blocks.c; sourceTree = "<group>"; };
 		0FBF04B83DBEEDBEB37789AB69EDD109 /* Pods-NativeMessageExample */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-NativeMessageExample"; path = Pods_NativeMessageExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1015,13 +1025,13 @@
 		117041B8647E513963A6BA13266955A3 /* html.c */ = {isa = PBXFileReference; includeInIndex = 1; name = html.c; path = Source/cmark/html.c; sourceTree = "<group>"; };
 		11860DB62CCE2A12727931490CF86F58 /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
 		120DB32A84B61F0C61C226D9D9D1E4E7 /* Pods-ConsentViewController_ExampleTests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-ConsentViewController_ExampleTests"; path = Pods_ConsentViewController_ExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		127EE88A356B276B186DC57DB052B67D /* SPCCPAVendorDetailsViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPAVendorDetailsViewController.xib; sourceTree = "<group>"; };
 		135E1342AB961BE0D0B71A03B9EDAA81 /* DownAttributedStringRenderable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownAttributedStringRenderable.swift; path = Source/Renderers/DownAttributedStringRenderable.swift; sourceTree = "<group>"; };
 		137918CE4B88414F0264658E8287F9FC /* Pods-NativePMExampleApp.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-NativePMExampleApp.modulemap"; sourceTree = "<group>"; };
 		137E03F5404ED389DB217A87950DE3D4 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
+		13C76D8D0D249A6C90C926901BC2B964 /* CCPAPMConsentSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CCPAPMConsentSnapshot.swift; sourceTree = "<group>"; };
 		13F75203FAF2E8BDDD24BCEADAEED36B /* Pods-SourcePointMetaApp-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SourcePointMetaApp-acknowledgements.markdown"; sourceTree = "<group>"; };
+		140B936C01A9D028032A703B1C792C02 /* SPCCPAVendorDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPAVendorDetailsViewController.swift; sourceTree = "<group>"; };
 		142CB463E6DC28D50FDFB70636557B4E /* DownDebugLayoutManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownDebugLayoutManager.swift; path = "Source/AST/Styling/Layout Managers/DownDebugLayoutManager.swift"; sourceTree = "<group>"; };
-		1471C6980E34597F9E9F0C7914CDE4F5 /* SPCCPACategoryDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPACategoryDetailsViewController.swift; sourceTree = "<group>"; };
 		14CC9F07ACC4CAD18A2A4F5AFF7D3D44 /* Down.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Down.release.xcconfig; sourceTree = "<group>"; };
 		15024E0436E62BED0C5FD20F29DDF1A4 /* Nimble-iOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Nimble-iOS-Info.plist"; sourceTree = "<group>"; };
 		152016598FEB9AF219872CCA45E20932 /* ListItemPrefixGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ListItemPrefixGenerator.swift; path = Source/AST/Visitors/ListItemPrefixGenerator.swift; sourceTree = "<group>"; };
@@ -1029,7 +1039,6 @@
 		15D70F7A298CC42D2568987A442A3935 /* Nimble-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Nimble-tvOS.debug.xcconfig"; path = "../Nimble-tvOS/Nimble-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		17190541F56BBA8694F01E6811EE3421 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
 		1757B8C944E1E0E10203BD4383190D16 /* Pods-SourcePointMetaApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourcePointMetaApp.release.xcconfig"; sourceTree = "<group>"; };
-		177DD5FB31148C2407BA8D43A0902DB7 /* SPError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPError.swift; path = ConsentViewController/Classes/SPError.swift; sourceTree = "<group>"; };
 		17E9762D087007658323A8BC59C33F9C /* Pods-NativePMExampleAppUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NativePMExampleAppUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		17F9CE199E7234100943A082F7090697 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
 		180EA410C8CD013748DA27C8F91AE330 /* Pods-ConsentViewController_ExampleTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ConsentViewController_ExampleTests-dummy.m"; sourceTree = "<group>"; };
@@ -1037,14 +1046,13 @@
 		187BE1A69563332FBCC49B18DF193F85 /* BeVoid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeVoid.swift; path = Sources/Nimble/Matchers/BeVoid.swift; sourceTree = "<group>"; };
 		18F5B34976A38DE6F144DBC79B173B19 /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
 		19110D21508DAB9D98C4C5D0BAF23535 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
-		19CF649845DEF2B829FB7FD5B787243B /* ConnectivityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectivityManager.swift; path = ConsentViewController/Classes/ConnectivityManager.swift; sourceTree = "<group>"; };
-		1A030B14F4462FC48F3E107A0BBD2279 /* GDPRPMConsentSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GDPRPMConsentSnapshot.swift; sourceTree = "<group>"; };
-		1A79E6E7F82594FE03ED849144F29C8A /* SPLocalStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPLocalStorage.swift; sourceTree = "<group>"; };
+		19263897F1B9153AED31149D986C8CEC /* ConsentViewController.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = ConsentViewController.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		19400978A8768F2D99CDF5E905392611 /* SPMessageLanguage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPMessageLanguage.swift; path = ConsentViewController/Classes/SPMessageLanguage.swift; sourceTree = "<group>"; };
+		1B1E7CBB8B76FFA6C6435F1483999E54 /* PrivacyManagerViewData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrivacyManagerViewData.swift; sourceTree = "<group>"; };
 		1B83C1EF010747D15760FE6A52D72BE7 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
 		1D337BBB5D7E432F57EFA909DD5A9160 /* Pods-SPGDPRExampleAppUITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SPGDPRExampleAppUITests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		1D3B561010BE2A4F21A3F0268ABDC331 /* CustomHTTPProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomHTTPProtocol.swift; path = Sources/CustomHTTPProtocol.swift; sourceTree = "<group>"; };
 		1D5CC00FA31E003434C6D65DF8F3DA91 /* Equal+Tuple.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Equal+Tuple.swift"; path = "Sources/Nimble/Matchers/Equal+Tuple.swift"; sourceTree = "<group>"; };
-		1DA590E70E93C5C8B5D4DEEB30EEF269 /* ConsentViewController-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ConsentViewController-iOS-umbrella.h"; sourceTree = "<group>"; };
 		1DFB52D0BAC06E2A28FC6B18D1216BF0 /* houdini_html_e.c */ = {isa = PBXFileReference; includeInIndex = 1; name = houdini_html_e.c; path = Source/cmark/houdini_html_e.c; sourceTree = "<group>"; };
 		1F125995019C967D8221B1998A1F45FA /* IQKeyboardManagerSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = IQKeyboardManagerSwift.modulemap; sourceTree = "<group>"; };
 		1F7A51BA7B38F5001CC54F7CB031B708 /* QuoteStripeAttribute.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuoteStripeAttribute.swift; path = "Source/AST/Styling/Custom Attributes/QuoteStripeAttribute.swift"; sourceTree = "<group>"; };
@@ -1052,57 +1060,55 @@
 		1FF9490F64DC44BA5A308995182E951C /* RequestTitleSectionView.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; name = RequestTitleSectionView.xib; path = Sources/UI/Sections/RequestTitleSectionView.xib; sourceTree = "<group>"; };
 		2012491F1151404FE86F38D1E721B6A5 /* Pods-NativeMessageExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NativeMessageExample.release.xcconfig"; sourceTree = "<group>"; };
 		20A4710BBD2EE3CFC496E3AF134BD4FD /* ConsentViewController-tvOS-ConsentViewController */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "ConsentViewController-tvOS-ConsentViewController"; path = ConsentViewController.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		2210A1777A462D1AE0916CFFD28EC9E5 /* ConsentStatusResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentStatusResponse.swift; sourceTree = "<group>"; };
 		2216707DE7A34766E9BA9524A4506770 /* LineBreak.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LineBreak.swift; path = Source/AST/Nodes/LineBreak.swift; sourceTree = "<group>"; };
-		223B68882D1E8F05E8747949943DC53F /* MetaDataRequestResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetaDataRequestResponse.swift; sourceTree = "<group>"; };
 		2250D5EFB0AB8081F75296DB53AFB6FD /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
 		22757A3DD0FCCB8D93C46FBC5F9AC8EF /* Wormholy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Wormholy.swift; path = Sources/Wormholy.swift; sourceTree = "<group>"; };
 		22868D7C990287D519469FED4DA72B95 /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
-		229CC510F53FF3126C395D3E16A734D0 /* PrivacyManagerViewData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrivacyManagerViewData.swift; sourceTree = "<group>"; };
+		22A18D2D21DFD35D6FF2027BBC658D50 /* SPGDPRVendorDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRVendorDetailsViewController.swift; sourceTree = "<group>"; };
 		22D6C8EDA33C564DE94EEA2C5A9F0E49 /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
 		22DD0E705B347629A8710A02B8299359 /* config.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = config.h; path = Source/cmark/config.h; sourceTree = "<group>"; };
 		2442FE4F068F207E66D30731905E72C0 /* Quick-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Quick-tvOS-dummy.m"; path = "../Quick-tvOS/Quick-tvOS-dummy.m"; sourceTree = "<group>"; };
-		24B9714020F6EE241E4029F9D71FB4DD /* SPJSReceiver.spec.js */ = {isa = PBXFileReference; includeInIndex = 1; path = SPJSReceiver.spec.js; sourceTree = "<group>"; };
 		24E349AFF4609C8B48DE335DAEC14E7C /* Pods-ConsentViewController_ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ConsentViewController_ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2530BC414137FF7A53A0368B476547B9 /* Wormholy */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Wormholy; path = Wormholy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2538445DADB67C90695102ED9F35D0AA /* HtmlInline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HtmlInline.swift; path = Source/AST/Nodes/HtmlInline.swift; sourceTree = "<group>"; };
 		25554D9FAA26AE20BF956E70CF34111D /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
+		259D9EBA80B18B2AD9E1F90FA7404C75 /* ConsentViewController-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ConsentViewController-tvOS-prefix.pch"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS-prefix.pch"; sourceTree = "<group>"; };
+		25C3EBF0B637984D46D2172610B3F786 /* SPJSReceiver.spec.js */ = {isa = PBXFileReference; includeInIndex = 1; path = SPJSReceiver.spec.js; sourceTree = "<group>"; };
 		25D6CFC5D7270163DB4FC94DF015D4FB /* Postman.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Postman.swift; path = Sources/Models/Postman/Postman.swift; sourceTree = "<group>"; };
 		260AEB7610E3844784B70DD9972E25A0 /* cmark.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = cmark.h; path = Source/cmark/cmark.h; sourceTree = "<group>"; };
 		26381AEAF3A5B85195A7735518CDE616 /* CGPoint+Translate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CGPoint+Translate.swift"; path = "Source/AST/Styling/Helpers/Extensions/CGPoint+Translate.swift"; sourceTree = "<group>"; };
 		264E52F029884E3FDBAA8282ACAAEF3F /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
-		276C04F2B5F9EFF3F61284610B09A1B1 /* SPCCPAManagePreferenceViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPAManagePreferenceViewController.swift; sourceTree = "<group>"; };
 		27721A433338F97FF04F8BE5D90C9FBD /* String+ToHTML.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+ToHTML.swift"; path = "Source/Extensions/String+ToHTML.swift"; sourceTree = "<group>"; };
-		2784307EA07123E8572C4FF93F3917CE /* SPGDPRConsent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRConsent.swift; sourceTree = "<group>"; };
 		27A8053D01FA94FBBF8AFA0E44BF02DF /* Pods-SourcePointMetaAppUITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SourcePointMetaAppUITests.modulemap"; sourceTree = "<group>"; };
 		27E4103920DAD41207C515376538B5A2 /* IQKeyboardManager+Internal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQKeyboardManager+Internal.swift"; path = "IQKeyboardManagerSwift/IQKeyboardManager+Internal.swift"; sourceTree = "<group>"; };
+		282733731A4D5C723DF051F47E92B452 /* Collection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		285BE3E66975DB446D5F1D0A93CE222F /* IQPreviousNextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQPreviousNextView.swift; path = IQKeyboardManagerSwift/IQToolbar/IQPreviousNextView.swift; sourceTree = "<group>"; };
 		28DB72A698D4BB26E79A8534A15FD073 /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
-		28EA9FB3734CAE2118135175D98F1D20 /* MessageRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageRequest.swift; sourceTree = "<group>"; };
 		28EDD4660752FB3848842119A27EDE10 /* Pods-AuthExample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AuthExample-acknowledgements.plist"; sourceTree = "<group>"; };
 		2934A524A3B3835F09EF2ECF8337CE24 /* WormholyConstructor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WormholyConstructor.m; path = Sources/Objc/WormholyConstructor.m; sourceTree = "<group>"; };
-		29C4F96A0A4D2D507766ED2F935595C6 /* SimpleClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SimpleClient.swift; sourceTree = "<group>"; };
 		2ADA402AD2C0DC196800D6D7DB4E8B11 /* WHView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WHView.swift; path = Sources/Subclasses/WHView.swift; sourceTree = "<group>"; };
-		2BDAB65BE94ACA7C2A6E08E2D4FB5425 /* ConsentStatusMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentStatusMetadata.swift; sourceTree = "<group>"; };
 		2BF36247AF67FD5FCF60C2A234F271CB /* Pods-AuthExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AuthExample.release.xcconfig"; sourceTree = "<group>"; };
-		2C6EF1ACD40341510CD18A00EE40C2E3 /* SPPublisherData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPPublisherData.swift; sourceTree = "<group>"; };
 		2CBC03C3431802F9F218104BDFB237F7 /* Quick-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Quick-tvOS-umbrella.h"; path = "../Quick-tvOS/Quick-tvOS-umbrella.h"; sourceTree = "<group>"; };
 		2CD9D4878151357A0A32FC57B0B6B9FE /* ParagraphStyleCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParagraphStyleCollection.swift; path = "Source/AST/Styling/Attribute Collections/ParagraphStyleCollection.swift"; sourceTree = "<group>"; };
+		2D1F1E83882B9DE7318ECFE065AAC229 /* ConnectivityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectivityManager.swift; path = ConsentViewController/Classes/ConnectivityManager.swift; sourceTree = "<group>"; };
+		2DB34657D9ED942AFDD2DA7839D04063 /* SourcepointClientCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SourcepointClientCoordinator.swift; sourceTree = "<group>"; };
 		2DBE73DB45AB94762EE68960C907A094 /* Down-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Down-dummy.m"; sourceTree = "<group>"; };
 		2DFAFF577444917A6AE859D33710B94A /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
 		2E52D2EDA2417EA4BA098CEFF6FAFE64 /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
-		2EDF6F527EBDA7A82AF59E4AB6C0E8A3 /* SPPMHeader.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPPMHeader.xib; sourceTree = "<group>"; };
-		2EF8480E5D04F34D740E0BF306B6EFFC /* SPPrivacyManagerTab.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPPrivacyManagerTab.swift; path = ConsentViewController/Classes/SPPrivacyManagerTab.swift; sourceTree = "<group>"; };
+		2F13DD6087C28E86B9C1788E8C496A78 /* SP_Icon.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = SP_Icon.png; sourceTree = "<group>"; };
 		2F16564FBAA0831A0474BCEA8CEFC281 /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
 		2F548C5F1ADA8C0124389079EFD59FD0 /* JSONView-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "JSONView-prefix.pch"; sourceTree = "<group>"; };
 		2FBD3480792BC2F46E97894268A8D1FC /* IQUIScrollView+Additions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQUIScrollView+Additions.swift"; path = "IQKeyboardManagerSwift/Categories/IQUIScrollView+Additions.swift"; sourceTree = "<group>"; };
-		30193087B41266CA96A7E86E3AC6EFDB /* SPQRCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPQRCode.swift; sourceTree = "<group>"; };
+		3020AB2EC042108B6C1E9EF8E7259B08 /* PMVendorManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PMVendorManager.swift; sourceTree = "<group>"; };
 		3072869E17E16DC8447F4923925AF669 /* chunk.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = chunk.h; path = Source/cmark/chunk.h; sourceTree = "<group>"; };
 		30FE921CDF3239D6ADA290836A61F626 /* Pods-NativePMExampleAppUITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-NativePMExampleAppUITests.modulemap"; sourceTree = "<group>"; };
 		312A1AF68BB57DFA7A0FF0EECFC51EB3 /* Pods-SPGDPRExampleAppUITests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SPGDPRExampleAppUITests-acknowledgements.plist"; sourceTree = "<group>"; };
-		314BF0457A28BB12F453112044DD385D /* OSLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OSLogger.swift; path = ConsentViewController/Classes/OSLogger.swift; sourceTree = "<group>"; };
+		312B839222265C5ABB21AEF7BDE52787 /* CustomConsentRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomConsentRequest.swift; sourceTree = "<group>"; };
 		316EC0791AD935F9B920930577B2C79F /* Pods-SourcePointMetaAppUITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SourcePointMetaAppUITests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		3179CECFE4593086EE4E88105BA82B07 /* Pods-AuthExampleUITests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AuthExampleUITests-acknowledgements.plist"; sourceTree = "<group>"; };
 		329F04CD8054B9D66AD1907605155E24 /* xml.c */ = {isa = PBXFileReference; includeInIndex = 1; name = xml.c; path = Source/cmark/xml.c; sourceTree = "<group>"; };
+		32EB8E8EC78E12CB5BD98D6EB510185B /* GDPRPMConsentSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GDPRPMConsentSnapshot.swift; sourceTree = "<group>"; };
 		3341F72CA9008F857FDC21E11D28934E /* Pods-SPGDPRExampleAppUITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SPGDPRExampleAppUITests-dummy.m"; sourceTree = "<group>"; };
 		33870645273F20E4E36E777203CED80F /* Pods-ConsentViewController_Example */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-ConsentViewController_Example"; path = Pods_ConsentViewController_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		340BD7B6229112CF361278C3D4A29AC1 /* DownLayoutManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownLayoutManager.swift; path = "Source/AST/Styling/Layout Managers/DownLayoutManager.swift"; sourceTree = "<group>"; };
@@ -1110,7 +1116,7 @@
 		3463540E81501C1B8A2E50EB8B788F45 /* IQUITextFieldView+Additions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQUITextFieldView+Additions.swift"; path = "IQKeyboardManagerSwift/Categories/IQUITextFieldView+Additions.swift"; sourceTree = "<group>"; };
 		356F7EAAD72C8F7AF7B705E00487476F /* CodeBlockOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CodeBlockOptions.swift; path = Source/AST/Styling/Options/CodeBlockOptions.swift; sourceTree = "<group>"; };
 		358E1F97E66A2ED0D7C2706C3E3E104F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		36B1AD04671BC2FBFB399E31BB49509A /* AddOrDeleteCustomConsentResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddOrDeleteCustomConsentResponse.swift; sourceTree = "<group>"; };
+		361136B705C356E2C8AD0865F060756E /* SPPrivacyPolicyViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPPrivacyPolicyViewController.swift; sourceTree = "<group>"; };
 		36DA77D6BDB2C9F2BA204816B5EE463E /* Pods-ObjC-ExampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ObjC-ExampleApp.release.xcconfig"; sourceTree = "<group>"; };
 		3721E35ADD486A483A31FD4BFF96009B /* SwiftLint-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "SwiftLint-tvOS.debug.xcconfig"; path = "../SwiftLint-tvOS/SwiftLint-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		3733B89950161339721CBE2E1CBE2E10 /* houdini_html_u.c */ = {isa = PBXFileReference; includeInIndex = 1; name = houdini_html_u.c; path = Source/cmark/houdini_html_u.c; sourceTree = "<group>"; };
@@ -1118,50 +1124,53 @@
 		380358C9A223FE55A10AC25127FF1410 /* ConsentViewController-iOS */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "ConsentViewController-iOS"; path = ConsentViewController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3822AE8AFE1ECE7CFA93E07CAB519381 /* Pods-SPGDPRExampleAppUITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SPGDPRExampleAppUITests.modulemap"; sourceTree = "<group>"; };
 		386A66D9CFBBAFEE1BB1C8675A87001F /* Pods-AuthExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AuthExample.debug.xcconfig"; sourceTree = "<group>"; };
+		38B12C4D3E7CECEC700CF63C90E14D9A /* MessagesRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagesRequest.swift; sourceTree = "<group>"; };
 		38BFE60FE731C6D6454BC1248F62E5B5 /* WHTextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WHTextView.swift; path = Sources/Subclasses/WHTextView.swift; sourceTree = "<group>"; };
 		39D407912C0402B1D7380AB3F91D2C37 /* houdini_href_e.c */ = {isa = PBXFileReference; includeInIndex = 1; name = houdini_href_e.c; path = Source/cmark/houdini_href_e.c; sourceTree = "<group>"; };
-		3A26AC79EFF2DDBD6DBD8F7972F2293A /* PMVendorManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PMVendorManager.swift; sourceTree = "<group>"; };
 		3AB0FC247E2A3101C90428EA40F1F0E6 /* IQNSArray+Sort.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQNSArray+Sort.swift"; path = "IQKeyboardManagerSwift/Categories/IQNSArray+Sort.swift"; sourceTree = "<group>"; };
 		3AC2AF5377818CA28D1C917C5DF040D3 /* Pods-SourcePointMetaApp-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SourcePointMetaApp-frameworks.sh"; sourceTree = "<group>"; };
-		3AE019D4EEC4EA171857F56855464099 /* images */ = {isa = PBXFileReference; includeInIndex = 1; name = images; path = ConsentViewController/Assets/images; sourceTree = "<group>"; };
 		3B3AC354F5A08216CE0ED780E5B2B82C /* DownDebugTextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownDebugTextView.swift; path = "Source/AST/Styling/Text Views/DownDebugTextView.swift"; sourceTree = "<group>"; };
 		3B953B8D624CEB234E8380E1D61EB7C5 /* Nimble-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Nimble-tvOS-dummy.m"; path = "../Nimble-tvOS/Nimble-tvOS-dummy.m"; sourceTree = "<group>"; };
-		3BA775630FBF5F32F26304E7C14ECA75 /* SPJson.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPJson.swift; path = ConsentViewController/Classes/SPJson.swift; sourceTree = "<group>"; };
 		3BECE616CF3BAC89AE57F207A153AF74 /* Down-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Down-prefix.pch"; sourceTree = "<group>"; };
-		3C2239F7E2BEC75150EB0EDE80F422F1 /* SPCCPAManagePreferenceViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPAManagePreferenceViewController.xib; sourceTree = "<group>"; };
+		3C09866DE5BD008CCCB89F1F635DA621 /* PvDataRequestResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PvDataRequestResponse.swift; sourceTree = "<group>"; };
+		3C1EE4614D5D401C3ACDAE634299A561 /* SPNativeUI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPNativeUI.swift; sourceTree = "<group>"; };
 		3CB79E0BDADBD16C58009FC26E8D55A6 /* Pods-AuthExampleUITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-AuthExampleUITests.modulemap"; sourceTree = "<group>"; };
-		3D175523BA47204A774F770AA3C336D7 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = ConsentViewController/Classes/Constants.swift; sourceTree = "<group>"; };
+		3D4B07460B142B84CA2496287FE5E036 /* SPIDFAStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPIDFAStatus.swift; path = ConsentViewController/Classes/SPIDFAStatus.swift; sourceTree = "<group>"; };
+		3D6F7D1208E608AAE2535D9ECDFE3259 /* IDFAStatusReportRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IDFAStatusReportRequest.swift; sourceTree = "<group>"; };
+		3DF8F244296F4E68BEBAFF70FBE0C89C /* javascript */ = {isa = PBXFileReference; includeInIndex = 1; name = javascript; path = ConsentViewController/Assets/javascript; sourceTree = "<group>"; };
+		3E6A455FB1B245997F231B89D2C082A6 /* SPUIColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPUIColor.swift; sourceTree = "<group>"; };
 		3E8151422F4D119BA7AFF87AE9863192 /* NSAttributedString+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSAttributedString+Helpers.swift"; path = "Source/AST/Styling/Helpers/Extensions/NSAttributedString+Helpers.swift"; sourceTree = "<group>"; };
-		3E84631157C0FF4981393CCAC765E14C /* SPCampaignType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPCampaignType.swift; path = ConsentViewController/Classes/SPCampaignType.swift; sourceTree = "<group>"; };
 		3E99BDED1E6FA8CEF01BF1ABCAC4C475 /* Pods-SourcePointMetaAppUITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SourcePointMetaAppUITests-dummy.m"; sourceTree = "<group>"; };
-		3F84A4260597992E19579D6359EBAB94 /* PvDataRequestResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PvDataRequestResponse.swift; sourceTree = "<group>"; };
-		4047D4CAC50B2C75E9F18BF861468108 /* SPStringifiedJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPStringifiedJSON.swift; path = ConsentViewController/Classes/SPStringifiedJSON.swift; sourceTree = "<group>"; };
+		3F9D6BED32E513A0AA13D9C78512A40B /* Date.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		4070BC13DFC74E11C100FD3411A6AAD5 /* render.c */ = {isa = PBXFileReference; includeInIndex = 1; name = render.c; path = Source/cmark/render.c; sourceTree = "<group>"; };
 		40815068C100A6167D4D3C47E57756B1 /* Nimble-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Nimble-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		40D30DD3C99D443D22DE81C3C4225D05 /* CGRect+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CGRect+Helpers.swift"; path = "Source/AST/Styling/Helpers/Extensions/CGRect+Helpers.swift"; sourceTree = "<group>"; };
 		412EEDB4587FF3FBE3B0FA5D464BA14B /* BlockBackgroundColorAttribute.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockBackgroundColorAttribute.swift; path = "Source/AST/Styling/Custom Attributes/BlockBackgroundColorAttribute.swift"; sourceTree = "<group>"; };
 		41417D017600B7A6C80E0DB98E70C384 /* JSONTreeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONTreeView.swift; path = Sources/JSONView/JSONTreeView.swift; sourceTree = "<group>"; };
 		4146F9ED6938E0E6704A42EFD6DD2A5F /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickObjCRuntime/include/QuickSpecBase.h; sourceTree = "<group>"; };
+		41538B082DCBAC311B391D62F9F77575 /* SPGDPRPartnersViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRPartnersViewController.swift; sourceTree = "<group>"; };
 		41CEEBBE3F8FB596EDE429EB392FEF19 /* Pods-AuthExampleUITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-AuthExampleUITests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		41EAEB1DF5B5B3F3E2D3E75D0CCCA702 /* ConsentViewController-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "ConsentViewController-tvOS.modulemap"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS.modulemap"; sourceTree = "<group>"; };
+		42400389E67139027FDA2C6F1F479A8C /* SPQRCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPQRCode.swift; sourceTree = "<group>"; };
 		4255A9684099CC057C80BE7B5F8CD7FB /* cmark.c */ = {isa = PBXFileReference; includeInIndex = 1; name = cmark.c; path = Source/cmark/cmark.c; sourceTree = "<group>"; };
 		42A51D82D7093FF4E1BF5B76F611BD58 /* Wormholy.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Wormholy.debug.xcconfig; sourceTree = "<group>"; };
+		42B69A493B5BB16AFB91A94CCF3EC370 /* SPSDK.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPSDK.swift; path = ConsentViewController/Classes/SPSDK.swift; sourceTree = "<group>"; };
 		42CBB759E4790435EC90368AFB4CFCF5 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
 		42F15ADA74D492BAC76AB3EDB6C12D3D /* DownTextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownTextView.swift; path = "Source/AST/Styling/Text Views/DownTextView.swift"; sourceTree = "<group>"; };
+		436C422929BBF411EE802DB972F2A7B4 /* SourcePointClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SourcePointClient.swift; sourceTree = "<group>"; };
 		437B791FEDC5C4B595D6D29500E11197 /* JSONView */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = JSONView; path = JSONView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		439477ADCB521D4280C2A22395DF57E6 /* ChoiceRequests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChoiceRequests.swift; sourceTree = "<group>"; };
+		439412BBD46371B4CF713AE48CEF7520 /* SPCCPACategoryDetailsViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPACategoryDetailsViewController.xib; sourceTree = "<group>"; };
 		43976BE89192EABAEF36AE877B44039E /* Pods-NativeMessageExampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NativeMessageExampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		43A59EFF147B151F00B68CC489EF1F61 /* scanners.c */ = {isa = PBXFileReference; includeInIndex = 1; name = scanners.c; path = Source/cmark/scanners.c; sourceTree = "<group>"; };
+		43BBBBE57C72E2AC7FBD58BF6D0D9246 /* DeleteCustomConsentRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeleteCustomConsentRequest.swift; sourceTree = "<group>"; };
 		442A98950A08DA1804EF7DDB733517E7 /* Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Node.swift; path = Source/AST/Nodes/Node.swift; sourceTree = "<group>"; };
-		4477BB8570CEF4A854228B7BAB01F423 /* SPGDPRCategoryDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRCategoryDetailsViewController.swift; sourceTree = "<group>"; };
 		44CD8A72F3A29EF02EE34B2A6EFB7EE9 /* man.c */ = {isa = PBXFileReference; includeInIndex = 1; name = man.c; path = Source/cmark/man.c; sourceTree = "<group>"; };
 		44D5B80ADB162722509684E405FE6437 /* WHString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WHString.swift; path = Sources/Subclasses/WHString.swift; sourceTree = "<group>"; };
-		44F462EFF078F36D350AD3131AC159D5 /* Barcode.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = Barcode.png; sourceTree = "<group>"; };
 		45116B4FE9CE942C3675B2BF08E8A83D /* DownOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownOptions.swift; path = "Source/Enums & Options/DownOptions.swift"; sourceTree = "<group>"; };
-		460C615AE163149149EF5A26844398ED /* Collection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		46FD5A5C89B78C89056BED3CC9CC1D74 /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
 		473A7C3CEFD5E9479DB337765E09E0A7 /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
 		4753479FB8DCD331A98162618B938BDC /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		47EDE3AA6C6E1DE2C97AC3AA44619B43 /* SPMessageUIDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPMessageUIDelegate.swift; path = ConsentViewController/Classes/SPMessageUIDelegate.swift; sourceTree = "<group>"; };
+		48059975E6928B40F98CE48EC7CE2DFB /* SPCCPACategoryDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPACategoryDetailsViewController.swift; sourceTree = "<group>"; };
 		484341D87F3E64B2D025EE94BCB11781 /* SoftBreak.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SoftBreak.swift; path = Source/AST/Nodes/SoftBreak.swift; sourceTree = "<group>"; };
 		48BF4B715D474202AB06AC4DFFE49825 /* SwiftLint-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "SwiftLint-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		48CF52E2571D5B654384C5E667CD4671 /* Quick-iOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Quick-iOS-Info.plist"; sourceTree = "<group>"; };
@@ -1170,7 +1179,7 @@
 		494B51C75ECF3D7F5E51FBD2833B6536 /* Pods-NativeMessageExample-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-NativeMessageExample-frameworks.sh"; sourceTree = "<group>"; };
 		4A29A77F9DF18C7CD65E01B28F6BD859 /* Pods-ObjC-ExampleAppUITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ObjC-ExampleAppUITests-dummy.m"; sourceTree = "<group>"; };
 		4AA8883FD67D3E660A06F9D599287EDD /* Pods-ObjC-ExampleApp.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-ObjC-ExampleApp.modulemap"; sourceTree = "<group>"; };
-		4AFA6B36ABC056586579FFA6D736DA71 /* SourcePointClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SourcePointClient.swift; sourceTree = "<group>"; };
+		4AE5CB34B4AB1F63B2555EF3D87038CC /* ChoiceRequests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChoiceRequests.swift; sourceTree = "<group>"; };
 		4B5E4651FDC49B3926EDEE0FDC6859F1 /* Pods-NativePMExampleAppUITests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-NativePMExampleAppUITests-frameworks.sh"; sourceTree = "<group>"; };
 		4B85932749565B4906CC95F83538C516 /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
 		4B8D19EC5179D7698B6F32F7EABAC1DD /* Pods-NativePMExampleApp-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-NativePMExampleApp-umbrella.h"; sourceTree = "<group>"; };
@@ -1178,7 +1187,6 @@
 		4C8031B5B0076AE14A6CF9249DF40286 /* WHNavigationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WHNavigationController.swift; path = Sources/Subclasses/WHNavigationController.swift; sourceTree = "<group>"; };
 		4C90E8F3F21B7688E1FB09920322D768 /* Down */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Down; path = Down.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E2B59D761B510E0E3646BDC3CCE697E /* Pods-ConsentViewController_ExampleTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ConsentViewController_ExampleTests-Info.plist"; sourceTree = "<group>"; };
-		4E6B5593EE61980CC9C62A1AF03D4990 /* SPCampaigns.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPCampaigns.swift; path = ConsentViewController/Classes/SPCampaigns.swift; sourceTree = "<group>"; };
 		4EA6C625C79E315252C57908F8B8C681 /* Nimble-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Nimble-tvOS.release.xcconfig"; path = "../Nimble-tvOS/Nimble-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		4F30C92BBD1CC27CB0971D9E9D0897BF /* IQKeyboardReturnKeyHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQKeyboardReturnKeyHandler.swift; path = IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift; sourceTree = "<group>"; };
 		4F4B7F54CB04FD10F903255E6A7F053B /* Pods-NativeMessageExample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NativeMessageExample-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -1190,31 +1198,29 @@
 		5047CC804189E94A9B3CEAB093F0C53A /* IQKeyboardManager+OrientationNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQKeyboardManager+OrientationNotification.swift"; path = "IQKeyboardManagerSwift/IQKeyboardManager+OrientationNotification.swift"; sourceTree = "<group>"; };
 		50A769B7B07BFE25CF2F46555EA8C33F /* IQKeyboardManagerConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQKeyboardManagerConstants.swift; path = IQKeyboardManagerSwift/Constants/IQKeyboardManagerConstants.swift; sourceTree = "<group>"; };
 		51039E4EFFDF22E0695ED52DB077E0A6 /* references.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = references.h; path = Source/cmark/references.h; sourceTree = "<group>"; };
+		5104F5ECF953CA5841925A2E54FCD1BB /* SPNativeMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPNativeMessage.swift; path = ConsentViewController/Classes/SPNativeMessage.swift; sourceTree = "<group>"; };
 		510925CF4993719A64DA67893F88EE67 /* Pods-SPGDPRExampleAppUITests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-SPGDPRExampleAppUITests"; path = Pods_SPGDPRExampleAppUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5134E1744DB502EB07BE7CA2D0739398 /* QueryParamEncodableProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QueryParamEncodableProtocol.swift; sourceTree = "<group>"; };
-		514C4E9A23F6AD1DB6E7310AE8C77F8C /* SPGDPRPartnersViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRPartnersViewController.swift; sourceTree = "<group>"; };
 		51CEF68E4C3B5CF489641AF1F5B0FF6D /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
-		52C97914BE77B99E39621A9EC7E58C21 /* SPMessageViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPMessageViewController.swift; path = ConsentViewController/Classes/SPMessageViewController.swift; sourceTree = "<group>"; };
 		53830D02039DE43B2FFBF8AF6FF4A78B /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
-		539C8DFC548F02D6D13136EFF52E51AA /* SPGDPRVendorDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRVendorDetailsViewController.swift; sourceTree = "<group>"; };
 		53C3E3B8AC4E7FFCA4CC1428AD662243 /* Pods-ConsentViewController_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ConsentViewController_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		53C8CC7E8FC942BEC4A1E73BD846E9D6 /* parser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = parser.h; path = Source/cmark/parser.h; sourceTree = "<group>"; };
 		53CCA4DCC9B066F8E74E39A9D62DE1AB /* Pods-ConsentViewController_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-ConsentViewController_Example-umbrella.h"; sourceTree = "<group>"; };
 		5459D9ADE3F53D06B748B04037F00167 /* Text.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Text.swift; path = Source/AST/Nodes/Text.swift; sourceTree = "<group>"; };
-		5475A5AA0068B5C7E68B5F416E428AA8 /* SPAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPAction.swift; path = ConsentViewController/Classes/SPAction.swift; sourceTree = "<group>"; };
+		547C53B56CF46EDF6FA808C3EDE70260 /* ConsentViewController-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "ConsentViewController-iOS.modulemap"; sourceTree = "<group>"; };
+		54FCB144D77EC7A1406130899FADA337 /* SPCustomViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCustomViewController.swift; sourceTree = "<group>"; };
 		556E2CB0C8EF0A8C8FFC3432D8CFF6C9 /* Pods-NativeMessageExample-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-NativeMessageExample-dummy.m"; sourceTree = "<group>"; };
-		5595D26CD0CE5203994A89F8AB1F68FF /* SPPrivacyManagerRequestResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPPrivacyManagerRequestResponse.swift; sourceTree = "<group>"; };
 		5641AE647FA56F350066C84F00C50112 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
 		5654C4A59E39459D55D4237E6C3C8ED4 /* Pods-ObjC-ExampleAppUITests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ObjC-ExampleAppUITests-acknowledgements.plist"; sourceTree = "<group>"; };
 		5809B792A9D471EC59ED1B3119F1FBF8 /* Pods-ConsentViewController_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ConsentViewController_Example-Info.plist"; sourceTree = "<group>"; };
-		584FD3F4B671BF7B2DD12426DEE51951 /* ConsentViewController-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ConsentViewController-tvOS-umbrella.h"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS-umbrella.h"; sourceTree = "<group>"; };
+		581B8A297C5BCB99513CA8A43ABE49C6 /* images */ = {isa = PBXFileReference; includeInIndex = 1; name = images; path = ConsentViewController/Assets/images; sourceTree = "<group>"; };
 		5881840E2FF0269E7DF0EBD5796161CB /* RequestDetailViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RequestDetailViewController.swift; path = Sources/UI/RequestDetailViewController.swift; sourceTree = "<group>"; };
 		58BDCC723571E0BEDD0A067BE8EEB4F6 /* Pods-ObjC-ExampleApp-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ObjC-ExampleApp-acknowledgements.plist"; sourceTree = "<group>"; };
 		599829DBCF8EA88FD7D89EB0D241534D /* Wormholy.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Wormholy.modulemap; sourceTree = "<group>"; };
+		5A8D3AB99F3203C5A3038F0B05514618 /* SPUserDefaults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPUserDefaults.swift; sourceTree = "<group>"; };
 		5B3A7F1CDBF86AAF8BC24D91BB329589 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
-		5B5D7BE97D7E130364D1F4057289EC03 /* jest.config.json */ = {isa = PBXFileReference; includeInIndex = 1; path = jest.config.json; sourceTree = "<group>"; };
 		5BBD1477BD8D482C9915EB8096D1F4E4 /* iterator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = iterator.h; path = Source/cmark/iterator.h; sourceTree = "<group>"; };
 		5BF9C5D0DD6D01554FF9C138D12D7D3E /* Pods-ConsentViewController_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ConsentViewController_Example.release.xcconfig"; sourceTree = "<group>"; };
+		5D01FB303A63A86DA0C36B82086B1F40 /* SPCCPAPartnersViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPAPartnersViewController.swift; sourceTree = "<group>"; };
 		5D1725DC51D44B4115DEE79C60D671DC /* Quick-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Quick-tvOS.release.xcconfig"; path = "../Quick-tvOS/Quick-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		5D21FEF1C9571A8DBCA6B3EC4628EBDB /* NSURLSessionConfiguration+Wormholy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLSessionConfiguration+Wormholy.h"; path = "Sources/Objc/NSURLSessionConfiguration+Wormholy.h"; sourceTree = "<group>"; };
 		5D635DB9163CAD1427C26932646DACCE /* Nimble-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Nimble-tvOS-umbrella.h"; path = "../Nimble-tvOS/Nimble-tvOS-umbrella.h"; sourceTree = "<group>"; };
@@ -1224,17 +1230,19 @@
 		5E9699DCBA3371AC26B64B3E8E544C9D /* ResourceBundle-Wormholy-Wormholy-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-Wormholy-Wormholy-Info.plist"; sourceTree = "<group>"; };
 		5F39E3C8D460315153200F2686CD7C79 /* Pods-ObjC-ExampleApp-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ObjC-ExampleApp-frameworks.sh"; sourceTree = "<group>"; };
 		5F4D5CD9F1F8FF97FC14E75387B62A87 /* Wormholy-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Wormholy-dummy.m"; sourceTree = "<group>"; };
-		5F8F37E1246867F64DA19CD63664C7A2 /* ChoiceResponses.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChoiceResponses.swift; sourceTree = "<group>"; };
+		5F643506E178F3E11AFFEBC84FF28857 /* SPError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPError.swift; path = ConsentViewController/Classes/SPError.swift; sourceTree = "<group>"; };
 		5FE896ADE3757DF3DEA87A9165AFD77C /* WormholyMethodSwizzling.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WormholyMethodSwizzling.h; path = Sources/Objc/WormholyMethodSwizzling.h; sourceTree = "<group>"; };
 		6051AB88CD4018DE5378000839397FF7 /* Pods-ObjC-ExampleAppUITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ObjC-ExampleAppUITests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		609263FAED42AE3143F24A404851BB29 /* Pods-AuthExampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AuthExampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		6164F084D470032D0A75C5D784D8FB4C /* Pods-ObjC-ExampleAppUITests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ObjC-ExampleAppUITests-frameworks.sh"; sourceTree = "<group>"; };
 		617BC5E5ED6957F2FE55CFA65E0A023A /* DownRenderable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownRenderable.swift; path = Source/Renderers/DownRenderable.swift; sourceTree = "<group>"; };
-		61CCECA6D5136305C7844F2F7745605E /* SPNativeUI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPNativeUI.swift; sourceTree = "<group>"; };
+		61F074F2CF5D98F1FE8054275E5A9B75 /* SPUserData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPUserData.swift; sourceTree = "<group>"; };
+		62ABE444F807061001F52E578A329E7E /* SPCCPANativePrivacyManagerViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPANativePrivacyManagerViewController.xib; sourceTree = "<group>"; };
 		6350587403D45403E667216ECE104468 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS14.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		6381389B408CDFAAA455A7A3F74F3B13 /* OSLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OSLogger.swift; path = ConsentViewController/Classes/OSLogger.swift; sourceTree = "<group>"; };
 		6393D709D5E4D7D2C22AF63A320B3417 /* Pods-ObjC-ExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ObjC-ExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		64112AD2026682A3DE57EEDB1D2865BA /* ConsentViewController-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ConsentViewController-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		641478048A05018FE96D042EAB9E67ED /* Pods-AuthExampleUITests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AuthExampleUITests-umbrella.h"; sourceTree = "<group>"; };
-		6487BE0AA27BF693E70D2321C14F25D8 /* SPPropertyName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPPropertyName.swift; path = ConsentViewController/Classes/SPPropertyName.swift; sourceTree = "<group>"; };
 		64B8B62FA761D8BEA52D7DEFA8EC55C6 /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
 		64E28E0A80C4A7D5E7C255D18AA75C5D /* Pods-ConsentViewController_ExampleTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ConsentViewController_ExampleTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		65431F2B1B767C6E562F451F5E6624CC /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
@@ -1243,147 +1251,153 @@
 		65CEBD3C5DD66F386216F48FD505F889 /* WormholyMethodSwizzling.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WormholyMethodSwizzling.m; path = Sources/Objc/WormholyMethodSwizzling.m; sourceTree = "<group>"; };
 		6743B749F15E00A2C18D42C86A0765CF /* Pods-SPGDPRExampleAppUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SPGDPRExampleAppUITests.release.xcconfig"; sourceTree = "<group>"; };
 		6779492234D4F962E2CF571B2C94019D /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
+		67A4828FB21F6D40312306A0E841E96D /* MessagesResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagesResponse.swift; sourceTree = "<group>"; };
 		67CF98B34415888CFCC0A3919A234894 /* RequestCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; name = RequestCell.xib; path = Sources/UI/Cells/RequestCell.xib; sourceTree = "<group>"; };
-		67D94A8C188A429D5BD2D620A801F5A5 /* SPCCPAVendorDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPAVendorDetailsViewController.swift; sourceTree = "<group>"; };
-		68A817DE3655D89F8A82DE70045E8F51 /* ChoiceAllResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChoiceAllResponse.swift; sourceTree = "<group>"; };
+		67FCA61B714EC75C9C041DEAC9653729 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		6874BBA7D9E7AE21FD890E2B7584FEF0 /* SPConsentManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPConsentManager.swift; path = ConsentViewController/Classes/SPConsentManager.swift; sourceTree = "<group>"; };
 		692C690285DAF9A7CA0DC5A23554CFF3 /* JSONView-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "JSONView-Info.plist"; sourceTree = "<group>"; };
 		6A21A8A668B97E7B42405AC8FFD20999 /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
-		6B3CFDECC0F12E3CBBFFC8D027D853DC /* SourcepointClientCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SourcepointClientCoordinator.swift; sourceTree = "<group>"; };
+		6A67307522A739D21C03BC55C7799A3F /* ConsentViewController-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ConsentViewController-tvOS.debug.xcconfig"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		6A9DE8572B70C4AEF2D400E28ECDF7AB /* SPGDPRCategoryDetailsViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRCategoryDetailsViewController.xib; sourceTree = "<group>"; };
+		6B1EABC4D216660430106609E2635E94 /* GDPRPrivacyManagerViewResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GDPRPrivacyManagerViewResponse.swift; sourceTree = "<group>"; };
 		6B404CBE40EFC7C7BDE894D329EDD7C2 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
 		6B579B6E7CFE017499BB1FEBEB94CD23 /* TextTableViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; name = TextTableViewCell.xib; path = Sources/UI/Cells/TextTableViewCell.xib; sourceTree = "<group>"; };
 		6B70E31B5F5D148C1410F07F7C6C78ED /* Pods-NativeMessageExampleUITests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-NativeMessageExampleUITests-umbrella.h"; sourceTree = "<group>"; };
 		6BF9B0F4B24AC371456E88A2A3DC4027 /* RequestCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RequestCell.swift; path = Sources/UI/Cells/RequestCell.swift; sourceTree = "<group>"; };
+		6C78C391518840A8E7006022EAF57E80 /* SPGDPRNativePrivacyManagerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRNativePrivacyManagerViewController.swift; sourceTree = "<group>"; };
+		6CA419A4B9A95901AE93A15465F93F46 /* SPCCPANativePrivacyManagerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPANativePrivacyManagerViewController.swift; sourceTree = "<group>"; };
 		6CD786494CC6EFDC2693FBE7DDAFE2F5 /* references.c */ = {isa = PBXFileReference; includeInIndex = 1; name = references.c; path = Source/cmark/references.c; sourceTree = "<group>"; };
 		6D660DDE4C1F24DC68B23DB115142AEC /* Pods-AuthExampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AuthExampleUITests.release.xcconfig"; sourceTree = "<group>"; };
 		6D7885C864C246711D62F40EC398C873 /* ListItemParagraphStyler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ListItemParagraphStyler.swift; path = Source/AST/Styling/Helpers/ListItemParagraphStyler.swift; sourceTree = "<group>"; };
 		6D86EC53B5BAC0C7290B2E00C0974795 /* Pods-NativePMExampleApp-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-NativePMExampleApp-acknowledgements.markdown"; sourceTree = "<group>"; };
 		6D9E52F42BBF10055CE335DF2CAD2D96 /* HtmlBlock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HtmlBlock.swift; path = Source/AST/Nodes/HtmlBlock.swift; sourceTree = "<group>"; };
-		6DE94D7CBAABAB291F7AE4A21CE48D66 /* javascript */ = {isa = PBXFileReference; includeInIndex = 1; name = javascript; path = ConsentViewController/Assets/javascript; sourceTree = "<group>"; };
 		6DEDB54E536714442A6EA8A2A05E7933 /* Pods-AuthExampleUITests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AuthExampleUITests-Info.plist"; sourceTree = "<group>"; };
+		6EB015AFF56EBB905B160D80CADCE889 /* SPDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPDelegate.swift; path = ConsentViewController/Classes/SPDelegate.swift; sourceTree = "<group>"; };
 		6F278F01ABEA6ADF72283305E88470CB /* Image.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Image.swift; path = Source/AST/Nodes/Image.swift; sourceTree = "<group>"; };
-		6F4957050C687F320ABCDB96B7AA1C54 /* ConsentViewController-tvOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "ConsentViewController-tvOS-Info.plist"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS-Info.plist"; sourceTree = "<group>"; };
-		6FDF85FFB061EC5C8D497766DF9D44A5 /* CCPAPMConsentSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CCPAPMConsentSnapshot.swift; sourceTree = "<group>"; };
-		701342168D9B0F621F560A7CFC81E140 /* ConsentViewController-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ConsentViewController-tvOS-dummy.m"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS-dummy.m"; sourceTree = "<group>"; };
+		6FD8BE80A9F24548A9A2102421EADEB0 /* QueryParamEncodableProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QueryParamEncodableProtocol.swift; sourceTree = "<group>"; };
 		701793AE80F8D38D3B7EE579EDC49DA2 /* Link.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Link.swift; path = Source/AST/Nodes/Link.swift; sourceTree = "<group>"; };
 		70294F2D3496502D0176E56BD5A0E1D9 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
 		7081DF63F8F7C26E5449D03D6A28AEE6 /* ThematicBreakOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThematicBreakOptions.swift; path = Source/AST/Styling/Options/ThematicBreakOptions.swift; sourceTree = "<group>"; };
+		70C9EEB9C55E8BEEED132AC3B3DFE809 /* Barcode.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = Barcode.png; sourceTree = "<group>"; };
 		717AD747CABD8F35DCEEBA3D35AB2453 /* Quick-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Quick-tvOS.debug.xcconfig"; path = "../Quick-tvOS/Quick-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		71857B94D3E4661FABC88C0FAF764D2C /* SPLocalStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPLocalStorage.swift; sourceTree = "<group>"; };
+		71899FA654FC2A36F8FC057719CE8B3A /* SPCCPAManagePreferenceViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPAManagePreferenceViewController.xib; sourceTree = "<group>"; };
 		720650416794F9CDFA5986D3D05CFBEA /* Pods-NativePMExampleAppUITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-NativePMExampleAppUITests-dummy.m"; sourceTree = "<group>"; };
 		721B0C7C51FF28CEFB75F3941BA81EA6 /* Quick-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-iOS-dummy.m"; sourceTree = "<group>"; };
 		726A34F9D4D17AE4EBF1C00A383C14CD /* IQKeyboardManager+Toolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQKeyboardManager+Toolbar.swift"; path = "IQKeyboardManagerSwift/IQKeyboardManager+Toolbar.swift"; sourceTree = "<group>"; };
 		73F566CFB5F21F61AC2FA68F08AA0B2D /* Quick-tvOS */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Quick-tvOS"; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74C2AD4FAEBDF5E270D3D8E565589880 /* TextTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TextTableViewCell.swift; path = Sources/UI/Cells/TextTableViewCell.swift; sourceTree = "<group>"; };
 		74FF6F061954BEE78199AE3972F4DBB2 /* Pods-SourcePointMetaApp-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourcePointMetaApp-Info.plist"; sourceTree = "<group>"; };
+		7518233A0C485853B9D0C17CD235064B /* ConsentViewController-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "ConsentViewController-tvOS-dummy.m"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS-dummy.m"; sourceTree = "<group>"; };
 		7520B9EDE9D4F5F035EFC7486AE11716 /* List.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = List.swift; path = Source/AST/Nodes/List.swift; sourceTree = "<group>"; };
+		76662C1EFF87E0368232723B3733766F /* SPPrivacyManagerRequestResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPPrivacyManagerRequestResponse.swift; sourceTree = "<group>"; };
 		76A215D03E34C06127D887F07C63397C /* Down-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Down-Info.plist"; sourceTree = "<group>"; };
+		76BCC1DD257B4A37FA77F484801024DF /* ConsentViewController-tvOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ConsentViewController-tvOS-umbrella.h"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS-umbrella.h"; sourceTree = "<group>"; };
 		770DD20F6C81CA75AD5242593462D0AB /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
-		777FC6E3031FD3F408A7F684CAA9CA27 /* SPAppleTVButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPAppleTVButton.swift; sourceTree = "<group>"; };
 		77DBEBDC400AAA8661412D2C950CDE90 /* inlines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = inlines.h; path = Source/cmark/inlines.h; sourceTree = "<group>"; };
 		7947BAB773F339EAC63DAAF04B2D8CFC /* IQKeyboardManagerSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IQKeyboardManagerSwift-dummy.m"; sourceTree = "<group>"; };
 		7951F1410E7686BC8E5151576CDB2B08 /* Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Colors.swift; path = "Sources/Support Files/Colors.swift"; sourceTree = "<group>"; };
-		7971F90764CADB78812440A92DA746C6 /* CustomConsentRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomConsentRequest.swift; sourceTree = "<group>"; };
 		79B3A869D1182177E19095C737657B2A /* Pods-NativePMExampleApp-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-NativePMExampleApp-dummy.m"; sourceTree = "<group>"; };
 		79D12FD1A71B7E99F4104E07B92F8758 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
 		79EB69639263444FE6B71A857954296D /* CustomBlock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomBlock.swift; path = Source/AST/Nodes/CustomBlock.swift; sourceTree = "<group>"; };
-		7A036380E05F52DB23AA8871BB06A4DC /* SPUserDefaults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPUserDefaults.swift; sourceTree = "<group>"; };
 		7A0A4F9E0A88F1089D54ECAE44A14BD5 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
-		7ABC8ABDA6DCCEDAB9FC6D033BF89939 /* SPPrivacyPolicyViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPPrivacyPolicyViewController.xib; sourceTree = "<group>"; };
 		7AD18DE8C07E493F29F21F71772D684F /* Pods-NativePMExampleAppUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NativePMExampleAppUITests.release.xcconfig"; sourceTree = "<group>"; };
 		7B86E6E82A4364E3929BB2B03A2EBFBD /* Nimble-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-iOS-prefix.pch"; sourceTree = "<group>"; };
 		7BACDA6E277E5B39C910B6A290643E0D /* BlockQuote.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockQuote.swift; path = Source/AST/Nodes/BlockQuote.swift; sourceTree = "<group>"; };
 		7CBFD733E83362BED7DF5FDB665DF8C1 /* ThematicBreak.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThematicBreak.swift; path = Source/AST/Nodes/ThematicBreak.swift; sourceTree = "<group>"; };
 		7CFEFC792F717489E1D0033C41385017 /* DownXMLRenderable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownXMLRenderable.swift; path = Source/Renderers/DownXMLRenderable.swift; sourceTree = "<group>"; };
 		7D1C13EDC05950C8FEDA0B515FE23D7F /* Pods-ConsentViewController_ExampleTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ConsentViewController_ExampleTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		7D65378A1B8E46EE5F67210393414B57 /* GDPRPMPayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GDPRPMPayload.swift; sourceTree = "<group>"; };
 		7DADFC5D46A6CCFCFCEB51BB9D3392E4 /* Pods-SourcePointMetaAppUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourcePointMetaAppUITests.release.xcconfig"; sourceTree = "<group>"; };
 		7E71B2760D2E8554D609900EBB8B7690 /* Pods-NativeMessageExampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NativeMessageExampleUITests.release.xcconfig"; sourceTree = "<group>"; };
-		7F964AB7CFB89116902A252500ADD788 /* ConsentViewController-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ConsentViewController-tvOS.debug.xcconfig"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		7FC1638981BCC1F808D6DC2560841524 /* SPGDPRVendorDetailsViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRVendorDetailsViewController.xib; sourceTree = "<group>"; };
 		80168F271651A604523035FD37B31496 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
 		806E84F1FCD36DA4F322A51F7A6882C0 /* Pods-SourcePointMetaAppUITests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SourcePointMetaAppUITests-frameworks.sh"; sourceTree = "<group>"; };
 		80F0FA4B4414AA005F66CCBE95343875 /* Pods-AuthExample-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-AuthExample-acknowledgements.markdown"; sourceTree = "<group>"; };
+		8192A816EE8F9CE7ED6486B77A00624C /* SPGDPRConsent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRConsent.swift; sourceTree = "<group>"; };
 		81ED03AB7884B5D1101A89F720BF884C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		820FF5AFD0E80C8C6941CC7EF4CAAF40 /* SPURLExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPURLExtensions.swift; sourceTree = "<group>"; };
 		827079B1C799620ADA70CFBA806FA7AA /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
-		828C8315C59EC0C8EFF52E652E944AB8 /* SPCCPAPartnersViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPAPartnersViewController.swift; sourceTree = "<group>"; };
+		82778513C28C2866957936898CDA602D /* ConsentViewController-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ConsentViewController-iOS-umbrella.h"; sourceTree = "<group>"; };
 		828FE571F426888999F376AA093B97F7 /* Pods-ConsentViewController_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ConsentViewController_Example-frameworks.sh"; sourceTree = "<group>"; };
+		82D70D15582AFD0AC6A0E69024D314DA /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		840B719545A6909C9264D7360E140E74 /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
-		8456974C643D13D0CEE0DEDDB3BA1F5F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		845B339986C9074BC7AE11FF95931123 /* SPCCPAConsent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPAConsent.swift; sourceTree = "<group>"; };
 		86895502D7A8FBC36517193F928B85D7 /* Item.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Item.swift; path = Source/AST/Nodes/Item.swift; sourceTree = "<group>"; };
 		86B2F1A946BF1440B16A1062112D22FE /* Quick-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Quick-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		86BA2F35C05C02BCABF8F3D30603A915 /* ConsentViewController-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ConsentViewController-tvOS.release.xcconfig"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		878715BE17B7F8EEE0EE94835AE58C98 /* DispatchTimeInterval.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DispatchTimeInterval.swift; path = Sources/Nimble/Utils/DispatchTimeInterval.swift; sourceTree = "<group>"; };
 		87F52123A0B2F891277E0CFF9A267D9B /* Pods-AuthExample */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-AuthExample"; path = Pods_AuthExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88C3960918EE14D8B5928FFE66526DFF /* CustomActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomActivity.swift; path = Sources/Subclasses/CustomActivity.swift; sourceTree = "<group>"; };
+		88D763EF8AB338EB770555D5677D48C0 /* SPCCPAPartnersViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPAPartnersViewController.xib; sourceTree = "<group>"; };
 		8AEE728651825B45170142762B9F92BC /* RequestTitleSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RequestTitleSectionView.swift; path = Sources/UI/Sections/RequestTitleSectionView.swift; sourceTree = "<group>"; };
 		8B4384F4271C4E1F68EDF2E1BCE26E1A /* Pods-ConsentViewController_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ConsentViewController_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		8B97C385536ECA9485526486DC990ECF /* Await.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Await.swift; path = Sources/Nimble/Utils/Await.swift; sourceTree = "<group>"; };
-		8C8E7531FEDF9A2B0EF955189B3AE6A9 /* ConsentViewController-tvOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "ConsentViewController-tvOS-prefix.pch"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS-prefix.pch"; sourceTree = "<group>"; };
-		8E26BF4E53CA96AEA636343BD452394F /* SPGDPRManagePreferenceViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRManagePreferenceViewController.xib; sourceTree = "<group>"; };
+		8E2C263BAF9DFE562CB999D63FBED33A /* ConsentViewController-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ConsentViewController-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		8E63CD0945B9D178FF0CC2AF2751C72B /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
 		8EFD389278DCAE40D4A6F1CD5019CCDE /* Pods-NativeMessageExampleUITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-NativeMessageExampleUITests.modulemap"; sourceTree = "<group>"; };
 		8F14AA232F04EB7627811BC6CD5E590F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		8F8E11F0BA49C7755489AD82C54034C9 /* IQKeyboardManager+Debug.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQKeyboardManager+Debug.swift"; path = "IQKeyboardManagerSwift/IQKeyboardManager+Debug.swift"; sourceTree = "<group>"; };
-		8FA771D5B9941FAE0033994DCAA0DFD0 /* SPWebViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPWebViewExtensions.swift; sourceTree = "<group>"; };
 		9003A744024FE2D5F4EA717E4524F872 /* Pods-AuthExample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AuthExample-umbrella.h"; sourceTree = "<group>"; };
 		904C94CF67C84BF6E4E596BFF070663F /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
 		90B9957458BA7BE9BCF5C8E5AE2DCAFE /* JSONView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "JSONView-dummy.m"; sourceTree = "<group>"; };
-		90D3727C4F0FA35173C80EB3C59DDF49 /* IDFAStatusReportRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IDFAStatusReportRequest.swift; sourceTree = "<group>"; };
 		92321CEC968DCD4908350231D8D17509 /* QuickConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickConfiguration.swift; path = Sources/Quick/Configuration/QuickConfiguration.swift; sourceTree = "<group>"; };
 		925E9581D16B3EC0C59F7FAE66E79D12 /* Nimble-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Nimble-iOS.modulemap"; sourceTree = "<group>"; };
 		92814138089BED333E2B2E1E6F205E9D /* DownCommonMarkRenderable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownCommonMarkRenderable.swift; path = Source/Renderers/DownCommonMarkRenderable.swift; sourceTree = "<group>"; };
 		932965E644537AC076786ECEF9097623 /* QuickObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickObjCRuntime.h; path = Sources/QuickObjCRuntime/include/QuickObjCRuntime.h; sourceTree = "<group>"; };
 		933A5B5638160E5921D63A4C3364E25F /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickObjCRuntime/QuickSpecBase.m; sourceTree = "<group>"; };
 		9344639DEC28DF6C91B12F94A3FF74C8 /* houdini.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = houdini.h; path = Source/cmark/houdini.h; sourceTree = "<group>"; };
-		93B85178157AB7E9CEB0F8DFD7359AE5 /* SPUIColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPUIColor.swift; sourceTree = "<group>"; };
+		9356730B123DC0D418A56CE82E9623E5 /* ResourceBundle-ConsentViewController-ConsentViewController-iOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-ConsentViewController-ConsentViewController-iOS-Info.plist"; sourceTree = "<group>"; };
 		94A1E9385C6926655A13C51E80576339 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		94A8DB62DF77D798B329646BD66F6239 /* WHDate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WHDate.swift; path = Sources/Subclasses/WHDate.swift; sourceTree = "<group>"; };
+		94BB776D3E20372DDF92F05076640AE1 /* NSObjectExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NSObjectExtensions.swift; sourceTree = "<group>"; };
+		94CB7EF4A828D46D4F0255622811021B /* SPPrivacyManagerTab.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPPrivacyManagerTab.swift; path = ConsentViewController/Classes/SPPrivacyManagerTab.swift; sourceTree = "<group>"; };
 		94E41F9E4F7F59DF33A7450045E91FAC /* IQKeyboardManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQKeyboardManager.swift; path = IQKeyboardManagerSwift/IQKeyboardManager.swift; sourceTree = "<group>"; };
 		94F0D55887BBB48A5F70C73FE33701EF /* CwlCatchBadInstructionPosix.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstructionPosix.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPosixPreconditionTesting/CwlCatchBadInstructionPosix.swift; sourceTree = "<group>"; };
+		958F48A6FBB82F23052D20A0602AA77F /* SPAppleTVButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPAppleTVButton.swift; sourceTree = "<group>"; };
+		95ABCCDF1B9D0C62FB0902117B9DD4CB /* ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist"; path = "../ConsentViewController-tvOS/ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist"; sourceTree = "<group>"; };
 		95AC1C935D0EFAD33334F0EC247AA314 /* Quick-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-iOS-prefix.pch"; sourceTree = "<group>"; };
 		960B3590544CFBA4BB273266039E1DCF /* Pods-NativeMessageExample-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NativeMessageExample-Info.plist"; sourceTree = "<group>"; };
-		964546ECA7E3236864DBFDC9EA1375CC /* DeleteCustomConsentRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeleteCustomConsentRequest.swift; sourceTree = "<group>"; };
-		9758CD86F35317EAE38A562A3630A7B3 /* SPGDPRNativePrivacyManagerViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRNativePrivacyManagerViewController.xib; sourceTree = "<group>"; };
+		966B2E914EEE28ECF349826319E685A0 /* SPPropertyName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPPropertyName.swift; path = ConsentViewController/Classes/SPPropertyName.swift; sourceTree = "<group>"; };
+		96974D8BCDCA8DBCE2ECBEA25147B75F /* ConsentViewController-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ConsentViewController-iOS-prefix.pch"; sourceTree = "<group>"; };
 		9772094106D90C4D54A9687DF2A7A60C /* Wormholy-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Wormholy-prefix.pch"; sourceTree = "<group>"; };
 		97744050CD3BA0B1EC4B29A1FBC3E186 /* Wormholy-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Wormholy-umbrella.h"; sourceTree = "<group>"; };
+		978E3F03E764292B1C1A142E4636C0E8 /* SPCustomViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCustomViewController.xib; sourceTree = "<group>"; };
+		989D2B471579A3D696A1F3418778EFCA /* SPURLExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPURLExtensions.swift; sourceTree = "<group>"; };
 		9A0E3CD9E2006DAAB5710802CD11B6D7 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
 		9A9C04673231C48B2E6ED42A2AB6D34E /* DownErrors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownErrors.swift; path = "Source/Enums & Options/DownErrors.swift"; sourceTree = "<group>"; };
 		9AC0A39714B6C57DA8F69184FA513363 /* Pods-NativeMessageExample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-NativeMessageExample-umbrella.h"; sourceTree = "<group>"; };
 		9BD71BF64D33A5EE5A322826A6D0E381 /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
-		9C2203991CF87910BDD063D65ACD1EBE /* GDPRPrivacyManagerViewResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GDPRPrivacyManagerViewResponse.swift; sourceTree = "<group>"; };
-		9CBF2460FDA962B0B444FA81DEE9E5F2 /* Date.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		9D0CC2596F659DEE896423741846BCDA /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
 		9D76D2AAF759795F17D78BD9B137FB61 /* Pods-ObjC-ExampleAppUITests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-ObjC-ExampleAppUITests"; path = Pods_ObjC_ExampleAppUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9D966529D260DF33A0925C56470DCABC /* Storage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Storage.swift; path = Sources/Storage.swift; sourceTree = "<group>"; };
 		9E108468363DC7CF9494FD4110912EF2 /* BeWithin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeWithin.swift; path = Sources/Nimble/Matchers/BeWithin.swift; sourceTree = "<group>"; };
+		9E351CB99D1D27B7B5A640849BD98C91 /* SPDate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPDate.swift; path = ConsentViewController/Classes/SPDate.swift; sourceTree = "<group>"; };
+		9E573C7AF82B5C83EFF10C961801B705 /* SPFocusableTextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPFocusableTextView.swift; sourceTree = "<group>"; };
 		9EED9D633EBC8E688948938F6618AB1A /* Pods-NativePMExampleApp-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-NativePMExampleApp-frameworks.sh"; sourceTree = "<group>"; };
 		9FC78135B0B858A8DF07F58C6F8451E5 /* Pods-SourcePointMetaAppUITests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourcePointMetaAppUITests-Info.plist"; sourceTree = "<group>"; };
 		A0032D232FB89AF247FB539CA7C6F645 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
 		A09FB9514C706BAC0D25E445FCF3BDCA /* BeResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeResult.swift; path = Sources/Nimble/Matchers/BeResult.swift; sourceTree = "<group>"; };
 		A0AA1AC65798F3632CEF26195BB3BB3F /* SwiftLint-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "SwiftLint-tvOS.release.xcconfig"; path = "../SwiftLint-tvOS/SwiftLint-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		A1A05DB1E1978F1BA2CA1919E3C47AE9 /* ConsentViewController-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ConsentViewController-iOS-dummy.m"; sourceTree = "<group>"; };
 		A20C28362BE5898EDE4FEE6C967AF566 /* ColorCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ColorCollection.swift; path = "Source/AST/Styling/Attribute Collections/ColorCollection.swift"; sourceTree = "<group>"; };
 		A2951E938C866691A0A2B9D510DCC6B0 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
 		A2A2ABEC75C3B201B4F8DFEBFE92FAA7 /* Pods-SourcePointMetaApp */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-SourcePointMetaApp"; path = Pods_SourcePointMetaApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2E4695922171AB0B0A489E7FE4127B0 /* Pods-ObjC-ExampleApp-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-ObjC-ExampleApp-umbrella.h"; sourceTree = "<group>"; };
 		A315A7B6ECBF785825BD78B7BB6D04FC /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
-		A492BCA73059A5069E9F8278726E515F /* SPWebMessageViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPWebMessageViewController.swift; sourceTree = "<group>"; };
 		A4CEDEF6E1052F883EC87F04399160CE /* Pods-ObjC-ExampleApp */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-ObjC-ExampleApp"; path = Pods_ObjC_ExampleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4DE98D8DF2002DAC3ACD4A54956E4DE /* Config.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Config.swift; path = "Sources/Support Files/Config.swift"; sourceTree = "<group>"; };
 		A5B781CE58834A8C23E37229F1561B47 /* Pods-AuthExample-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-AuthExample-Info.plist"; sourceTree = "<group>"; };
 		A5F0A5D25E74A091B2F052AABAD11F67 /* Pods-ObjC-ExampleAppUITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-ObjC-ExampleAppUITests.modulemap"; sourceTree = "<group>"; };
 		A62B616AE6A6F954362F28DD8D88366B /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
 		A63143CE5782F61A3E2FA8639850BBC7 /* Pods-NativePMExampleAppUITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-NativePMExampleAppUITests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		A785D33B369746C28846A1B67D6AFEC0 /* SPGDPRPartnersViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRPartnersViewController.xib; sourceTree = "<group>"; };
-		A809A545BBF7F5ACCE142F3DEFC24B82 /* SPFocusableTextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPFocusableTextView.swift; sourceTree = "<group>"; };
 		A88CE3A6E51C34187F86281DB75F54E7 /* Down-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Down-umbrella.h"; sourceTree = "<group>"; };
 		A8E950A16D00F649C54FFB30F81D7842 /* IQKeyboardManagerSwift */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = IQKeyboardManagerSwift; path = IQKeyboardManagerSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A91027530C899F224F03C827FEBFC0B2 /* SimpleClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SimpleClient.swift; sourceTree = "<group>"; };
 		A92617F51470C15CAD521741390A422E /* BaseNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BaseNode.swift; path = Source/AST/Nodes/BaseNode.swift; sourceTree = "<group>"; };
+		A9D6BAFBBE5B76401E897D8280933836 /* SPPMHeader.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPPMHeader.xib; sourceTree = "<group>"; };
 		AA329714BAC4D98AC0B97306AA80D9B4 /* FileHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FileHandler.swift; path = Sources/Utils/FileHandler.swift; sourceTree = "<group>"; };
 		AA7CFFF9CE15070521A2CA8C209A9889 /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
 		AA92ED38E716E03D3FC758C810953B95 /* Wormholy-Wormholy */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "Wormholy-Wormholy"; path = Wormholy.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
-		AA9B15B0D15EF898E424E727B2E9A01C /* PMCategoryManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PMCategoryManager.swift; sourceTree = "<group>"; };
-		AB6F0B2251A6458ABB109B0A14981E5F /* ConsentViewController-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ConsentViewController-iOS.debug.xcconfig"; sourceTree = "<group>"; };
-		ABC0C636E983A146EF76F6E672AA40B3 /* ConsentViewController-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "ConsentViewController-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		AB725A064558DC098766E7C83944569A /* SPUSNatConsent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPUSNatConsent.swift; sourceTree = "<group>"; };
 		ABD6628D8C0F2EF1B89427447D9CC83D /* Pods-ObjC-ExampleApp-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ObjC-ExampleApp-acknowledgements.markdown"; sourceTree = "<group>"; };
 		AC34A396EA216E294416AD4721B04981 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
 		AC55A3ECDCCE7AD91C0C1F82F0D436B0 /* Pods-ObjC-ExampleAppUITests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ObjC-ExampleAppUITests-Info.plist"; sourceTree = "<group>"; };
@@ -1391,79 +1405,80 @@
 		AF6663C4A3C0BDC918F93DC3363922E4 /* ShareUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareUtils.swift; path = Sources/Utils/ShareUtils.swift; sourceTree = "<group>"; };
 		AF9A2702875DD2CA1970105832580D39 /* String+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+C99ExtendedIdentifier.swift"; path = "Sources/Quick/String+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
 		AFB25B07CCBB900612F3038AA46140FB /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
-		AFF54F2D66863A21794692394B4DE853 /* SPCampaignEnv.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPCampaignEnv.swift; path = ConsentViewController/Classes/SPCampaignEnv.swift; sourceTree = "<group>"; };
 		B03360C3F37767F8978ECE6727624F1A /* RequestModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RequestModel.swift; path = Sources/Models/RequestModel.swift; sourceTree = "<group>"; };
+		B0F238701ED3EDA2C5FEF40EBD01B0FC /* ChoiceAllResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChoiceAllResponse.swift; sourceTree = "<group>"; };
 		B117EC0E0AB4F2BF2420B2BBE01E6BC8 /* Quick-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "Quick-tvOS.modulemap"; path = "../Quick-tvOS/Quick-tvOS.modulemap"; sourceTree = "<group>"; };
 		B15ADC04FF459E84C6ABC2BDB65630B5 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
+		B18F4FD8E657BC422B2BE3723477129D /* ConsentViewController-tvOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "ConsentViewController-tvOS-Info.plist"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS-Info.plist"; sourceTree = "<group>"; };
 		B1F086384F6B2F848A9A1256E8E74A58 /* IQKeyboardManagerSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IQKeyboardManagerSwift-umbrella.h"; sourceTree = "<group>"; };
 		B236B9D85298E0C2286C09291A270BF4 /* JSONView.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = JSONView.debug.xcconfig; sourceTree = "<group>"; };
-		B252B8E80DCE0FD094FA558FCB0B5320 /* ConsentStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentStatus.swift; sourceTree = "<group>"; };
-		B3ED46B71DB1362B2152B842E734FC2D /* SPCCPANativePrivacyManagerViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPANativePrivacyManagerViewController.xib; sourceTree = "<group>"; };
+		B34866691E75484824EC739581DCD053 /* SPCampaignType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPCampaignType.swift; path = ConsentViewController/Classes/SPCampaignType.swift; sourceTree = "<group>"; };
 		B458415857EF90712D86C5E0A6BFA112 /* Pods-NativePMExampleAppUITests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NativePMExampleAppUITests-acknowledgements.plist"; sourceTree = "<group>"; };
 		B4B9C691E324AE9E7F94E1561C96C4D8 /* NimbleEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleEnvironment.swift; path = Sources/Nimble/Adapters/NimbleEnvironment.swift; sourceTree = "<group>"; };
 		B573BE43616EFECAB832B3CB2CC426F2 /* Pods-NativeMessageExample-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-NativeMessageExample-acknowledgements.markdown"; sourceTree = "<group>"; };
 		B583A85EEA77DA2A44A2FEF3AFEC3A67 /* Pods-SourcePointMetaAppUITests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SourcePointMetaAppUITests-umbrella.h"; sourceTree = "<group>"; };
 		B5D2D1A2EC4B0FEEF03C642D6B99C06E /* RequestsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RequestsViewController.swift; path = Sources/UI/RequestsViewController.swift; sourceTree = "<group>"; };
 		B5E95A52AFAF15D941AE275A43898765 /* IQKeyboardManagerConstantsInternal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQKeyboardManagerConstantsInternal.swift; path = IQKeyboardManagerSwift/Constants/IQKeyboardManagerConstantsInternal.swift; sourceTree = "<group>"; };
+		B6392C301C609DA6F69C097BFF04872A /* LongButtonViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = LongButtonViewCell.xib; sourceTree = "<group>"; };
 		B65C472BE17C0D3E1326DCDB50A7EF8E /* Down.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Down.h; path = Source/Down.h; sourceTree = "<group>"; };
 		B750314F9A38D3666A6541C6369B5D1D /* Pods-SPGDPRExampleAppUITests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SPGDPRExampleAppUITests-frameworks.sh"; sourceTree = "<group>"; };
-		B75CE812789369B344F36EE008ED79B6 /* ConsentViewController.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = ConsentViewController.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		B76BA69EF675BA3E104496E798C3E72E /* IQUIViewController+Additions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQUIViewController+Additions.swift"; path = "IQKeyboardManagerSwift/Categories/IQUIViewController+Additions.swift"; sourceTree = "<group>"; };
+		B808D0A304860016288A645F95B37A47 /* SPGDPRCategoryDetailsViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRCategoryDetailsViewController.swift; sourceTree = "<group>"; };
+		B889D5BC3C973D012577EFE632A14F18 /* GDPRPMPayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GDPRPMPayload.swift; sourceTree = "<group>"; };
 		B8C11695EE5B193D1F0D8BF72B9C9AA7 /* BeginWithPrefix.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWithPrefix.swift; path = Sources/Nimble/Matchers/BeginWithPrefix.swift; sourceTree = "<group>"; };
 		B925A01B46DC4576D5A7DCEDDB5DD6C6 /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
+		B9375B3FF39FE8E647DEF816E4A4BA4B /* SPStringifiedJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPStringifiedJSON.swift; path = ConsentViewController/Classes/SPStringifiedJSON.swift; sourceTree = "<group>"; };
 		B9A9FAAF3CDE683DCE7F80696E3E1780 /* Visitor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Visitor.swift; path = Source/AST/Visitors/Visitor.swift; sourceTree = "<group>"; };
-		BA0FC05392595124ACD912E0FAC83A97 /* SPGDPRCategoryDetailsViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRCategoryDetailsViewController.xib; sourceTree = "<group>"; };
 		BA36FFECCCE8F0C5DF4B2C03698A3AE4 /* Pods-NativePMExampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-NativePMExampleApp.debug.xcconfig"; sourceTree = "<group>"; };
-		BA78A05C69F29E2CA0169D67110BCBE7 /* LongButtonViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = LongButtonViewCell.xib; sourceTree = "<group>"; };
 		BB99BA06CBE242DB60211532AF6D3446 /* Wormholy.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Wormholy.release.xcconfig; sourceTree = "<group>"; };
+		BBA59492BB5FDCC898516A27C6F6D2AD /* AddOrDeleteCustomConsentResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddOrDeleteCustomConsentResponse.swift; sourceTree = "<group>"; };
 		BD31644DADCD4A243771D8DD47442F62 /* utf8.c */ = {isa = PBXFileReference; includeInIndex = 1; name = utf8.c; path = Source/cmark/utf8.c; sourceTree = "<group>"; };
 		BD3571F06BA6522D948405B220E90283 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
-		BEB4710F72E37782F211DAD8B4C712FC /* SPCCPAPartnersViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPAPartnersViewController.xib; sourceTree = "<group>"; };
 		BF234D7502CABD3ECCE3DB47C14619FE /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
 		BF34295A4EEB1DD5444CFD386B9FC50D /* Pods-ConsentViewController_ExampleTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ConsentViewController_ExampleTests-frameworks.sh"; sourceTree = "<group>"; };
 		BFACA9FCCC8A1B367EF4F8611D73E3A2 /* Emphasis.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Emphasis.swift; path = Source/AST/Nodes/Emphasis.swift; sourceTree = "<group>"; };
-		C00F8E0AE9705B47C4A9A184BE46431A /* SPCCPANativePrivacyManagerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPANativePrivacyManagerViewController.swift; sourceTree = "<group>"; };
+		BFECB5A821926764458845FF526DDA6B /* SPJSReceiver.js */ = {isa = PBXFileReference; includeInIndex = 1; path = SPJSReceiver.js; sourceTree = "<group>"; };
 		C14D9A75C6D0D148766A787E6DAEEEA2 /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
 		C1A5FA27905F9B4BACFA1D7F792D487A /* Quick-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Quick-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		C1A772930289BCF3CAA8EA3D19487AA1 /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
 		C2450198951C7A04D49D9EC3D4796A23 /* IQKeyboardManager+UIKeyboardNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQKeyboardManager+UIKeyboardNotification.swift"; path = "IQKeyboardManagerSwift/IQKeyboardManager+UIKeyboardNotification.swift"; sourceTree = "<group>"; };
 		C2766E728CD9592E3A30878EBA5AF776 /* WHLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WHLabel.swift; path = Sources/Subclasses/WHLabel.swift; sourceTree = "<group>"; };
-		C2CB6B9880FD351B6C08374FBDFD7C6D /* SPNativeMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPNativeMessage.swift; path = ConsentViewController/Classes/SPNativeMessage.swift; sourceTree = "<group>"; };
 		C2FCA34B3522D944BAA3DC6A57D99686 /* Nimble-iOS */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Nimble-iOS"; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C376E206D0D66370BA9AB1F8832BD3B8 /* ElementsEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementsEqual.swift; path = Sources/Nimble/Matchers/ElementsEqual.swift; sourceTree = "<group>"; };
 		C3B6F134DE0CE4BE0763FBD533D71D0A /* cmark_ctype.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = cmark_ctype.h; path = Source/cmark/cmark_ctype.h; sourceTree = "<group>"; };
 		C3C5C29210CD22378C6D7E9483EB41BB /* buffer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = buffer.c; path = Source/cmark/buffer.c; sourceTree = "<group>"; };
 		C443E6DD1ADC19142B5667B7378C9880 /* DownHTMLRenderable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownHTMLRenderable.swift; path = Source/Renderers/DownHTMLRenderable.swift; sourceTree = "<group>"; };
-		C4462582FCCE51251BEBB673193362F4 /* ConsentViewController-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "ConsentViewController-iOS.modulemap"; sourceTree = "<group>"; };
 		C45FE0ACA89D6EAC73605EB0429AB073 /* Pods-ConsentViewController_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ConsentViewController_Example-dummy.m"; sourceTree = "<group>"; };
 		C4A4CD43F953CBB0C3D4664BE54D9BA5 /* Pods-AuthExample-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-AuthExample-frameworks.sh"; sourceTree = "<group>"; };
+		C4BFF4525B8E99AC8AA9682A0AD5096C /* SPAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPAction.swift; path = ConsentViewController/Classes/SPAction.swift; sourceTree = "<group>"; };
 		C4FC37CE1C465F65FBF6CC8565C0EFE4 /* utf8.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = utf8.h; path = Source/cmark/utf8.h; sourceTree = "<group>"; };
 		C511053A4578911005F325403FEDD36E /* ActionableTableViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; name = ActionableTableViewCell.xib; path = Sources/UI/Cells/ActionableTableViewCell.xib; sourceTree = "<group>"; };
 		C5161DB129928CB0A61582027AFBBAE1 /* Wormholy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Wormholy.h; path = Sources/Wormholy.h; sourceTree = "<group>"; };
 		C51645FD8897485F1D69445B38DAE43C /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
+		C57396400EE00521565E70F98E6BDFD1 /* SPPMHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPPMHeader.swift; sourceTree = "<group>"; };
 		C621160453E58A808103CD9384B2AD4E /* IQUIView+IQKeyboardToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQUIView+IQKeyboardToolbar.swift"; path = "IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift"; sourceTree = "<group>"; };
+		C64B56D57B02D8D11C91C959BA4069BC /* SPCampaigns.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPCampaigns.swift; path = ConsentViewController/Classes/SPCampaigns.swift; sourceTree = "<group>"; };
 		C6DF058A61D708AF2FB75A61C5C773A8 /* Document.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Document.swift; path = Source/AST/Nodes/Document.swift; sourceTree = "<group>"; };
-		C7F01F54D5755E2A41C32B8A844B29DD /* SPUserData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPUserData.swift; sourceTree = "<group>"; };
+		C6F151B5C0933D8A655A7DF020970178 /* SPCampaignEnv.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPCampaignEnv.swift; path = ConsentViewController/Classes/SPCampaignEnv.swift; sourceTree = "<group>"; };
 		C8131FF6AD0882BD02A7B7EC78AF0CDE /* Pods-SourcePointMetaAppUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SourcePointMetaAppUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		C8233E8F1FDFC0D097C32E689CA106F9 /* Pods-NativePMExampleAppUITests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-NativePMExampleAppUITests"; path = Pods_NativePMExampleAppUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C85151050329E96D5DDA93AA7EB8A335 /* SPConsentManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPConsentManager.swift; path = ConsentViewController/Classes/SPConsentManager.swift; sourceTree = "<group>"; };
 		C864DD236E19DDEC0855CD6DC11DE43C /* Pods-ConsentViewController_ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ConsentViewController_ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		C8B7ECBC48D5A4C7558411E8764C9E1F /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
 		C8E0F49D3F9CF6715FD8D2D98638F20F /* Quick-iOS */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Quick-iOS"; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9449F190ED29BBB0E615C70560D4FA7 /* Pods-AuthExample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-AuthExample.modulemap"; sourceTree = "<group>"; };
 		C96FDBF32869B4E9BEA3EBC65DE5F273 /* NSMutableAttributedString+Attributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSMutableAttributedString+Attributes.swift"; path = "Source/AST/Styling/Helpers/Extensions/NSMutableAttributedString+Attributes.swift"; sourceTree = "<group>"; };
 		C97CD2F577668AFD8F544447A6328493 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
-		C99F1367AA419AD39BA004551C43D993 /* SPSDK.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPSDK.swift; path = ConsentViewController/Classes/SPSDK.swift; sourceTree = "<group>"; };
-		C9F5A4C0E23281A4DE22DF8D3A07CF2F /* SPString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPString.swift; sourceTree = "<group>"; };
+		C995D751887BE3C8F691C0C521442AD2 /* SPGDPRNativePrivacyManagerViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRNativePrivacyManagerViewController.xib; sourceTree = "<group>"; };
 		CA3196906642F926213FD7D7BE1EEEE3 /* Pods-SPGDPRExampleAppUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SPGDPRExampleAppUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		CA4F80DF4A9707BD0EE7C79298BE4E51 /* ErrorMetricsRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorMetricsRequest.swift; sourceTree = "<group>"; };
 		CAAC5927463AA87FB034761B3595C1D3 /* Flow.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = Flow.storyboard; path = Sources/UI/Flow.storyboard; sourceTree = "<group>"; };
 		CAEA285DACFED563DC456C78F35A66CF /* Pods-SourcePointMetaAppUITests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-SourcePointMetaAppUITests"; path = Pods_SourcePointMetaAppUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB04BE1AF8FE9BD398CF4B13EEE1B40D /* Nimble-tvOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Nimble-tvOS-Info.plist"; path = "../Nimble-tvOS/Nimble-tvOS-Info.plist"; sourceTree = "<group>"; };
+		CBAD3F2BD4D00E9574790ACC3405E443 /* MessageRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageRequest.swift; sourceTree = "<group>"; };
 		CC4BF4A2CD5B5CB6EA8A7C9B0F662CD6 /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
 		CD49BC421FEE8709A52890556B3E6197 /* inlines.c */ = {isa = PBXFileReference; includeInIndex = 1; name = inlines.c; path = Source/cmark/inlines.c; sourceTree = "<group>"; };
 		CD6B894B1009A4ECEB2DCAEDF78291F8 /* Pods-ObjC-ExampleApp-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ObjC-ExampleApp-dummy.m"; sourceTree = "<group>"; };
 		CD9D36A3F5DA5E98DB86DF08477AE877 /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Sources/Quick/World.swift; sourceTree = "<group>"; };
-		CDC16C315EDCAE62E1828446CBE23901 /* SPDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPDelegate.swift; path = ConsentViewController/Classes/SPDelegate.swift; sourceTree = "<group>"; };
 		CE22DD310BE71ABD5D88DAC8018A4401 /* FontCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FontCollection.swift; path = "Source/AST/Styling/Attribute Collections/FontCollection.swift"; sourceTree = "<group>"; };
 		CE249B34809CAE3033328C1268A59433 /* IQTextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQTextView.swift; path = IQKeyboardManagerSwift/IQTextView/IQTextView.swift; sourceTree = "<group>"; };
 		CEFE2FFF1CB533C6879E27F92F3A0195 /* Section.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Section.swift; path = Sources/Models/Section.swift; sourceTree = "<group>"; };
@@ -1473,8 +1488,6 @@
 		D1A51BD19FF4F43299CFD85B8CB5BFC9 /* Nimble-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Nimble-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		D1E8A5142B09DB9B65C84189E4515DC5 /* DownGroffRenderable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownGroffRenderable.swift; path = Source/Renderers/DownGroffRenderable.swift; sourceTree = "<group>"; };
 		D21A71AD36A279984DFE6049180C8C4E /* scanners.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = scanners.h; path = Source/cmark/scanners.h; sourceTree = "<group>"; };
-		D29BC86232D98099004CB552B613C066 /* ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist"; path = "../ConsentViewController-tvOS/ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist"; sourceTree = "<group>"; };
-		D2BF89AC326EB7E5B953753088D331E4 /* SPNativeScreenViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPNativeScreenViewController.swift; sourceTree = "<group>"; };
 		D2EA4D4CB879E31CCAF1E4E3D382970B /* Pods-AuthExampleUITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-AuthExampleUITests-dummy.m"; sourceTree = "<group>"; };
 		D30BC4A2BB02509CD9B6921D29507A79 /* DownStyler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownStyler.swift; path = Source/AST/Styling/Stylers/DownStyler.swift; sourceTree = "<group>"; };
 		D31606EA9B6F472B81F34078D7AC51CB /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
@@ -1482,25 +1495,19 @@
 		D37748E4D88C06FD855A363D9E50128C /* Pods-AuthExampleUITests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-AuthExampleUITests-frameworks.sh"; sourceTree = "<group>"; };
 		D4582032A25ED6D21D0244FEBAC77E47 /* Pods-NativePMExampleApp-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NativePMExampleApp-Info.plist"; sourceTree = "<group>"; };
 		D463E95BBD33777E282E9ACA1764722C /* Pods-NativePMExampleAppUITests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-NativePMExampleAppUITests-umbrella.h"; sourceTree = "<group>"; };
-		D4B803807F52ECA8CB5C7409EB5668EC /* SPMessageLanguage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPMessageLanguage.swift; path = ConsentViewController/Classes/SPMessageLanguage.swift; sourceTree = "<group>"; };
-		D5995A7529476DDF73A9A8296514C860 /* SPPrivacyPolicyViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPPrivacyPolicyViewController.swift; sourceTree = "<group>"; };
-		D60693B6637959F079E0D340EFE645C2 /* SPGDPRNativePrivacyManagerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRNativePrivacyManagerViewController.swift; sourceTree = "<group>"; };
 		D6E2DA62A305B313F740939D3F6A71F8 /* Down.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Down.modulemap; sourceTree = "<group>"; };
-		D6E8B5EB05FE7DEA4D9BDE8E6D3ED8E1 /* ResourceBundle-ConsentViewController-ConsentViewController-iOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-ConsentViewController-ConsentViewController-iOS-Info.plist"; sourceTree = "<group>"; };
-		D74D183755488CDCC8BCFA54A1B7EB2B /* SPCCPACategoryDetailsViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPACategoryDetailsViewController.xib; sourceTree = "<group>"; };
 		D789344B063B6B4798D349FDDA21D27C /* NSAttributedString+HTML.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSAttributedString+HTML.swift"; path = "Source/Extensions/NSAttributedString+HTML.swift"; sourceTree = "<group>"; };
 		D796E9E3C0C9CD2EEB46A54519800192 /* node.c */ = {isa = PBXFileReference; includeInIndex = 1; name = node.c; path = Source/cmark/node.c; sourceTree = "<group>"; };
 		D92F71F24E4CDF4CAD3BA73B49528433 /* Pods-ConsentViewController_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-ConsentViewController_Example.modulemap"; sourceTree = "<group>"; };
 		D9840C2E2FAEF98DDD565CE6D3440E98 /* WHBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WHBundle.swift; path = Sources/Subclasses/WHBundle.swift; sourceTree = "<group>"; };
 		DA8CF835B395E0A0C4CD245C5DC019AD /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
+		DB08B381B740C27856D4153B7167A89F /* ConsentViewController-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ConsentViewController-iOS-dummy.m"; sourceTree = "<group>"; };
 		DB8595FA58C64090133B1404C303988C /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
 		DBFB437DC66245AD0C2BDC0A5C302AB1 /* Strong.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strong.swift; path = Source/AST/Nodes/Strong.swift; sourceTree = "<group>"; };
-		DD09A632C263F627D162E805440F5648 /* ConsentViewController-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ConsentViewController-iOS-prefix.pch"; sourceTree = "<group>"; };
+		DD0C0D6E820FBB1090FFA6175AC9BDFD /* ConsentStatusMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentStatusMetadata.swift; sourceTree = "<group>"; };
 		DD36E655D8EE068EFF50A0757E1F193D /* Down.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Down.swift; path = Source/Down.swift; sourceTree = "<group>"; };
 		DD783487C1DFFC517AF0E6DD261A5A09 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
-		DEC21ED487A14977C49B886AC04D349A /* SPIDFAStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPIDFAStatus.swift; path = ConsentViewController/Classes/SPIDFAStatus.swift; sourceTree = "<group>"; };
 		DED0566FE4F1AAD73E29261F2647D4CF /* WHCollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WHCollectionView.swift; path = Sources/Subclasses/WHCollectionView.swift; sourceTree = "<group>"; };
-		DF42833ED704F1D08E1588247A04BD1A /* SPDate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPDate.swift; path = ConsentViewController/Classes/SPDate.swift; sourceTree = "<group>"; };
 		DFB18C136DCE99B90FF7D411931EB2F4 /* cmark_ctype.c */ = {isa = PBXFileReference; includeInIndex = 1; name = cmark_ctype.c; path = Source/cmark/cmark_ctype.c; sourceTree = "<group>"; };
 		E105D4CE3E1294C57780FD40F1B18C84 /* CustomInline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomInline.swift; path = Source/AST/Nodes/CustomInline.swift; sourceTree = "<group>"; };
 		E1A0AADCD274D67C7CA432AF116F108E /* Nimble-tvOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "Nimble-tvOS.modulemap"; path = "../Nimble-tvOS/Nimble-tvOS.modulemap"; sourceTree = "<group>"; };
@@ -1510,13 +1517,13 @@
 		E3A5BCA07FC62773D3782117F0871384 /* Styler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Styler.swift; path = Source/AST/Styling/Stylers/Styler.swift; sourceTree = "<group>"; };
 		E41025D27A8A28123FBC9E5303F176B5 /* Pods-SourcePointMetaApp-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SourcePointMetaApp-umbrella.h"; sourceTree = "<group>"; };
 		E4815C6903D5CE0C70AEE9AE28B6243D /* Pods-NativeMessageExampleUITests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NativeMessageExampleUITests-Info.plist"; sourceTree = "<group>"; };
-		E4B90D884A1E8F6702545EEA3217C6DB /* SPCustomViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCustomViewController.xib; sourceTree = "<group>"; };
 		E4BBB585B354A0FBE99C21B1C36D35A1 /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
-		E4C52023C0BE5895911B529281CFA8D3 /* Bundle+Framework.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bundle+Framework.swift"; path = "ConsentViewController/Classes/Bundle+Framework.swift"; sourceTree = "<group>"; };
+		E55659631F09CC0006809BF9DFAB5EEA /* SPString.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPString.swift; sourceTree = "<group>"; };
+		E58B299E95E357B2AFB44800057B0F15 /* SPGDPRPartnersViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRPartnersViewController.xib; sourceTree = "<group>"; };
 		E5CDEAF94251001BA1B79F2F99403933 /* IQKeyboardManager+Position.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQKeyboardManager+Position.swift"; path = "IQKeyboardManagerSwift/IQKeyboardManager+Position.swift"; sourceTree = "<group>"; };
 		E5E649623D9E40861B378DBDEF1928D7 /* UIFont+Traits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIFont+Traits.swift"; path = "Source/AST/Styling/Helpers/Extensions/UIFont+Traits.swift"; sourceTree = "<group>"; };
 		E6299AFFC345696A42141091DCDB1341 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
-		E669610B15E89D68A59B4ADA6046934C /* MessagesResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagesResponse.swift; sourceTree = "<group>"; };
+		E6DC7F0FB1838294BA74E9BFDB30157D /* ConsentStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentStatus.swift; sourceTree = "<group>"; };
 		E735ADF04B48BEEF187FCD9E0BEC9586 /* Pods-SPGDPRExampleAppUITests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SPGDPRExampleAppUITests-umbrella.h"; sourceTree = "<group>"; };
 		E797A7DB019FE3394A969E7B42A29D4B /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
 		E99011D6DC0752191B6C0D0AAE03B10F /* IQKeyboardManager+UITextFieldViewNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQKeyboardManager+UITextFieldViewNotification.swift"; path = "IQKeyboardManagerSwift/IQKeyboardManager+UITextFieldViewNotification.swift"; sourceTree = "<group>"; };
@@ -1525,9 +1532,7 @@
 		E9B9DE8BE49CD9DD2D6D3F6A9B633732 /* Pods-AuthExample-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-AuthExample-dummy.m"; sourceTree = "<group>"; };
 		E9D5368B55EA84908DB0B3619DA8A1F9 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
 		EA0192695DA1B280F4BAF140ACD24C02 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Sources/QuickObjectiveC/DSL/QCKDSL.m; sourceTree = "<group>"; };
-		EBD53F1406CCCEB589874F2718A8E25A /* LongButtonViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LongButtonViewCell.swift; sourceTree = "<group>"; };
 		EC77CD266D1284DD54A1446419D5C03E /* Pods-ObjC-ExampleApp-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ObjC-ExampleApp-Info.plist"; sourceTree = "<group>"; };
-		ECC74D56FDDCCD5DBDF2F603F5BEB55C /* ConsentStatusResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsentStatusResponse.swift; sourceTree = "<group>"; };
 		ED145CB8610837DAAB01AA6075562DD1 /* IQInvocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQInvocation.swift; path = IQKeyboardManagerSwift/IQToolbar/IQInvocation.swift; sourceTree = "<group>"; };
 		ED4AA5CC1F2A2D60B5832E735EC0B968 /* RequestResponseExportOption.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RequestResponseExportOption.swift; path = Sources/Utils/RequestResponseExportOption.swift; sourceTree = "<group>"; };
 		ED53C7A7A4F09274BBF9FF96AB04E6B5 /* BodyDetailViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BodyDetailViewController.swift; path = Sources/UI/BodyDetailViewController.swift; sourceTree = "<group>"; };
@@ -1536,49 +1541,47 @@
 		EDC964878FBCD5EA6DDDB4F674BBCC57 /* IQKeyboardManagerSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IQKeyboardManagerSwift-prefix.pch"; sourceTree = "<group>"; };
 		EE3F15539BB1143B4EBBDC81499A6939 /* Pods-ObjC-ExampleAppUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ObjC-ExampleAppUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		EE815C02DE4CDD9B27CE39AB6863DE08 /* Quick-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Quick-iOS.modulemap"; sourceTree = "<group>"; };
+		EED581AAA5B3AA02FA8C571320995C16 /* SPPrivacyPolicyViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPPrivacyPolicyViewController.xib; sourceTree = "<group>"; };
 		EF200C29F5757D84AB72546365956279 /* DownStylerConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownStylerConfiguration.swift; path = Source/AST/Styling/Stylers/DownStylerConfiguration.swift; sourceTree = "<group>"; };
-		F0315852DCBAEF8931C5E1F069E419DF /* SPCustomViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCustomViewController.swift; sourceTree = "<group>"; };
-		F0594D4B29BF1FFCBEBE609EBC5B50EB /* ConsentViewController-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ConsentViewController-tvOS.release.xcconfig"; path = "../ConsentViewController-tvOS/ConsentViewController-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		F105951FFBC9DB3F80D0818CDC74E2CA /* SPDeviceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPDeviceManager.swift; path = ConsentViewController/Classes/SPDeviceManager.swift; sourceTree = "<group>"; };
 		F11A37CBB808CEE0FF299BADBF67DE39 /* cmark_version.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = cmark_version.h; path = Source/cmark/cmark_version.h; sourceTree = "<group>"; };
 		F122B45B33E4C2924F2A6034B7D35605 /* QuoteStripeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuoteStripeOptions.swift; path = Source/AST/Styling/Options/QuoteStripeOptions.swift; sourceTree = "<group>"; };
 		F17A64B69F9CAA574619498002BA3ACC /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
 		F17AD4E54096E2D9DB39C7DB4E565F8A /* commonmark.c */ = {isa = PBXFileReference; includeInIndex = 1; name = commonmark.c; path = Source/cmark/commonmark.c; sourceTree = "<group>"; };
-		F230947DA34DF18BEB412F130148E3BB /* ErrorMetricsRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorMetricsRequest.swift; sourceTree = "<group>"; };
+		F17FBA5182E772BCA2F3B3F55002CD78 /* SPCCPAVendorDetailsViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPCCPAVendorDetailsViewController.xib; sourceTree = "<group>"; };
+		F197E4956D85BA7097F61D3662960B7F /* LongButtonViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LongButtonViewCell.swift; sourceTree = "<group>"; };
 		F27E7590E21F4CF0EF3F520B93B1FA63 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
 		F28AC251F58EA3598F307B0408E60056 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
 		F2ADB47439104387B051C0F4F093FEE8 /* Pods-ConsentViewController_ExampleTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-ConsentViewController_ExampleTests.modulemap"; sourceTree = "<group>"; };
 		F2C168F3A1444427CBC39692E3CEEB60 /* Pods-NativeMessageExampleUITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-NativeMessageExampleUITests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		F309820BB3F1570708091996EE72057D /* ThematicBreakAttribute.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThematicBreakAttribute.swift; path = "Source/AST/Styling/Custom Attributes/ThematicBreakAttribute.swift"; sourceTree = "<group>"; };
-		F33D1CA7157620140646E3E0564ED248 /* MessagesRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessagesRequest.swift; sourceTree = "<group>"; };
 		F3851B0BF7B7EAFB0D692EAFFB61D7FA /* Pods-ConsentViewController_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ConsentViewController_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		F4C1045E7B11276558ACCB7A723DF82B /* SPJSReceiver.js */ = {isa = PBXFileReference; includeInIndex = 1; path = SPJSReceiver.js; sourceTree = "<group>"; };
 		F548BFEA0ABCD63735858C1C7E3660AD /* IQKeyboardManagerSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IQKeyboardManagerSwift.release.xcconfig; sourceTree = "<group>"; };
 		F560308EBBF1319B95EE523C06689586 /* JSONView.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = JSONView.modulemap; sourceTree = "<group>"; };
 		F57CF95A5BD30FB7562C976EA29963FC /* Quick-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-iOS-umbrella.h"; sourceTree = "<group>"; };
 		F5CEFC6A0CC6A008931AFEBBB9BB993F /* DownLaTeXRenderable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownLaTeXRenderable.swift; path = Source/Renderers/DownLaTeXRenderable.swift; sourceTree = "<group>"; };
 		F65671B772731C7D68ADCBDE962B9D0E /* InputStream+Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "InputStream+Utils.swift"; path = "Sources/Utils/InputStream+Utils.swift"; sourceTree = "<group>"; };
-		F69175CFEF4241C2C231F6D7D430FAD6 /* SPGDPRManagePreferenceViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPGDPRManagePreferenceViewController.swift; sourceTree = "<group>"; };
+		F685AD4AB412458C5FB0A7E92CFEBD48 /* SPCCPAManagePreferenceViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPAManagePreferenceViewController.swift; sourceTree = "<group>"; };
 		F6B391138C925C36A372D168BE645C69 /* Pods-NativePMExampleApp-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NativePMExampleApp-acknowledgements.plist"; sourceTree = "<group>"; };
-		F71FA3D73199D169754EE5F6261861AA /* SPPMHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPPMHeader.swift; sourceTree = "<group>"; };
+		F74C9B99E79D5B4E81470F0EE516B998 /* IncludeData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IncludeData.swift; sourceTree = "<group>"; };
 		F798E3221E5B46D8B6769D98F40D2F74 /* Pods-SourcePointMetaApp-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SourcePointMetaApp-acknowledgements.plist"; sourceTree = "<group>"; };
 		F7AEE99DB02A4428037B0864E9F8D711 /* CodeBlock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CodeBlock.swift; path = Source/AST/Nodes/CodeBlock.swift; sourceTree = "<group>"; };
-		F7D014C17997C779CCF417FC64A00A45 /* SPGDPRVendorDetailsViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SPGDPRVendorDetailsViewController.xib; sourceTree = "<group>"; };
 		F7F82DA3FBFF7199F4A6DB4CA204B187 /* Pods-NativeMessageExampleUITests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-NativeMessageExampleUITests-frameworks.sh"; sourceTree = "<group>"; };
 		F7FA610780C15C414C40385861A21ED4 /* ChildSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChildSequence.swift; path = Source/AST/Nodes/ChildSequence.swift; sourceTree = "<group>"; };
 		F8CA88978345560FFB4A39F2E5A86334 /* IQKeyboardManagerSwift-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "IQKeyboardManagerSwift-Info.plist"; sourceTree = "<group>"; };
 		F8E0156BBDCAA49BAAE07A1878819159 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
 		F9AB079CF093527A4CFFAB09421335E5 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
 		FA53C49EE9E47CCD7458E36103D8D8B4 /* iterator.c */ = {isa = PBXFileReference; includeInIndex = 1; name = iterator.c; path = Source/cmark/iterator.c; sourceTree = "<group>"; };
+		FA768698B1E6F086512B8C99BF5A2F1B /* SPPublisherData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPPublisherData.swift; sourceTree = "<group>"; };
+		FB50DECADBBA55B54D01AD8F6EBA0106 /* PMCategoryManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PMCategoryManager.swift; sourceTree = "<group>"; };
+		FB8C0E307B1A76FB7D46C8227CA208CB /* ChoiceResponses.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChoiceResponses.swift; sourceTree = "<group>"; };
 		FB9663275D36F2DF8F24EE7DBC70A4F7 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
-		FC28310BA7EB1F7DA1CFFCEC65E22D7F /* SPDeviceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPDeviceManager.swift; path = ConsentViewController/Classes/SPDeviceManager.swift; sourceTree = "<group>"; };
 		FD2D21D6421A7ED9A1EABC6BC6965D44 /* IQBarButtonItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQBarButtonItem.swift; path = IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift; sourceTree = "<group>"; };
-		FD2F6FF780EF05D13850B9B75F93F9BB /* NSObjectExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NSObjectExtensions.swift; sourceTree = "<group>"; };
 		FE05B6F5D5849C89D668385AE14DCBB5 /* RequestModelBeautifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RequestModelBeautifier.swift; path = Sources/Utils/RequestModelBeautifier.swift; sourceTree = "<group>"; };
 		FE3E5ADA5583AAAD42F4FE34CFB5CC81 /* JSONView.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = JSONView.release.xcconfig; sourceTree = "<group>"; };
 		FE5623B2F4D94F11763708052AA66052 /* Pods-NativePMExampleAppUITests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-NativePMExampleAppUITests-Info.plist"; sourceTree = "<group>"; };
 		FE8B12B56BE2A03693BE1AC03EC2C77E /* WHBaseViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WHBaseViewController.swift; path = Sources/Subclasses/WHBaseViewController.swift; sourceTree = "<group>"; };
-		FEA01C3D38F1284A8C46DC024B42B4A6 /* SPCCPAConsent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPCCPAConsent.swift; sourceTree = "<group>"; };
-		FF7FCD5D97E9C44DD791C95F75D527DF /* IncludeData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IncludeData.swift; sourceTree = "<group>"; };
+		FEB4FA61B354A7E3F028418E57FDCE43 /* SPWebMessageViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SPWebMessageViewController.swift; sourceTree = "<group>"; };
 		FF9B524B32EBD31EBE91A65B1AEAE2B4 /* SatisfyAllOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAllOf.swift; path = Sources/Nimble/Matchers/SatisfyAllOf.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1588,13 +1591,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9FB5B8C302F44E02838C5F51A98F0DB2 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		05EABBF3078CE79A2BC96A11C16324C4 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1611,14 +1607,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				038B9A29198D9ECD65A926483B0BC6B4 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		17A1D959F2695A0EDBAD74D620BA1AA3 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E0319CB65CD76E214AD48EEFFCC03AD0 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1662,18 +1650,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3FF58C69D250D2CBFE450460E0184122 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4DD6CAAB4CC32C9CCE21071CCCC4BE94 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				E03C605C2CBB4A45A75BF4D025CA737A /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5E13AFEDBD3A5A8E692C1DB31B870D57 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1685,11 +1673,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6A84D88D40E96AB1D42D5AAFEC683C3F /* Frameworks */ = {
+		6A44DF6BE20E17215E8BEA799C0C8C5E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0AE135A7215AE85F9D752120828C1CF9 /* Foundation.framework in Frameworks */,
+				9F2D48F1E9FDDEB061A3062D2F6A499B /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1698,6 +1686,28 @@
 			buildActionMask = 2147483647;
 			files = (
 				237915FFFDA90EF0F995E5366C0390CD /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		929D3062B128F11AA801D9164533A88E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		95E4133248B84AFE374F1DB8E0140F2B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5DB676033E48338FA32945F7141C111D /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		968D60FD7EB1AE4708A1FB11FA432230 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1729,26 +1739,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ACBC435C988748E6BABF42CFD93DE2E1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		B4480343BF361361BFDDFC5DEDD8ECD8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				C15B7C50B3A6B4E0906117E2B81A331F /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B5861FD579DDAC522C0BBA707FC4F47A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7A67AB44F013A515B5AA5804FEE2BA53 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1765,6 +1760,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				9E36D6BC753F4D70CAF6053C9A0A4D6D /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CF0AD51D98D0B53F12F3BA3B570038F0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				21A1CDA50E0EECA49422A00FA421546D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1796,37 +1799,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		002E8F4D74E7CA04D49879A691D64347 /* NativePrivacyManager */ = {
-			isa = PBXGroup;
-			children = (
-				02E3AEC2886DDA36954F2E1FA9F42CBC /* CCPA */,
-				26284BDFC50493E3155FD05119859111 /* Common */,
-				2303D180E6C55A8A06E981B19403AFDF /* Data */,
-				A745757CAB6E91B9371BF790A414EFE6 /* GDPR */,
-			);
-			name = NativePrivacyManager;
-			path = NativePrivacyManager;
-			sourceTree = "<group>";
-		};
-		02E3AEC2886DDA36954F2E1FA9F42CBC /* CCPA */ = {
-			isa = PBXGroup;
-			children = (
-				6FDF85FFB061EC5C8D497766DF9D44A5 /* CCPAPMConsentSnapshot.swift */,
-				1471C6980E34597F9E9F0C7914CDE4F5 /* SPCCPACategoryDetailsViewController.swift */,
-				D74D183755488CDCC8BCFA54A1B7EB2B /* SPCCPACategoryDetailsViewController.xib */,
-				276C04F2B5F9EFF3F61284610B09A1B1 /* SPCCPAManagePreferenceViewController.swift */,
-				3C2239F7E2BEC75150EB0EDE80F422F1 /* SPCCPAManagePreferenceViewController.xib */,
-				C00F8E0AE9705B47C4A9A184BE46431A /* SPCCPANativePrivacyManagerViewController.swift */,
-				B3ED46B71DB1362B2152B842E734FC2D /* SPCCPANativePrivacyManagerViewController.xib */,
-				828C8315C59EC0C8EFF52E652E944AB8 /* SPCCPAPartnersViewController.swift */,
-				BEB4710F72E37782F211DAD8B4C712FC /* SPCCPAPartnersViewController.xib */,
-				67D94A8C188A429D5BD2D620A801F5A5 /* SPCCPAVendorDetailsViewController.swift */,
-				127EE88A356B276B186DC57DB052B67D /* SPCCPAVendorDetailsViewController.xib */,
-			);
-			name = CCPA;
-			path = CCPA;
-			sourceTree = "<group>";
-		};
 		143812CFE568DA2DCAB74F4013A3EC0D /* Pods-ObjC-ExampleAppUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1887,43 +1859,12 @@
 			name = tvOS;
 			sourceTree = "<group>";
 		};
-		2303D180E6C55A8A06E981B19403AFDF /* Data */ = {
-			isa = PBXGroup;
-			children = (
-				7D65378A1B8E46EE5F67210393414B57 /* GDPRPMPayload.swift */,
-				AA9B15B0D15EF898E424E727B2E9A01C /* PMCategoryManager.swift */,
-				3A26AC79EFF2DDBD6DBD8F7972F2293A /* PMVendorManager.swift */,
-			);
-			name = Data;
-			path = Data;
-			sourceTree = "<group>";
-		};
 		2440D6E45C5F424A06DAC0009FC9E4C9 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				D26DAB6AB18B49229734EC1626A21116 /* ConsentViewController */,
+				7E3F9A76519C9BA46B7E49EA8CF81BAD /* ConsentViewController */,
 			);
 			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		26284BDFC50493E3155FD05119859111 /* Common */ = {
-			isa = PBXGroup;
-			children = (
-				EBD53F1406CCCEB589874F2718A8E25A /* LongButtonViewCell.swift */,
-				BA78A05C69F29E2CA0169D67110BCBE7 /* LongButtonViewCell.xib */,
-				777FC6E3031FD3F408A7F684CAA9CA27 /* SPAppleTVButton.swift */,
-				F0315852DCBAEF8931C5E1F069E419DF /* SPCustomViewController.swift */,
-				E4B90D884A1E8F6702545EEA3217C6DB /* SPCustomViewController.xib */,
-				A809A545BBF7F5ACCE142F3DEFC24B82 /* SPFocusableTextView.swift */,
-				D2BF89AC326EB7E5B953753088D331E4 /* SPNativeScreenViewController.swift */,
-				F71FA3D73199D169754EE5F6261861AA /* SPPMHeader.swift */,
-				2EDF6F527EBDA7A82AF59E4AB6C0E8A3 /* SPPMHeader.xib */,
-				D5995A7529476DDF73A9A8296514C860 /* SPPrivacyPolicyViewController.swift */,
-				7ABC8ABDA6DCCEDAB9FC6D033BF89939 /* SPPrivacyPolicyViewController.xib */,
-				30193087B41266CA96A7E86E3AC6EFDB /* SPQRCode.swift */,
-			);
-			name = Common;
-			path = Common;
 			sourceTree = "<group>";
 		};
 		285F8EF3008EED7E49D497A676875543 /* Products */ = {
@@ -1991,6 +1932,30 @@
 			path = "../Target Support Files/IQKeyboardManagerSwift";
 			sourceTree = "<group>";
 		};
+		2CD211806AF1B90A43878051E3AAD7E4 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				547C53B56CF46EDF6FA808C3EDE70260 /* ConsentViewController-iOS.modulemap */,
+				DB08B381B740C27856D4153B7167A89F /* ConsentViewController-iOS-dummy.m */,
+				02BD6CE30EDAF3FEB1C5954BA4614E2E /* ConsentViewController-iOS-Info.plist */,
+				96974D8BCDCA8DBCE2ECBEA25147B75F /* ConsentViewController-iOS-prefix.pch */,
+				82778513C28C2866957936898CDA602D /* ConsentViewController-iOS-umbrella.h */,
+				64112AD2026682A3DE57EEDB1D2865BA /* ConsentViewController-iOS.debug.xcconfig */,
+				8E2C263BAF9DFE562CB999D63FBED33A /* ConsentViewController-iOS.release.xcconfig */,
+				09339EFDCB488877772DA5F965A30C89 /* ConsentViewController-tvOS.modulemap */,
+				7518233A0C485853B9D0C17CD235064B /* ConsentViewController-tvOS-dummy.m */,
+				B18F4FD8E657BC422B2BE3723477129D /* ConsentViewController-tvOS-Info.plist */,
+				259D9EBA80B18B2AD9E1F90FA7404C75 /* ConsentViewController-tvOS-prefix.pch */,
+				76BCC1DD257B4A37FA77F484801024DF /* ConsentViewController-tvOS-umbrella.h */,
+				6A67307522A739D21C03BC55C7799A3F /* ConsentViewController-tvOS.debug.xcconfig */,
+				86BA2F35C05C02BCABF8F3D30603A915 /* ConsentViewController-tvOS.release.xcconfig */,
+				9356730B123DC0D418A56CE82E9623E5 /* ResourceBundle-ConsentViewController-ConsentViewController-iOS-Info.plist */,
+				95ABCCDF1B9D0C62FB0902117B9DD4CB /* ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/ConsentViewController-iOS";
+			sourceTree = "<group>";
+		};
 		2D4E5CF3B4F4AFDE0CADC26925BBF795 /* Pods-NativePMExampleAppUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2006,6 +1971,17 @@
 			);
 			name = "Pods-NativePMExampleAppUITests";
 			path = "Target Support Files/Pods-NativePMExampleAppUITests";
+			sourceTree = "<group>";
+		};
+		37B76BED6A0CC9432B3BE61B6D6E17A2 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				B889D5BC3C973D012577EFE632A14F18 /* GDPRPMPayload.swift */,
+				FB50DECADBBA55B54D01AD8F6EBA0106 /* PMCategoryManager.swift */,
+				3020AB2EC042108B6C1E9EF8E7259B08 /* PMVendorManager.swift */,
+			);
+			name = Data;
+			path = Data;
 			sourceTree = "<group>";
 		};
 		3C1A72554DD08CA0E8561E82BB97F374 /* Wormholy */ = {
@@ -2055,6 +2031,39 @@
 			path = Wormholy;
 			sourceTree = "<group>";
 		};
+		41E51348E0FCA55E6B78AD962C7BC7C8 /* SourcePointClient */ = {
+			isa = PBXGroup;
+			children = (
+				BBA59492BB5FDCC898516A27C6F6D2AD /* AddOrDeleteCustomConsentResponse.swift */,
+				B0F238701ED3EDA2C5FEF40EBD01B0FC /* ChoiceAllResponse.swift */,
+				4AE5CB34B4AB1F63B2555EF3D87038CC /* ChoiceRequests.swift */,
+				FB8C0E307B1A76FB7D46C8227CA208CB /* ChoiceResponses.swift */,
+				DD0C0D6E820FBB1090FFA6175AC9BDFD /* ConsentStatusMetadata.swift */,
+				2210A1777A462D1AE0916CFFD28EC9E5 /* ConsentStatusResponse.swift */,
+				312B839222265C5ABB21AEF7BDE52787 /* CustomConsentRequest.swift */,
+				43BBBBE57C72E2AC7FBD58BF6D0D9246 /* DeleteCustomConsentRequest.swift */,
+				CA4F80DF4A9707BD0EE7C79298BE4E51 /* ErrorMetricsRequest.swift */,
+				6B1EABC4D216660430106609E2635E94 /* GDPRPrivacyManagerViewResponse.swift */,
+				3D6F7D1208E608AAE2535D9ECDFE3259 /* IDFAStatusReportRequest.swift */,
+				F74C9B99E79D5B4E81470F0EE516B998 /* IncludeData.swift */,
+				CBAD3F2BD4D00E9574790ACC3405E443 /* MessageRequest.swift */,
+				38B12C4D3E7CECEC700CF63C90E14D9A /* MessagesRequest.swift */,
+				67A4828FB21F6D40312306A0E841E96D /* MessagesResponse.swift */,
+				0BD271375B4B91D1F7C3304B8FEEA781 /* MetaDataRequestResponse.swift */,
+				1B1E7CBB8B76FFA6C6435F1483999E54 /* PrivacyManagerViewData.swift */,
+				3C09866DE5BD008CCCB89F1F635DA621 /* PvDataRequestResponse.swift */,
+				6FD8BE80A9F24548A9A2102421EADEB0 /* QueryParamEncodableProtocol.swift */,
+				A91027530C899F224F03C827FEBFC0B2 /* SimpleClient.swift */,
+				436C422929BBF411EE802DB972F2A7B4 /* SourcePointClient.swift */,
+				2DB34657D9ED942AFDD2DA7839D04063 /* SourcepointClientCoordinator.swift */,
+				3C1EE4614D5D401C3ACDAE634299A561 /* SPNativeUI.swift */,
+				76662C1EFF87E0368232723B3733766F /* SPPrivacyManagerRequestResponse.swift */,
+				FA768698B1E6F086512B8C99BF5A2F1B /* SPPublisherData.swift */,
+			);
+			name = SourcePointClient;
+			path = ConsentViewController/Classes/SourcePointClient;
+			sourceTree = "<group>";
+		};
 		430FFAD590D757BF4128EF9184649384 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -2084,6 +2093,17 @@
 			path = "Target Support Files/Pods-SourcePointMetaApp";
 			sourceTree = "<group>";
 		};
+		4617406CF8AA28AF12FAD61329488F66 /* javascript */ = {
+			isa = PBXGroup;
+			children = (
+				0DB88029D7BE239F468C617AC20AB271 /* jest.config.json */,
+				BFECB5A821926764458845FF526DDA6B /* SPJSReceiver.js */,
+				25C3EBF0B637984D46D2172610B3F786 /* SPJSReceiver.spec.js */,
+			);
+			name = javascript;
+			path = ConsentViewController/Assets/javascript;
+			sourceTree = "<group>";
+		};
 		464CCD5360C1C1A8131B4F4379048325 /* Pods-AuthExampleUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2101,61 +2121,25 @@
 			path = "Target Support Files/Pods-AuthExampleUITests";
 			sourceTree = "<group>";
 		};
-		4986AE6DAE62391338EC1DE36D25B405 /* Support Files */ = {
+		53E84BD41A3BF07D56F8A80D1DB0CBFC /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				C4462582FCCE51251BEBB673193362F4 /* ConsentViewController-iOS.modulemap */,
-				A1A05DB1E1978F1BA2CA1919E3C47AE9 /* ConsentViewController-iOS-dummy.m */,
-				0155E52FC425A331422920A5DA08BA3C /* ConsentViewController-iOS-Info.plist */,
-				DD09A632C263F627D162E805440F5648 /* ConsentViewController-iOS-prefix.pch */,
-				1DA590E70E93C5C8B5D4DEEB30EEF269 /* ConsentViewController-iOS-umbrella.h */,
-				AB6F0B2251A6458ABB109B0A14981E5F /* ConsentViewController-iOS.debug.xcconfig */,
-				ABC0C636E983A146EF76F6E672AA40B3 /* ConsentViewController-iOS.release.xcconfig */,
-				41EAEB1DF5B5B3F3E2D3E75D0CCCA702 /* ConsentViewController-tvOS.modulemap */,
-				701342168D9B0F621F560A7CFC81E140 /* ConsentViewController-tvOS-dummy.m */,
-				6F4957050C687F320ABCDB96B7AA1C54 /* ConsentViewController-tvOS-Info.plist */,
-				8C8E7531FEDF9A2B0EF955189B3AE6A9 /* ConsentViewController-tvOS-prefix.pch */,
-				584FD3F4B671BF7B2DD12426DEE51951 /* ConsentViewController-tvOS-umbrella.h */,
-				7F964AB7CFB89116902A252500ADD788 /* ConsentViewController-tvOS.debug.xcconfig */,
-				F0594D4B29BF1FFCBEBE609EBC5B50EB /* ConsentViewController-tvOS.release.xcconfig */,
-				D6E8B5EB05FE7DEA4D9BDE8E6D3ED8E1 /* ResourceBundle-ConsentViewController-ConsentViewController-iOS-Info.plist */,
-				D29BC86232D98099004CB552B613C066 /* ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist */,
+				3E6A455FB1B245997F231B89D2C082A6 /* SPUIColor.swift */,
+				B5820C96BD8B7F308128CA918510A5EB /* iOS */,
+				C69CF9F41A15E181934F1936BC981F15 /* tvOS */,
 			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/ConsentViewController-iOS";
+			name = Views;
+			path = ConsentViewController/Classes/Views;
 			sourceTree = "<group>";
 		};
-		4B24099895B8068D522FA7098BA60E01 /* Pod */ = {
+		5489E5AEEC4590BFCB0DD68F7F91074A /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				B75CE812789369B344F36EE008ED79B6 /* ConsentViewController.podspec */,
-				042F1D1EFBC0EBC3551A937778F1BBE0 /* LICENSE */,
-				8456974C643D13D0CEE0DEDDB3BA1F5F /* README.md */,
+				19263897F1B9153AED31149D986C8CEC /* ConsentViewController.podspec */,
+				82D70D15582AFD0AC6A0E69024D314DA /* LICENSE */,
+				67FCA61B714EC75C9C041DEAC9653729 /* README.md */,
 			);
 			name = Pod;
-			sourceTree = "<group>";
-		};
-		4FA40F0D8178DDA9FF45F260A1C92DA0 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				A492BCA73059A5069E9F8278726E515F /* SPWebMessageViewController.swift */,
-				8FA771D5B9941FAE0033994DCAA0DFD0 /* SPWebViewExtensions.swift */,
-			);
-			name = iOS;
-			path = iOS;
-			sourceTree = "<group>";
-		};
-		536300C9DBD1C4D585E0AB39304781B7 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				460C615AE163149149EF5A26844398ED /* Collection.swift */,
-				9CBF2460FDA962B0B444FA81DEE9E5F2 /* Date.swift */,
-				FD2F6FF780EF05D13850B9B75F93F9BB /* NSObjectExtensions.swift */,
-				C9F5A4C0E23281A4DE22DF8D3A07CF2F /* SPString.swift */,
-				820FF5AFD0E80C8C6941CC7EF4CAAF40 /* SPURLExtensions.swift */,
-			);
-			name = Extensions;
-			path = ConsentViewController/Classes/Extensions;
 			sourceTree = "<group>";
 		};
 		562951052C47612455B2438329A54C81 /* Pods-ConsentViewController_ExampleTests */ = {
@@ -2190,6 +2174,16 @@
 			);
 			name = "Pods-NativePMExampleApp";
 			path = "Target Support Files/Pods-NativePMExampleApp";
+			sourceTree = "<group>";
+		};
+		5FF5B50F21FA82C35972150594583FE2 /* LocalStorage */ = {
+			isa = PBXGroup;
+			children = (
+				71857B94D3E4661FABC88C0FAF764D2C /* SPLocalStorage.swift */,
+				5A8D3AB99F3203C5A3038F0B05514618 /* SPUserDefaults.swift */,
+			);
+			name = LocalStorage;
+			path = ConsentViewController/Classes/LocalStorage;
 			sourceTree = "<group>";
 		};
 		601804A74933CFDD1BA521AAF123072C /* Down */ = {
@@ -2300,17 +2294,6 @@
 			path = Down;
 			sourceTree = "<group>";
 		};
-		63C7FC91796FF66256AC80B4CE991BA0 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				93B85178157AB7E9CEB0F8DFD7359AE5 /* SPUIColor.swift */,
-				4FA40F0D8178DDA9FF45F260A1C92DA0 /* iOS */,
-				8691104DFF65E136FD5DDB3A4E717977 /* tvOS */,
-			);
-			name = Views;
-			path = ConsentViewController/Classes/Views;
-			sourceTree = "<group>";
-		};
 		6530E7C8B91D6E499171BA79322E45FF /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -2359,6 +2342,80 @@
 			path = JSONView;
 			sourceTree = "<group>";
 		};
+		7E3F9A76519C9BA46B7E49EA8CF81BAD /* ConsentViewController */ = {
+			isa = PBXGroup;
+			children = (
+				0BBD33A69B5A2C3CAC2538722F871505 /* Bundle+Framework.swift */,
+				2D1F1E83882B9DE7318ECFE065AAC229 /* ConnectivityManager.swift */,
+				0C7B86DCBBC1489611E4530C9CDEB342 /* Constants.swift */,
+				581B8A297C5BCB99513CA8A43ABE49C6 /* images */,
+				3DF8F244296F4E68BEBAFF70FBE0C89C /* javascript */,
+				6381389B408CDFAAA455A7A3F74F3B13 /* OSLogger.swift */,
+				C4BFF4525B8E99AC8AA9682A0AD5096C /* SPAction.swift */,
+				C6F151B5C0933D8A655A7DF020970178 /* SPCampaignEnv.swift */,
+				C64B56D57B02D8D11C91C959BA4069BC /* SPCampaigns.swift */,
+				B34866691E75484824EC739581DCD053 /* SPCampaignType.swift */,
+				6874BBA7D9E7AE21FD890E2B7584FEF0 /* SPConsentManager.swift */,
+				9E351CB99D1D27B7B5A640849BD98C91 /* SPDate.swift */,
+				6EB015AFF56EBB905B160D80CADCE889 /* SPDelegate.swift */,
+				F105951FFBC9DB3F80D0818CDC74E2CA /* SPDeviceManager.swift */,
+				5F643506E178F3E11AFFEBC84FF28857 /* SPError.swift */,
+				3D4B07460B142B84CA2496287FE5E036 /* SPIDFAStatus.swift */,
+				099AE19CF3B7A3159AED28EE53DE3229 /* SPJson.swift */,
+				19400978A8768F2D99CDF5E905392611 /* SPMessageLanguage.swift */,
+				47EDE3AA6C6E1DE2C97AC3AA44619B43 /* SPMessageUIDelegate.swift */,
+				06F803628BFA08F2F555342D92731F3B /* SPMessageViewController.swift */,
+				5104F5ECF953CA5841925A2E54FCD1BB /* SPNativeMessage.swift */,
+				94CB7EF4A828D46D4F0255622811021B /* SPPrivacyManagerTab.swift */,
+				966B2E914EEE28ECF349826319E685A0 /* SPPropertyName.swift */,
+				42B69A493B5BB16AFB91A94CCF3EC370 /* SPSDK.swift */,
+				B9375B3FF39FE8E647DEF816E4A4BA4B /* SPStringifiedJSON.swift */,
+				9F18A23C171E2E516146BD7D3BB2F30D /* Consents */,
+				7F92978A0A4EA133DD69A83C71ED2F76 /* Extensions */,
+				E33EBBD5EB1AB83FE249DDB91293E143 /* images */,
+				4617406CF8AA28AF12FAD61329488F66 /* javascript */,
+				5FF5B50F21FA82C35972150594583FE2 /* LocalStorage */,
+				5489E5AEEC4590BFCB0DD68F7F91074A /* Pod */,
+				41E51348E0FCA55E6B78AD962C7BC7C8 /* SourcePointClient */,
+				2CD211806AF1B90A43878051E3AAD7E4 /* Support Files */,
+				53E84BD41A3BF07D56F8A80D1DB0CBFC /* Views */,
+			);
+			name = ConsentViewController;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		7E83E9EE4757A0114FA904AF5E45462E /* CCPA */ = {
+			isa = PBXGroup;
+			children = (
+				13C76D8D0D249A6C90C926901BC2B964 /* CCPAPMConsentSnapshot.swift */,
+				48059975E6928B40F98CE48EC7CE2DFB /* SPCCPACategoryDetailsViewController.swift */,
+				439412BBD46371B4CF713AE48CEF7520 /* SPCCPACategoryDetailsViewController.xib */,
+				F685AD4AB412458C5FB0A7E92CFEBD48 /* SPCCPAManagePreferenceViewController.swift */,
+				71899FA654FC2A36F8FC057719CE8B3A /* SPCCPAManagePreferenceViewController.xib */,
+				6CA419A4B9A95901AE93A15465F93F46 /* SPCCPANativePrivacyManagerViewController.swift */,
+				62ABE444F807061001F52E578A329E7E /* SPCCPANativePrivacyManagerViewController.xib */,
+				5D01FB303A63A86DA0C36B82086B1F40 /* SPCCPAPartnersViewController.swift */,
+				88D763EF8AB338EB770555D5677D48C0 /* SPCCPAPartnersViewController.xib */,
+				140B936C01A9D028032A703B1C792C02 /* SPCCPAVendorDetailsViewController.swift */,
+				F17FBA5182E772BCA2F3B3F55002CD78 /* SPCCPAVendorDetailsViewController.xib */,
+			);
+			name = CCPA;
+			path = CCPA;
+			sourceTree = "<group>";
+		};
+		7F92978A0A4EA133DD69A83C71ED2F76 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				282733731A4D5C723DF051F47E92B452 /* Collection.swift */,
+				3F9D6BED32E513A0AA13D9C78512A40B /* Date.swift */,
+				94BB776D3E20372DDF92F05076640AE1 /* NSObjectExtensions.swift */,
+				E55659631F09CC0006809BF9DFAB5EEA /* SPString.swift */,
+				989D2B471579A3D696A1F3418778EFCA /* SPURLExtensions.swift */,
+			);
+			name = Extensions;
+			path = ConsentViewController/Classes/Extensions;
+			sourceTree = "<group>";
+		};
 		81D6054EF43F63BB285E94E3EFC28597 /* Pods-SPGDPRExampleAppUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2374,25 +2431,6 @@
 			);
 			name = "Pods-SPGDPRExampleAppUITests";
 			path = "Target Support Files/Pods-SPGDPRExampleAppUITests";
-			sourceTree = "<group>";
-		};
-		8691104DFF65E136FD5DDB3A4E717977 /* tvOS */ = {
-			isa = PBXGroup;
-			children = (
-				002E8F4D74E7CA04D49879A691D64347 /* NativePrivacyManager */,
-			);
-			name = tvOS;
-			path = tvOS;
-			sourceTree = "<group>";
-		};
-		8A802E623473D1923803E63ED633EB5C /* images */ = {
-			isa = PBXGroup;
-			children = (
-				44F462EFF078F36D350AD3131AC159D5 /* Barcode.png */,
-				0C5FF8AFF5BB78C11B41EDBDA9311585 /* SP_Icon.png */,
-			);
-			name = images;
-			path = ConsentViewController/Assets/images;
 			sourceTree = "<group>";
 		};
 		8AFDA2E94D2D26BC9B836229A3927125 /* Resources */ = {
@@ -2424,23 +2462,17 @@
 			path = "Target Support Files/Pods-ConsentViewController_Example";
 			sourceTree = "<group>";
 		};
-		A745757CAB6E91B9371BF790A414EFE6 /* GDPR */ = {
+		9F18A23C171E2E516146BD7D3BB2F30D /* Consents */ = {
 			isa = PBXGroup;
 			children = (
-				1A030B14F4462FC48F3E107A0BBD2279 /* GDPRPMConsentSnapshot.swift */,
-				4477BB8570CEF4A854228B7BAB01F423 /* SPGDPRCategoryDetailsViewController.swift */,
-				BA0FC05392595124ACD912E0FAC83A97 /* SPGDPRCategoryDetailsViewController.xib */,
-				F69175CFEF4241C2C231F6D7D430FAD6 /* SPGDPRManagePreferenceViewController.swift */,
-				8E26BF4E53CA96AEA636343BD452394F /* SPGDPRManagePreferenceViewController.xib */,
-				D60693B6637959F079E0D340EFE645C2 /* SPGDPRNativePrivacyManagerViewController.swift */,
-				9758CD86F35317EAE38A562A3630A7B3 /* SPGDPRNativePrivacyManagerViewController.xib */,
-				514C4E9A23F6AD1DB6E7310AE8C77F8C /* SPGDPRPartnersViewController.swift */,
-				A785D33B369746C28846A1B67D6AFEC0 /* SPGDPRPartnersViewController.xib */,
-				539C8DFC548F02D6D13136EFF52E51AA /* SPGDPRVendorDetailsViewController.swift */,
-				F7D014C17997C779CCF417FC64A00A45 /* SPGDPRVendorDetailsViewController.xib */,
+				E6DC7F0FB1838294BA74E9BFDB30157D /* ConsentStatus.swift */,
+				845B339986C9074BC7AE11FF95931123 /* SPCCPAConsent.swift */,
+				8192A816EE8F9CE7ED6486B77A00624C /* SPGDPRConsent.swift */,
+				61F074F2CF5D98F1FE8054275E5A9B75 /* SPUserData.swift */,
+				AB725A064558DC098766E7C83944569A /* SPUSNatConsent.swift */,
 			);
-			name = GDPR;
-			path = GDPR;
+			name = Consents;
+			path = ConsentViewController/Classes/Consents;
 			sourceTree = "<group>";
 		};
 		AA0FF5B84BA9871989AB30E01C8198D3 /* Targets Support Files */ = {
@@ -2461,6 +2493,26 @@
 				81D6054EF43F63BB285E94E3EFC28597 /* Pods-SPGDPRExampleAppUITests */,
 			);
 			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		ACC27ABBFD15605AAA79FED59FAB96C5 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				F197E4956D85BA7097F61D3662960B7F /* LongButtonViewCell.swift */,
+				B6392C301C609DA6F69C097BFF04872A /* LongButtonViewCell.xib */,
+				958F48A6FBB82F23052D20A0602AA77F /* SPAppleTVButton.swift */,
+				54FCB144D77EC7A1406130899FADA337 /* SPCustomViewController.swift */,
+				978E3F03E764292B1C1A142E4636C0E8 /* SPCustomViewController.xib */,
+				9E573C7AF82B5C83EFF10C961801B705 /* SPFocusableTextView.swift */,
+				0058A14E36B563CE681060B13CEDE40E /* SPNativeScreenViewController.swift */,
+				C57396400EE00521565E70F98E6BDFD1 /* SPPMHeader.swift */,
+				A9D6BAFBBE5B76401E897D8280933836 /* SPPMHeader.xib */,
+				361136B705C356E2C8AD0865F060756E /* SPPrivacyPolicyViewController.swift */,
+				EED581AAA5B3AA02FA8C571320995C16 /* SPPrivacyPolicyViewController.xib */,
+				42400389E67139027FDA2C6F1F479A8C /* SPQRCode.swift */,
+			);
+			name = Common;
+			path = Common;
 			sourceTree = "<group>";
 		};
 		AD06EB9B832C3BFAD12A0F36DA4C89AB /* Pods-ObjC-ExampleApp */ = {
@@ -2511,16 +2563,16 @@
 			path = "../Target Support Files/Down";
 			sourceTree = "<group>";
 		};
-		B1739CED36743B4630595EE7902A0E90 /* Consents */ = {
+		B3A3F2E66243EBDD6D812F46D67DFB90 /* NativePrivacyManager */ = {
 			isa = PBXGroup;
 			children = (
-				B252B8E80DCE0FD094FA558FCB0B5320 /* ConsentStatus.swift */,
-				FEA01C3D38F1284A8C46DC024B42B4A6 /* SPCCPAConsent.swift */,
-				2784307EA07123E8572C4FF93F3917CE /* SPGDPRConsent.swift */,
-				C7F01F54D5755E2A41C32B8A844B29DD /* SPUserData.swift */,
+				7E83E9EE4757A0114FA904AF5E45462E /* CCPA */,
+				ACC27ABBFD15605AAA79FED59FAB96C5 /* Common */,
+				37B76BED6A0CC9432B3BE61B6D6E17A2 /* Data */,
+				BCC73B8B5865A1426B31635E4F4ACFBF /* GDPR */,
 			);
-			name = Consents;
-			path = ConsentViewController/Classes/Consents;
+			name = NativePrivacyManager;
+			path = NativePrivacyManager;
 			sourceTree = "<group>";
 		};
 		B4E2225F325AA42C7DFE2C9BF5AF1C28 /* Pods */ = {
@@ -2535,6 +2587,35 @@
 				3C1A72554DD08CA0E8561E82BB97F374 /* Wormholy */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		B5820C96BD8B7F308128CA918510A5EB /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				FEB4FA61B354A7E3F028418E57FDCE43 /* SPWebMessageViewController.swift */,
+				024869A0C07426817DF3CC3AD024EDF1 /* SPWebViewExtensions.swift */,
+			);
+			name = iOS;
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		BCC73B8B5865A1426B31635E4F4ACFBF /* GDPR */ = {
+			isa = PBXGroup;
+			children = (
+				32EB8E8EC78E12CB5BD98D6EB510185B /* GDPRPMConsentSnapshot.swift */,
+				B808D0A304860016288A645F95B37A47 /* SPGDPRCategoryDetailsViewController.swift */,
+				6A9DE8572B70C4AEF2D400E28ECDF7AB /* SPGDPRCategoryDetailsViewController.xib */,
+				0C10539449E25FDBA3FE13D3ECB2ACB0 /* SPGDPRManagePreferenceViewController.swift */,
+				052F0758AB741230E72561BDC7A22ACA /* SPGDPRManagePreferenceViewController.xib */,
+				6C78C391518840A8E7006022EAF57E80 /* SPGDPRNativePrivacyManagerViewController.swift */,
+				C995D751887BE3C8F691C0C521442AD2 /* SPGDPRNativePrivacyManagerViewController.xib */,
+				41538B082DCBAC311B391D62F9F77575 /* SPGDPRPartnersViewController.swift */,
+				E58B299E95E357B2AFB44800057B0F15 /* SPGDPRPartnersViewController.xib */,
+				22A18D2D21DFD35D6FF2027BBC658D50 /* SPGDPRVendorDetailsViewController.swift */,
+				7FC1638981BCC1F808D6DC2560841524 /* SPGDPRVendorDetailsViewController.xib */,
+			);
+			name = GDPR;
+			path = GDPR;
 			sourceTree = "<group>";
 		};
 		BEDA5D120B9E397B2D6BF8D79DBCF25A /* Pods-SourcePointMetaAppUITests */ = {
@@ -2552,39 +2633,6 @@
 			);
 			name = "Pods-SourcePointMetaAppUITests";
 			path = "Target Support Files/Pods-SourcePointMetaAppUITests";
-			sourceTree = "<group>";
-		};
-		C42F9D18A8BFC81EF50AC108E4FE4723 /* SourcePointClient */ = {
-			isa = PBXGroup;
-			children = (
-				36B1AD04671BC2FBFB399E31BB49509A /* AddOrDeleteCustomConsentResponse.swift */,
-				68A817DE3655D89F8A82DE70045E8F51 /* ChoiceAllResponse.swift */,
-				439477ADCB521D4280C2A22395DF57E6 /* ChoiceRequests.swift */,
-				5F8F37E1246867F64DA19CD63664C7A2 /* ChoiceResponses.swift */,
-				2BDAB65BE94ACA7C2A6E08E2D4FB5425 /* ConsentStatusMetadata.swift */,
-				ECC74D56FDDCCD5DBDF2F603F5BEB55C /* ConsentStatusResponse.swift */,
-				7971F90764CADB78812440A92DA746C6 /* CustomConsentRequest.swift */,
-				964546ECA7E3236864DBFDC9EA1375CC /* DeleteCustomConsentRequest.swift */,
-				F230947DA34DF18BEB412F130148E3BB /* ErrorMetricsRequest.swift */,
-				9C2203991CF87910BDD063D65ACD1EBE /* GDPRPrivacyManagerViewResponse.swift */,
-				90D3727C4F0FA35173C80EB3C59DDF49 /* IDFAStatusReportRequest.swift */,
-				FF7FCD5D97E9C44DD791C95F75D527DF /* IncludeData.swift */,
-				28EA9FB3734CAE2118135175D98F1D20 /* MessageRequest.swift */,
-				F33D1CA7157620140646E3E0564ED248 /* MessagesRequest.swift */,
-				E669610B15E89D68A59B4ADA6046934C /* MessagesResponse.swift */,
-				223B68882D1E8F05E8747949943DC53F /* MetaDataRequestResponse.swift */,
-				229CC510F53FF3126C395D3E16A734D0 /* PrivacyManagerViewData.swift */,
-				3F84A4260597992E19579D6359EBAB94 /* PvDataRequestResponse.swift */,
-				5134E1744DB502EB07BE7CA2D0739398 /* QueryParamEncodableProtocol.swift */,
-				29C4F96A0A4D2D507766ED2F935595C6 /* SimpleClient.swift */,
-				4AFA6B36ABC056586579FFA6D736DA71 /* SourcePointClient.swift */,
-				6B3CFDECC0F12E3CBBFFC8D027D853DC /* SourcepointClientCoordinator.swift */,
-				61CCECA6D5136305C7844F2F7745605E /* SPNativeUI.swift */,
-				5595D26CD0CE5203994A89F8AB1F68FF /* SPPrivacyManagerRequestResponse.swift */,
-				2C6EF1ACD40341510CD18A00EE40C2E3 /* SPPublisherData.swift */,
-			);
-			name = SourcePointClient;
-			path = ConsentViewController/Classes/SourcePointClient;
 			sourceTree = "<group>";
 		};
 		C514E0AC53CC3B362B999AA02BB69D44 /* IQKeyboardManagerSwift */ = {
@@ -2619,15 +2667,13 @@
 			path = IQKeyboardManagerSwift;
 			sourceTree = "<group>";
 		};
-		CEBAC773B25894992487A65F3D217164 /* javascript */ = {
+		C69CF9F41A15E181934F1936BC981F15 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				5B5D7BE97D7E130364D1F4057289EC03 /* jest.config.json */,
-				F4C1045E7B11276558ACCB7A723DF82B /* SPJSReceiver.js */,
-				24B9714020F6EE241E4029F9D71FB4DD /* SPJSReceiver.spec.js */,
+				B3A3F2E66243EBDD6D812F46D67DFB90 /* NativePrivacyManager */,
 			);
-			name = javascript;
-			path = ConsentViewController/Assets/javascript;
+			name = tvOS;
+			path = tvOS;
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -2662,48 +2708,6 @@
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Quick-iOS";
-			sourceTree = "<group>";
-		};
-		D26DAB6AB18B49229734EC1626A21116 /* ConsentViewController */ = {
-			isa = PBXGroup;
-			children = (
-				E4C52023C0BE5895911B529281CFA8D3 /* Bundle+Framework.swift */,
-				19CF649845DEF2B829FB7FD5B787243B /* ConnectivityManager.swift */,
-				3D175523BA47204A774F770AA3C336D7 /* Constants.swift */,
-				3AE019D4EEC4EA171857F56855464099 /* images */,
-				6DE94D7CBAABAB291F7AE4A21CE48D66 /* javascript */,
-				314BF0457A28BB12F453112044DD385D /* OSLogger.swift */,
-				5475A5AA0068B5C7E68B5F416E428AA8 /* SPAction.swift */,
-				AFF54F2D66863A21794692394B4DE853 /* SPCampaignEnv.swift */,
-				4E6B5593EE61980CC9C62A1AF03D4990 /* SPCampaigns.swift */,
-				3E84631157C0FF4981393CCAC765E14C /* SPCampaignType.swift */,
-				C85151050329E96D5DDA93AA7EB8A335 /* SPConsentManager.swift */,
-				DF42833ED704F1D08E1588247A04BD1A /* SPDate.swift */,
-				CDC16C315EDCAE62E1828446CBE23901 /* SPDelegate.swift */,
-				FC28310BA7EB1F7DA1CFFCEC65E22D7F /* SPDeviceManager.swift */,
-				177DD5FB31148C2407BA8D43A0902DB7 /* SPError.swift */,
-				DEC21ED487A14977C49B886AC04D349A /* SPIDFAStatus.swift */,
-				3BA775630FBF5F32F26304E7C14ECA75 /* SPJson.swift */,
-				D4B803807F52ECA8CB5C7409EB5668EC /* SPMessageLanguage.swift */,
-				0DCEC17591F80FCF182482B83F37421A /* SPMessageUIDelegate.swift */,
-				52C97914BE77B99E39621A9EC7E58C21 /* SPMessageViewController.swift */,
-				C2CB6B9880FD351B6C08374FBDFD7C6D /* SPNativeMessage.swift */,
-				2EF8480E5D04F34D740E0BF306B6EFFC /* SPPrivacyManagerTab.swift */,
-				6487BE0AA27BF693E70D2321C14F25D8 /* SPPropertyName.swift */,
-				C99F1367AA419AD39BA004551C43D993 /* SPSDK.swift */,
-				4047D4CAC50B2C75E9F18BF861468108 /* SPStringifiedJSON.swift */,
-				B1739CED36743B4630595EE7902A0E90 /* Consents */,
-				536300C9DBD1C4D585E0AB39304781B7 /* Extensions */,
-				8A802E623473D1923803E63ED633EB5C /* images */,
-				CEBAC773B25894992487A65F3D217164 /* javascript */,
-				EC8F35ED7E4DE7274F32135D5612D9D8 /* LocalStorage */,
-				4B24099895B8068D522FA7098BA60E01 /* Pod */,
-				C42F9D18A8BFC81EF50AC108E4FE4723 /* SourcePointClient */,
-				4986AE6DAE62391338EC1DE36D25B405 /* Support Files */,
-				63C7FC91796FF66256AC80B4CE991BA0 /* Views */,
-			);
-			name = ConsentViewController;
-			path = ../..;
 			sourceTree = "<group>";
 		};
 		E0873A6C53E21D171AE9DDED8072BC71 /* Support Files */ = {
@@ -2770,6 +2774,16 @@
 			path = Quick;
 			sourceTree = "<group>";
 		};
+		E33EBBD5EB1AB83FE249DDB91293E143 /* images */ = {
+			isa = PBXGroup;
+			children = (
+				70C9EEB9C55E8BEEED132AC3B3DFE809 /* Barcode.png */,
+				2F13DD6087C28E86B9C1788E8C496A78 /* SP_Icon.png */,
+			);
+			name = images;
+			path = ConsentViewController/Assets/images;
+			sourceTree = "<group>";
+		};
 		E56E671D3A7B0425903309A49BF605B9 /* SwiftLint */ = {
 			isa = PBXGroup;
 			children = (
@@ -2777,16 +2791,6 @@
 			);
 			name = SwiftLint;
 			path = SwiftLint;
-			sourceTree = "<group>";
-		};
-		EC8F35ED7E4DE7274F32135D5612D9D8 /* LocalStorage */ = {
-			isa = PBXGroup;
-			children = (
-				1A79E6E7F82594FE03ED849144F29C8A /* SPLocalStorage.swift */,
-				7A036380E05F52DB23AA8871BB06A4DC /* SPUserDefaults.swift */,
-			);
-			name = LocalStorage;
-			path = ConsentViewController/Classes/LocalStorage;
 			sourceTree = "<group>";
 		};
 		F060D937EBFB6C3CD5279D431AD760AD /* Nimble */ = {
@@ -2938,11 +2942,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3A8307D927BBE119C46E3984B2FA0735 /* Headers */ = {
+		36D097537E1CE104FD2DB96AA767DD24 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				924C71BBF57628EA66A0C0BFC355A796 /* ConsentViewController-tvOS-umbrella.h in Headers */,
+				708A420FD17F797F725B08FE89D0F418 /* ConsentViewController-tvOS-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3005,28 +3009,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BCAE7C1D937C56D3987B95D58D6E2C09 /* Headers */ = {
+		B6EB724BD57C7E40E484875D522CB73B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				92D2CAA5FE5AA3F1382AEE48126B32D2 /* buffer.h in Headers */,
-				9225ED7EDF8C310923271879CEBEBF21 /* chunk.h in Headers */,
-				9BD1C0C3923D85BDD91B6BFFDE1697B9 /* cmark.h in Headers */,
-				94A1F85585D28C1246CE68DAA85A7A85 /* cmark_ctype.h in Headers */,
-				8D9B74A3CBF6D662311147AF53153856 /* cmark_export.h in Headers */,
-				F68DFB3A02A4443B87ECCF1C62D97826 /* cmark_version.h in Headers */,
-				28492CB04C8DE23C3B0475B73FC83EFE /* config.h in Headers */,
-				1398218008F3AA63D2AE0C882915DCBE /* Down.h in Headers */,
-				0B5ABBFD41542196FEC9560AF979774A /* Down-umbrella.h in Headers */,
-				CC5052CD69BEACB16A6BA9935C7CC8A9 /* houdini.h in Headers */,
-				604CB62A0892654E295E49A4FE2CD0A9 /* inlines.h in Headers */,
-				668AFC3458ED8948609653936EE3D18A /* iterator.h in Headers */,
-				204F3FD59C01BE9D4B739D0C1D4A7BC0 /* node.h in Headers */,
-				1A44CB217A52E069392B7C3B1B3E1BC3 /* parser.h in Headers */,
-				E2FC266B367D859383ECF728B35422BA /* references.h in Headers */,
-				1D9809F3DC6BD8650AE4707D96AC488A /* render.h in Headers */,
-				9AA177B1BAA2610F9EDD1A04074C72F7 /* scanners.h in Headers */,
-				CB70A94948381ACC5ADD15166975274A /* utf8.h in Headers */,
+				6977FC153C068B016A6BBDFA08940BD4 /* ConsentViewController-iOS-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3054,19 +3041,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E17BE2A84CFC1FAB146156DF7EECFBB7 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				22A2650B6135BB8176F20103DC4EF15F /* buffer.h in Headers */,
+				CB8BCF2EEA07ACA3399100F0D4506C87 /* chunk.h in Headers */,
+				8897BB2703B7BB4B4760294FE4EBF293 /* cmark.h in Headers */,
+				6DD9CA4DB36FD8FC37608F6B7EF67B34 /* cmark_ctype.h in Headers */,
+				297CE1761AF7549659362BAE7C5037BA /* cmark_export.h in Headers */,
+				2C84B2D85D1C7E0DF22B56E6A0B34B61 /* cmark_version.h in Headers */,
+				415B9BA2AD785521ABB441C819AB3D06 /* config.h in Headers */,
+				2C49C38789D067D97963BC55E3E5D6B3 /* Down.h in Headers */,
+				06837F9F37D4713F9838A687323812A5 /* Down-umbrella.h in Headers */,
+				31923FAB43928DA9AB0DE311F13C3EDF /* houdini.h in Headers */,
+				30227E26AE6FE9B95E8C96E463C4055F /* inlines.h in Headers */,
+				33D5376DD1888F3949FE3FDF3305C5E6 /* iterator.h in Headers */,
+				9497CA192F7C7080878C32A58FF985F0 /* node.h in Headers */,
+				2C7C34A83AD21BF2905D76C63CDC65FE /* parser.h in Headers */,
+				3AA3CE7AEFF8C6E932E00AAACCCB0843 /* references.h in Headers */,
+				5E28679BD2E2D435C596F3DED21E17A5 /* render.h in Headers */,
+				FAD032C117F13D23749BAB24C4EAD3B1 /* scanners.h in Headers */,
+				C676707E15772A1F7FDF5003DFD4D747 /* utf8.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E6E640A95F45154DEDBBD6C169212310 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				89AD53FD6F377D272B66C26B57779B75 /* Pods-SPGDPRExampleAppUITests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F1BF9F9C7C56D47A224301C345BE7C22 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				421DC21727A2DBCC94113C27DC0044BA /* ConsentViewController-iOS-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3116,9 +3120,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				5CCF4C706A1D1458C9C46AEA1EB56278 /* PBXTargetDependency */,
-				2B416DF13E98D18DFC80DB68F8498D7C /* PBXTargetDependency */,
-				9800DC88D5370195F85B179B5619555B /* PBXTargetDependency */,
+				F6CEAD9133997D5F3C386BCACE4BCC1E /* PBXTargetDependency */,
+				4C0E7EC20AF5D42E2999700D5D73965A /* PBXTargetDependency */,
+				00C2CB860908C3EA5C13990EF701A472 /* PBXTargetDependency */,
 			);
 			name = "Pods-AuthExample";
 			productName = Pods_AuthExample;
@@ -3137,9 +3141,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				42886AB822FDC8BF3197127020545BF1 /* PBXTargetDependency */,
-				0EDAD8D01C099B1FF23D4C9B1AD8BE4F /* PBXTargetDependency */,
-				D04F94F7505A91A31643AB458CEC8C6C /* PBXTargetDependency */,
+				7EAE540829CCFAE20A28002E38476954 /* PBXTargetDependency */,
+				ECE52E1A7420444F3491AD9C740EDA86 /* PBXTargetDependency */,
+				ACE42A67D806A29DEE2F049D94E738B6 /* PBXTargetDependency */,
 			);
 			name = "Pods-ObjC-ExampleAppUITests";
 			productName = Pods_ObjC_ExampleAppUITests;
@@ -3176,9 +3180,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				C5ADAFD7D106B2ED8AD9D8351067B913 /* PBXTargetDependency */,
-				F7871A369EF73AA466B6B033E11CA4E4 /* PBXTargetDependency */,
-				18A90A23BB7A826BD8A20B4209DC5BF2 /* PBXTargetDependency */,
+				597920466A1435C84267C52F2C8D31BC /* PBXTargetDependency */,
+				6D4A18368B1AB8248957C149A15CA6A5 /* PBXTargetDependency */,
+				7A3E34046FEEBB4CB032090E5E743540 /* PBXTargetDependency */,
 			);
 			name = "Pods-SPGDPRExampleAppUITests";
 			productName = Pods_SPGDPRExampleAppUITests;
@@ -3215,9 +3219,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				5FC130EC539F3691217DE2317DCE7C6B /* PBXTargetDependency */,
-				F533353FF0CCE7F8B901A1C8BACEF6D6 /* PBXTargetDependency */,
-				1D817EEB323678729645004FA4B3A856 /* PBXTargetDependency */,
+				C40855A43EE5843E4B5036EDEA4D3D89 /* PBXTargetDependency */,
+				91D51B0983DE1B53648D6870289CBCEF /* PBXTargetDependency */,
+				C679F612E8CEB34497D5FC82AE3C2D34 /* PBXTargetDependency */,
 			);
 			name = "Pods-NativeMessageExample";
 			productName = Pods_NativeMessageExample;
@@ -3236,10 +3240,10 @@
 			buildRules = (
 			);
 			dependencies = (
-				8A4BCAC7BA434BCE548A6025E547972D /* PBXTargetDependency */,
-				39A04234650125EF45634E25236141F5 /* PBXTargetDependency */,
-				35877D1287C2F4EECE315A7D7EB99B56 /* PBXTargetDependency */,
-				B63688CBF35F174CBED68F23ED53CBF9 /* PBXTargetDependency */,
+				8F6C468D6785F8DD08B2242DE2B88E20 /* PBXTargetDependency */,
+				12C63C8F542029F4964E1768AF58C24F /* PBXTargetDependency */,
+				21152E2139178304A85BB77BF9C32862 /* PBXTargetDependency */,
+				05269D079B7D902026190F96099BE8CB /* PBXTargetDependency */,
 			);
 			name = "Pods-ConsentViewController_Example";
 			productName = Pods_ConsentViewController_Example;
@@ -3276,7 +3280,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				5B3C724543EE36576BF48FF1E09C9DA6 /* PBXTargetDependency */,
+				86C04C0AFD21277A4029F80E07EEC054 /* PBXTargetDependency */,
 			);
 			name = Wormholy;
 			productName = Wormholy;
@@ -3285,11 +3289,11 @@
 		};
 		5D0718052BFEE502C9D9BEC44BDCFA76 /* ConsentViewController-tvOS-ConsentViewController */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6FD6729A41A3247C1240607A2D9235AD /* Build configuration list for PBXNativeTarget "ConsentViewController-tvOS-ConsentViewController" */;
+			buildConfigurationList = F9EE0728868978B4E665129E8E0CB554 /* Build configuration list for PBXNativeTarget "ConsentViewController-tvOS-ConsentViewController" */;
 			buildPhases = (
-				3CC70D19090D510B193E0C237AA8CD62 /* Sources */,
-				ACBC435C988748E6BABF42CFD93DE2E1 /* Frameworks */,
-				37CEEFF8D1C13AF6EA660CBCDFB018B5 /* Resources */,
+				65C66BE0ACD7B1F2E09BBDAEC07CAAEE /* Sources */,
+				3FF58C69D250D2CBFE450460E0184122 /* Frameworks */,
+				16B1C52D4CA38FFC88C1CBE5DAE17B8C /* Resources */,
 			);
 			buildRules = (
 			);
@@ -3312,9 +3316,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				D0657478CA67403C33E2351BCC8E1F61 /* PBXTargetDependency */,
-				3DC312B44FDDA696FE608DFD4723DCCF /* PBXTargetDependency */,
-				2F0E7818127100F77F31CF8207B4BD63 /* PBXTargetDependency */,
+				7E5252E28A8880C286C6E3515EDDADC2 /* PBXTargetDependency */,
+				6B8A78046B7D8A023E79998EA91FA50C /* PBXTargetDependency */,
+				21842F441F9F640D02252DBAE1BE9CDB /* PBXTargetDependency */,
 			);
 			name = "Pods-SourcePointMetaApp";
 			productName = Pods_SourcePointMetaApp;
@@ -3323,17 +3327,17 @@
 		};
 		84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7B5DAC41EF3F896427FC9C30DC6C9AD2 /* Build configuration list for PBXNativeTarget "ConsentViewController-iOS" */;
+			buildConfigurationList = FD12896596E31CF67041D230A855E993 /* Build configuration list for PBXNativeTarget "ConsentViewController-iOS" */;
 			buildPhases = (
-				F1BF9F9C7C56D47A224301C345BE7C22 /* Headers */,
-				2754E173E2191D9A97C8EACF454C0A35 /* Sources */,
-				6A84D88D40E96AB1D42D5AAFEC683C3F /* Frameworks */,
-				4D74E6D7C1A866D8DFBFEEA28EE3682A /* Resources */,
+				B6EB724BD57C7E40E484875D522CB73B /* Headers */,
+				CB282BA4A33F3E6460D76C45842143E8 /* Sources */,
+				6A44DF6BE20E17215E8BEA799C0C8C5E /* Frameworks */,
+				6AC4EB4B3E3ABA313D9383364AB8703C /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				7F0196C32D06A0C139CAD340817DD685 /* PBXTargetDependency */,
+				D54449243D110E5DCBA3C6F1E201C6B3 /* PBXTargetDependency */,
 			);
 			name = "ConsentViewController-iOS";
 			productName = ConsentViewController;
@@ -3370,10 +3374,10 @@
 			buildRules = (
 			);
 			dependencies = (
-				80E3EDED6E1062FE5A4BE025717B3C29 /* PBXTargetDependency */,
-				7D5E31321E2A99C00CADD9777567F7A0 /* PBXTargetDependency */,
-				ADF0996DB9CCE99D066ED3470CFA4F46 /* PBXTargetDependency */,
-				E223A9349FA2A956831D70D9CE0B1946 /* PBXTargetDependency */,
+				CB501D5E7C66012C2115C590D6FE1EF0 /* PBXTargetDependency */,
+				A79AE7A6A7EA626209C5BDC01E8AC5CF /* PBXTargetDependency */,
+				88C5045F2E4D752793D29181889DCF9C /* PBXTargetDependency */,
+				421CD1A69D0D1DD7EF173998D1FB0156 /* PBXTargetDependency */,
 			);
 			name = "Pods-NativePMExampleAppUITests";
 			productName = Pods_NativePMExampleAppUITests;
@@ -3382,11 +3386,11 @@
 		};
 		93CEC7FFB57A497DE49471C5D9517C13 /* Wormholy-Wormholy */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 23AF51B058580EC2BD55E9CF139988DA /* Build configuration list for PBXNativeTarget "Wormholy-Wormholy" */;
+			buildConfigurationList = 9200B5FD285E083A51425DB30064EEE8 /* Build configuration list for PBXNativeTarget "Wormholy-Wormholy" */;
 			buildPhases = (
-				21CD9C3924DD3C20E5138B52CE3C3F26 /* Sources */,
-				5E13AFEDBD3A5A8E692C1DB31B870D57 /* Frameworks */,
-				AB2F7FF95FFE9712AD0ECF7F9C74A0FB /* Resources */,
+				31319BCFC5345D9CA28392C1501839E1 /* Sources */,
+				968D60FD7EB1AE4708A1FB11FA432230 /* Frameworks */,
+				EA29D540C9EB13C5F9B3326B9A5DD1B7 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -3409,9 +3413,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				9D9FD4A63888EE6BF12E76B158872B23 /* PBXTargetDependency */,
-				44DC54C6F646DEFD3F8AF51915989AAD /* PBXTargetDependency */,
-				2F74B75149D368122283CFAC9CAECCD3 /* PBXTargetDependency */,
+				E715548AFDD927BA2332CF0E9E243B6B /* PBXTargetDependency */,
+				5B1F06AAAF8C183FCFCD6AFE91D7861B /* PBXTargetDependency */,
+				DBEC714D2F90ABC5F77733F53E0FC210 /* PBXTargetDependency */,
 			);
 			name = "Pods-NativePMExampleApp";
 			productName = Pods_NativePMExampleApp;
@@ -3430,9 +3434,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				E5D343636409627A97789EF74AEA1B54 /* PBXTargetDependency */,
-				4E170EAF4163585151684FDDB79F5B85 /* PBXTargetDependency */,
-				B8469307BAC3AB2165E261F7D86E7BE2 /* PBXTargetDependency */,
+				72152A6048D9F3E501C45685B2B01B2D /* PBXTargetDependency */,
+				2E424ED6963BF170ED94D045CFB00DE2 /* PBXTargetDependency */,
+				BBE328FD7BAFE453EED509B56AF1BEAA /* PBXTargetDependency */,
 			);
 			name = "Pods-NativeMessageExampleUITests";
 			productName = Pods_NativeMessageExampleUITests;
@@ -3441,18 +3445,18 @@
 		};
 		94DAD332BFFC672BBE92726504A716F8 /* ConsentViewController-tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B35C8DCE4E723B8050C8AF02047EB695 /* Build configuration list for PBXNativeTarget "ConsentViewController-tvOS" */;
+			buildConfigurationList = BEFA0297B3D240216851578D96A31668 /* Build configuration list for PBXNativeTarget "ConsentViewController-tvOS" */;
 			buildPhases = (
-				3A8307D927BBE119C46E3984B2FA0735 /* Headers */,
-				4BA2C9A007E243225111B74A1AEE6BF2 /* Sources */,
-				B5861FD579DDAC522C0BBA707FC4F47A /* Frameworks */,
-				12EF5891050A850A5337B9178F348EBA /* Resources */,
+				36D097537E1CE104FD2DB96AA767DD24 /* Headers */,
+				122E3C893822BD54CB10117EA37954B4 /* Sources */,
+				95E4133248B84AFE374F1DB8E0140F2B /* Frameworks */,
+				453DCDD3E86709EC677A1472CB4AA5B0 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				CCBA251BD08EF87D77EF9B0A64BFDF6A /* PBXTargetDependency */,
-				FF4DA7E4FD840A4E86416448BC649851 /* PBXTargetDependency */,
+				B4EC0F8508D741B2B9AE8DFAF7A2BD58 /* PBXTargetDependency */,
+				AE81D426D55C1309E850FCD8247141C3 /* PBXTargetDependency */,
 			);
 			name = "ConsentViewController-tvOS";
 			productName = ConsentViewController;
@@ -3479,12 +3483,12 @@
 		};
 		B4575FF01775E963E58050542C9A4E7A /* Down */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A3C54A93F9720A7819E98D4EDFA3FDB4 /* Build configuration list for PBXNativeTarget "Down" */;
+			buildConfigurationList = 6CBC2C9167F540881A213AEA58A6BD1C /* Build configuration list for PBXNativeTarget "Down" */;
 			buildPhases = (
-				BCAE7C1D937C56D3987B95D58D6E2C09 /* Headers */,
-				F412B30E309AD99864724F5F859415E4 /* Sources */,
-				17A1D959F2695A0EDBAD74D620BA1AA3 /* Frameworks */,
-				9002AAF5286AA8898F96E216E5C6BE1F /* Resources */,
+				E17BE2A84CFC1FAB146156DF7EECFBB7 /* Headers */,
+				7BA93C1E91F5855516A4F3F52395B17F /* Sources */,
+				CF0AD51D98D0B53F12F3BA3B570038F0 /* Frameworks */,
+				39CE2BEB8FED69BA82AB305537B9BD53 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -3525,8 +3529,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				075B88CA3D16BE1D079CFB8B2CED2D93 /* PBXTargetDependency */,
-				C3E7EDCA29B83C63E30A40089C71AC2D /* PBXTargetDependency */,
+				4BD5749091913957710214DE471EF4B4 /* PBXTargetDependency */,
+				7E11C12519E54B0A1596B20575F4626B /* PBXTargetDependency */,
 			);
 			name = "Pods-ObjC-ExampleApp";
 			productName = Pods_ObjC_ExampleApp;
@@ -3545,9 +3549,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				7136B7A3AAA1039B79F83ACCCB60A0E4 /* PBXTargetDependency */,
-				92EDECA4DA5B5959ABA5D934FB0C7628 /* PBXTargetDependency */,
-				8A1ACC1190D55E45387BD7F5F98F572C /* PBXTargetDependency */,
+				88ACD56619ECD6477866C1A4ED548C2D /* PBXTargetDependency */,
+				44D6DC5773EADB1C99A61400BBE793E5 /* PBXTargetDependency */,
+				C0F0E25BDB702888D19EF370C140EE5F /* PBXTargetDependency */,
 			);
 			name = "Pods-AuthExampleUITests";
 			productName = Pods_AuthExampleUITests;
@@ -3556,11 +3560,11 @@
 		};
 		F9B2C41D8F3FCEB2256091CF2667D600 /* ConsentViewController-iOS-ConsentViewController */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = BB0F236B65CF2CEE01DEB816389B234C /* Build configuration list for PBXNativeTarget "ConsentViewController-iOS-ConsentViewController" */;
+			buildConfigurationList = AD80BBB004316DCCE3319230516202AE /* Build configuration list for PBXNativeTarget "ConsentViewController-iOS-ConsentViewController" */;
 			buildPhases = (
-				78D9590198926D1A055E444A4A06668D /* Sources */,
-				05EABBF3078CE79A2BC96A11C16324C4 /* Frameworks */,
-				9774E5D84D9E4DB3C09140FAF1D815E1 /* Resources */,
+				7EE0E30A74A5B36C4FAFEC3C66FBABA5 /* Sources */,
+				929D3062B128F11AA801D9164533A88E /* Frameworks */,
+				F388908D8FC2E384D53E38528344045E /* Resources */,
 			);
 			buildRules = (
 			);
@@ -3583,9 +3587,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				3363DC0678ADB85A40A256FA239B4A63 /* PBXTargetDependency */,
-				78DEFD6750A5735F10E0AF81F722B116 /* PBXTargetDependency */,
-				1B19D6FC02449776F00FCA4E7874AC28 /* PBXTargetDependency */,
+				E8006DA537E8B1B1A35D3C8B502C725D /* PBXTargetDependency */,
+				10A537EA4B9333C339D98470550E9B5D /* PBXTargetDependency */,
+				450E1AA5592C4855A3D47198E68C9E78 /* PBXTargetDependency */,
 			);
 			name = "Pods-SourcePointMetaAppUITests";
 			productName = Pods_SourcePointMetaAppUITests;
@@ -3604,9 +3608,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				5A98820D808532CC408A300A19B0A752 /* PBXTargetDependency */,
-				1E8A2DB665A5184352A92F0F83F0F1D0 /* PBXTargetDependency */,
-				7042EF2FBCE9A3249414AE81B20F34C7 /* PBXTargetDependency */,
+				96F4FD01D743A4566EA1A053A5971B84 /* PBXTargetDependency */,
+				98A4438EE7F40B40F0D7A8BFD849B392 /* PBXTargetDependency */,
+				E54E773DA433A0BC289339D9F1E0EE47 /* PBXTargetDependency */,
 			);
 			name = "Pods-ConsentViewController_ExampleTests";
 			productName = Pods_ConsentViewController_ExampleTests;
@@ -3689,16 +3693,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		12EF5891050A850A5337B9178F348EBA /* Resources */ = {
+		16B1C52D4CA38FFC88C1CBE5DAE17B8C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				83D8205655CADBFC20F48C577A0E018E /* Barcode.png in Resources */,
-				DB668BB8EC15FCB5A8935BD3EE2838B7 /* ConsentViewController-tvOS-ConsentViewController in Resources */,
-				6487DEEF57EF7BED67AD9F04CCD26869 /* jest.config.json in Resources */,
-				C8FDB68E98949FAA6EB7457F40A8175F /* SP_Icon.png in Resources */,
-				0D5A638BEE7B8374BA9F97048B56E29C /* SPJSReceiver.js in Resources */,
-				8FBAC81908883C735F2F05A79A3DA72E /* SPJSReceiver.spec.js in Resources */,
+				56928CF0AECE7181603DFC4FEF5DDB24 /* Barcode.png in Resources */,
+				264839A6926F4FECAEBB893CAF725770 /* images in Resources */,
+				13D33746AE0238795E807AE4DF2B58A5 /* javascript in Resources */,
+				61F2A42BAE6CE57BDF6CDA92A176F037 /* jest.config.json in Resources */,
+				BC6380E551F282A9798DC9BDA76566CD /* SP_Icon.png in Resources */,
+				CFFE3020232CA1F65BF227DAE90DF70E /* SPJSReceiver.js in Resources */,
+				A234648CFA7A1BE7A8D2F818F08D06B2 /* SPJSReceiver.spec.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3716,17 +3721,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		37CEEFF8D1C13AF6EA660CBCDFB018B5 /* Resources */ = {
+		39CE2BEB8FED69BA82AB305537B9BD53 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				53A76A58A63D85865F11BC763D65AC8E /* Barcode.png in Resources */,
-				659DF7C642C1F930F4110C850A8B621E /* images in Resources */,
-				A761BE20CB64A5564A842655829C2410 /* javascript in Resources */,
-				B625825A470502B6724CB0AF4CF0732E /* jest.config.json in Resources */,
-				F5C68980310A8B5D35F6A0C2887127DF /* SP_Icon.png in Resources */,
-				BE184262DC08FEC8D8DC11FDEECD17DD /* SPJSReceiver.js in Resources */,
-				513D0266B7F58B696A551CE08EF39D55 /* SPJSReceiver.spec.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		453DCDD3E86709EC677A1472CB4AA5B0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F9283547E3E308B3001409180E5C96B8 /* Barcode.png in Resources */,
+				89A1347E8651438D9A102629547C39AC /* ConsentViewController-tvOS-ConsentViewController in Resources */,
+				0CDD87EBBE71EF6951C892FD6EF3EFE3 /* jest.config.json in Resources */,
+				D2CCACA8DE98902878CAD9D8193913E4 /* SP_Icon.png in Resources */,
+				72F431C0F668F4EBA12EF5F4A8D9E9DE /* SPJSReceiver.js in Resources */,
+				7406E0A5B4C79A1A880E0E8E5F6CEB0F /* SPJSReceiver.spec.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3741,19 +3752,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4D74E6D7C1A866D8DFBFEEA28EE3682A /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E4870FCFE27776304FBD2507F76514A1 /* Barcode.png in Resources */,
-				FBAA4BFC298CF11AB4ED3C2161787AE6 /* ConsentViewController-iOS-ConsentViewController in Resources */,
-				96AD1EECD396BAE6524F91EDD78883E9 /* jest.config.json in Resources */,
-				B4E64303527304E86FB4ADD043672E62 /* SP_Icon.png in Resources */,
-				FB6330BC0E667A3977232DDBC1A99DD3 /* SPJSReceiver.js in Resources */,
-				525ACE768CAC3C088BC1AC6E53858151 /* SPJSReceiver.spec.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3778,6 +3776,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6AC4EB4B3E3ABA313D9383364AB8703C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F341ECC83957A8BA336392104EFBABAB /* Barcode.png in Resources */,
+				ECADCA8CED9142EDBB07CF08B5CE5201 /* ConsentViewController-iOS-ConsentViewController in Resources */,
+				E6282CF44C2FCD77CC9E439D29E9DDF0 /* jest.config.json in Resources */,
+				C99E780D999B238956481EDB1B312E88 /* SP_Icon.png in Resources */,
+				8C86806B3F489AFA1B6C8745D9938422 /* SPJSReceiver.js in Resources */,
+				AB84C91DF3E9E56CB1A3105EB89F705E /* SPJSReceiver.spec.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7D1DF32B3F4C004C090533F0C3B79979 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3796,27 +3807,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9002AAF5286AA8898F96E216E5C6BE1F /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9774E5D84D9E4DB3C09140FAF1D815E1 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5D58790EA320A5623330E04749C40348 /* Barcode.png in Resources */,
-				74AFB49333A351F46FD30C0C55E2C9DC /* images in Resources */,
-				83C81D9CA03CAEE5B03DADBBA48EF249 /* javascript in Resources */,
-				99D0A3F07DD28D2CA895094E581408EB /* jest.config.json in Resources */,
-				13434450BF03A9E3AF6A140E12BAD742 /* SP_Icon.png in Resources */,
-				D89C1C641FF808B729CFC47AF3DBF24B /* SPJSReceiver.js in Resources */,
-				976EDA6710BA2115FFA3CE341DE6085E /* SPJSReceiver.spec.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3839,18 +3829,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AB2F7FF95FFE9712AD0ECF7F9C74A0FB /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D225EA80210E2C74DDA4FAA4E1C24206 /* ActionableTableViewCell.xib in Resources */,
-				2322461C644F8F05973A87E91489495C /* Flow.storyboard in Resources */,
-				6786CB42766CCC8BA3B556505A70D4B6 /* RequestCell.xib in Resources */,
-				FE2C505D02DA5D5E14F1F8AF91EBB580 /* RequestTitleSectionView.xib in Resources */,
-				29527709CA5EF3517107CD5B752C171A /* TextTableViewCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3882,21 +3860,146 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EA29D540C9EB13C5F9B3326B9A5DD1B7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ACB44957980530398957F0D6AB878E74 /* ActionableTableViewCell.xib in Resources */,
+				D61323F83C4A0903570331C1F8D9D06D /* Flow.storyboard in Resources */,
+				E34320762BB97AF2F63942DAA4E4B4E2 /* RequestCell.xib in Resources */,
+				53145D761CDB31738F2591FB046AF10C /* RequestTitleSectionView.xib in Resources */,
+				27EC61F6ED7DED5ECADD4B1AA138AAF4 /* TextTableViewCell.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F388908D8FC2E384D53E38528344045E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FA956015FCAF30ECCE011F2A0C36815 /* Barcode.png in Resources */,
+				04302C24091025617A3C500B6DF3265D /* images in Resources */,
+				290547E5F5F5B21D667FF8011E027FF9 /* javascript in Resources */,
+				77EF9CE1E63EFC64B7516E355015D71A /* jest.config.json in Resources */,
+				3B1A5E6FD278BAAE3A401ACB04FAF59A /* SP_Icon.png in Resources */,
+				9B7F6BF8A77460752215D1B682592A9B /* SPJSReceiver.js in Resources */,
+				B4F1A277A9599866A749FE9286D3A4C0 /* SPJSReceiver.spec.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		122E3C893822BD54CB10117EA37954B4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8EE95A80F1D826DED5758C19E615FC23 /* AddOrDeleteCustomConsentResponse.swift in Sources */,
+				3B5ED478EB10076C1870E27575DD3B10 /* Bundle+Framework.swift in Sources */,
+				9A3465AB8088C8D6AF6EC4347A53935D /* CCPAPMConsentSnapshot.swift in Sources */,
+				31B520279493FABB299F8DF2323D2F96 /* ChoiceAllResponse.swift in Sources */,
+				0580F0E80B4C0D9B6A1C6221B36E718D /* ChoiceRequests.swift in Sources */,
+				6E70E106BDFCD6703C01165DCAE45B16 /* ChoiceResponses.swift in Sources */,
+				530EE7E16B6827ECDDAC474F8F9CB296 /* Collection.swift in Sources */,
+				06DDAC82CE15DCCA6E2F717E8E97F1E6 /* ConnectivityManager.swift in Sources */,
+				09745F77B38B2953467EB4DB4A68B0F6 /* ConsentStatus.swift in Sources */,
+				1A8DFE1D2026DAF975A594D4679C0579 /* ConsentStatusMetadata.swift in Sources */,
+				6E43E34E335B8966AC96E645E442F68B /* ConsentStatusResponse.swift in Sources */,
+				CAD0D61DC9D59BEDAF2DD1A249D07877 /* ConsentViewController-tvOS-dummy.m in Sources */,
+				089034098C0B0C3BFBFD0C724E452C31 /* Constants.swift in Sources */,
+				02A38A93D00327FA02959C9711652F26 /* CustomConsentRequest.swift in Sources */,
+				F9A987306E48537B8C9D3D866044EAFF /* Date.swift in Sources */,
+				CA958C9774B63DC9AFAD8A419ADBC851 /* DeleteCustomConsentRequest.swift in Sources */,
+				33D3ACBC8D75923729D62AC5DF6E387D /* ErrorMetricsRequest.swift in Sources */,
+				2390AC255AE12FF8D9C7BA1975B1C594 /* GDPRPMConsentSnapshot.swift in Sources */,
+				212BDF5D1202B62C7FB7AABFEBE43A22 /* GDPRPMPayload.swift in Sources */,
+				6F43D0A23731EB50170C6A910F9A5FA8 /* GDPRPrivacyManagerViewResponse.swift in Sources */,
+				A8F1911B92C8DC791862BCFFFB4DFBD3 /* IDFAStatusReportRequest.swift in Sources */,
+				5F283C1BFF5A0F6DA7BAA8C5CF49FC2F /* IncludeData.swift in Sources */,
+				41CB5F295C39BC0A161C44538A83134B /* LongButtonViewCell.swift in Sources */,
+				27137825057CCED38D757693FA700513 /* LongButtonViewCell.xib in Sources */,
+				246DD1A4D6824A1CE39A2792F9A7CCF9 /* MessageRequest.swift in Sources */,
+				73CEC25F2BC403C72098BB47F50212B8 /* MessagesRequest.swift in Sources */,
+				1FA9F6A59A2F19C6FC273C20E5F6FD13 /* MessagesResponse.swift in Sources */,
+				8330E5383CE8995EE6267B19A4635E76 /* MetaDataRequestResponse.swift in Sources */,
+				FEBB13047E3229648187FA07A6141FE6 /* NSObjectExtensions.swift in Sources */,
+				FC7C883BCCD82FDE500C1C03C7157EB5 /* OSLogger.swift in Sources */,
+				A008ACB4CB8284C84ABDC6A5B7002B45 /* PMCategoryManager.swift in Sources */,
+				2C6DC86A0753F14DA9A89AEEECDD270E /* PMVendorManager.swift in Sources */,
+				59CEE89F72F04FA135449D94290F0F06 /* PrivacyManagerViewData.swift in Sources */,
+				899C875767DFEDDCFB588BC1406D3F76 /* PvDataRequestResponse.swift in Sources */,
+				5270DB357AFF6DA9F377A505CD18EF5C /* QueryParamEncodableProtocol.swift in Sources */,
+				4A28FDC458580086A2D593743B1B4C0B /* SimpleClient.swift in Sources */,
+				64A9334E350FFE9D9889A8B39B057300 /* SourcePointClient.swift in Sources */,
+				1896B671F28E3681E78D2584AD40406C /* SourcepointClientCoordinator.swift in Sources */,
+				CE424338DBC5F1FC2DF166B8583BFEB4 /* SPAction.swift in Sources */,
+				47093A5FC229C3C23722103BDAB005C4 /* SPAppleTVButton.swift in Sources */,
+				0CD806B915253E26DA4F3D090AA106B1 /* SPCampaignEnv.swift in Sources */,
+				AA225BDA4F05E65D9ACE403D92EB79CE /* SPCampaigns.swift in Sources */,
+				341D14E14B366AEEDB7A1E1A5677BE03 /* SPCampaignType.swift in Sources */,
+				28A15FC60516AB1F98A846C1FFF756D4 /* SPCCPACategoryDetailsViewController.swift in Sources */,
+				DDEC2BBD2FD13E2C8994D4D20AC1EC79 /* SPCCPACategoryDetailsViewController.xib in Sources */,
+				0A060BBE78DF452A773DC6EEC71BC81C /* SPCCPAConsent.swift in Sources */,
+				26ED9FB09E70ED33680A8916C483263C /* SPCCPAManagePreferenceViewController.swift in Sources */,
+				84513EC042577E76F5137AD44FABF822 /* SPCCPAManagePreferenceViewController.xib in Sources */,
+				3762EDDE73A0B22200C88E4D9A16CE52 /* SPCCPANativePrivacyManagerViewController.swift in Sources */,
+				EB23D7F14E3596854E5E0710DFF48A1E /* SPCCPANativePrivacyManagerViewController.xib in Sources */,
+				5972BB823E058083C30D0D3505A5744B /* SPCCPAPartnersViewController.swift in Sources */,
+				C27B4C3A93F38237F95F74C4B6A5FA62 /* SPCCPAPartnersViewController.xib in Sources */,
+				E480795C524BF8B41E2DFE2DFD8D8EBF /* SPCCPAVendorDetailsViewController.swift in Sources */,
+				41F4D479CA27981C28EEF72D3148F32F /* SPCCPAVendorDetailsViewController.xib in Sources */,
+				764A557A402309001947003CFF43D49E /* SPConsentManager.swift in Sources */,
+				7F73D710BD42B6865538F5F6A03EFA0C /* SPCustomViewController.swift in Sources */,
+				98080A0910BBE8094E4F3152C0D9B4FD /* SPCustomViewController.xib in Sources */,
+				F21B1C964636D5D25015B06E6ED331AF /* SPDate.swift in Sources */,
+				A09F4829078460DEB3A2118670176016 /* SPDelegate.swift in Sources */,
+				F7DA64A51CFC3C3B5D89BEBFA7CEF5A3 /* SPDeviceManager.swift in Sources */,
+				3D3F8A26343E290C4A83C53C909DF03B /* SPError.swift in Sources */,
+				22EC895FECE39417402FC3F9B58FC42A /* SPFocusableTextView.swift in Sources */,
+				73DC5F451204E312CF6A4C08EF4F1096 /* SPGDPRCategoryDetailsViewController.swift in Sources */,
+				ECE909A942B0364E0D241E631CBAEEB5 /* SPGDPRCategoryDetailsViewController.xib in Sources */,
+				12E82D709BF8639CEAD5ACE8C8452982 /* SPGDPRConsent.swift in Sources */,
+				EE3008C2F60F5D0B08B0E0519CF3D3E4 /* SPGDPRManagePreferenceViewController.swift in Sources */,
+				D9FFE888F27B42E092644AAAE2C61540 /* SPGDPRManagePreferenceViewController.xib in Sources */,
+				7F55D5A4F3167CD7C32644D98F72C86F /* SPGDPRNativePrivacyManagerViewController.swift in Sources */,
+				902ED6C92F8CF929990C4E5B84B63D42 /* SPGDPRNativePrivacyManagerViewController.xib in Sources */,
+				CEFF650E7F137FC4CE0E5861452AB6AA /* SPGDPRPartnersViewController.swift in Sources */,
+				3CB826EB2CB8348BE42A3B6BABD3CBF9 /* SPGDPRPartnersViewController.xib in Sources */,
+				D80B6001077BC3C35C161105C8AC55E3 /* SPGDPRVendorDetailsViewController.swift in Sources */,
+				E7A593D0BB2DCD32F2F75055AF558526 /* SPGDPRVendorDetailsViewController.xib in Sources */,
+				FD26BBAD91F0DB0EA68C9FFFFD9EE82A /* SPIDFAStatus.swift in Sources */,
+				93432A6A0D31937859A4156AB1B5AC3E /* SPJson.swift in Sources */,
+				A999E109423B69F02514DD3F08A48463 /* SPLocalStorage.swift in Sources */,
+				47EAF250030F4625D9BDA674E2BFA251 /* SPMessageLanguage.swift in Sources */,
+				457D5CAF8CC7BE998AC498AF47F7D5F3 /* SPMessageUIDelegate.swift in Sources */,
+				E6676E13D2C9C0535F566C089D3F8E96 /* SPMessageViewController.swift in Sources */,
+				91415A20AE03DD72D55CD2B112090A14 /* SPNativeMessage.swift in Sources */,
+				E5997F970E4A1C3B6D632A64B45E4885 /* SPNativeScreenViewController.swift in Sources */,
+				D6571C5DEB2A1112A8FDC111B40D5754 /* SPNativeUI.swift in Sources */,
+				A378B1A3798BA87FEE35A01DD116F59C /* SPPMHeader.swift in Sources */,
+				FE69273359AA25FC8636F04B9D38662C /* SPPMHeader.xib in Sources */,
+				C338FBF1F3178269570E5F512C96665C /* SPPrivacyManagerRequestResponse.swift in Sources */,
+				7BDE2231296BD7DFDD9114F435A1CABB /* SPPrivacyManagerTab.swift in Sources */,
+				D412C356EF48368DCB6CAC48622EB5FC /* SPPrivacyPolicyViewController.swift in Sources */,
+				AAC01F68DF3685494BB8867779D2607B /* SPPrivacyPolicyViewController.xib in Sources */,
+				E99BBA31AF5D1267E890E866F733C2DE /* SPPropertyName.swift in Sources */,
+				B905B8EEB641E3F1B1A8F42A7A95BD97 /* SPPublisherData.swift in Sources */,
+				7D64C1187D721F971D7CEA9C671A19E2 /* SPQRCode.swift in Sources */,
+				1BF4B639116426C64048D8955717FFD1 /* SPSDK.swift in Sources */,
+				F2290581DD9F60496D925BECB69A3DAF /* SPString.swift in Sources */,
+				A41CCB2072B85EDF6D386871628C677E /* SPStringifiedJSON.swift in Sources */,
+				872C0736B2C331825C3253AB20FF60C7 /* SPUIColor.swift in Sources */,
+				44050ACEAB658A2658E6E147115189CF /* SPURLExtensions.swift in Sources */,
+				DCD3D9B2C7CA90E0BA9460680A8BC59E /* SPUserData.swift in Sources */,
+				A4609C4B7BFD9A2C09FDF30879ADA62C /* SPUserDefaults.swift in Sources */,
+				35FB9BA0CF8DDC0FE5B140424288DEE5 /* SPUSNatConsent.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1EAC666E9962B105733A9D07953390FB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				2B45CC6028262EDFC605F642E095F886 /* Pods-NativePMExampleApp-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		21CD9C3924DD3C20E5138B52CE3C3F26 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3908,76 +4011,6 @@
 				2D4A4D18AC6DE990B350196BF5623061 /* JSONTreeView.swift in Sources */,
 				E665718896A9811A51B4946563237EC5 /* JSONView.swift in Sources */,
 				02339A7908BF70B860FC985F334486CB /* JSONView-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		2754E173E2191D9A97C8EACF454C0A35 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				47901C9002F7CF448654C32699FEC2D4 /* AddOrDeleteCustomConsentResponse.swift in Sources */,
-				9832DA7FCDBAB8700C62D3B1F16963F2 /* Bundle+Framework.swift in Sources */,
-				053EDC69C349C009E70B471DCAA43B2F /* ChoiceAllResponse.swift in Sources */,
-				9D1D83DF14B08E72FB5DD615E7EF6B6B /* ChoiceRequests.swift in Sources */,
-				ED8DE56F1AC45F19170DFBDCDCEFFB35 /* ChoiceResponses.swift in Sources */,
-				53863EEAC6EC04A953C94868FEC49F2A /* Collection.swift in Sources */,
-				E9ACD22D1C5BCF7A42EED6A352D3DCDD /* ConnectivityManager.swift in Sources */,
-				D24971AA9F9B7030C14D5878B8F8C495 /* ConsentStatus.swift in Sources */,
-				C937572239E5833B9BD3F989A0EC7AC5 /* ConsentStatusMetadata.swift in Sources */,
-				946ED9BD634516DF7281FE094881C779 /* ConsentStatusResponse.swift in Sources */,
-				D2D4025BA80DC4621D765C1B12181B97 /* ConsentViewController-iOS-dummy.m in Sources */,
-				338ADA4DD7C6D6D5DA47242779C055A7 /* Constants.swift in Sources */,
-				C2B16AA4A8846C4BE6448E8AEC14D1E5 /* CustomConsentRequest.swift in Sources */,
-				C6261C7DEDBD4F357C8BEBF0759425A4 /* Date.swift in Sources */,
-				58A6D73356334421A6C43FECB157B8B6 /* DeleteCustomConsentRequest.swift in Sources */,
-				9DF9367380F8A98CF61697B9AD38A79E /* ErrorMetricsRequest.swift in Sources */,
-				C91C9E658F587B3DA2DB0A7E70DBD92F /* GDPRPrivacyManagerViewResponse.swift in Sources */,
-				2F4B5D450E6A770940E25CE6F654A143 /* IDFAStatusReportRequest.swift in Sources */,
-				BE0DB525EBBE421DD59F12B9A09BA1D4 /* IncludeData.swift in Sources */,
-				0852D072998EB3EAF3644D6D6F6CFF80 /* MessageRequest.swift in Sources */,
-				C6CE4A8E6EA9DCAB0DF84EB0BD32072B /* MessagesRequest.swift in Sources */,
-				D507F428ACC29464177D7B86ECC27237 /* MessagesResponse.swift in Sources */,
-				5F9D7DE3EE4D15A837B1A0A203C11443 /* MetaDataRequestResponse.swift in Sources */,
-				B692D5045153FA7C9C447646E37C43CA /* NSObjectExtensions.swift in Sources */,
-				2D8BB332ED1AE1656513D2B5D1305F86 /* OSLogger.swift in Sources */,
-				4C162963061CFD67294B64643ED1C997 /* PrivacyManagerViewData.swift in Sources */,
-				AE1479E3CF561968A01BC2DE9C913901 /* PvDataRequestResponse.swift in Sources */,
-				C75DEED0D21A9C6199486A007E2DC265 /* QueryParamEncodableProtocol.swift in Sources */,
-				BA9DA2608A60B5DF65DDFA0CAB75AC96 /* SimpleClient.swift in Sources */,
-				B6600B5C8406E69D582ABB7E5C145824 /* SourcePointClient.swift in Sources */,
-				24F19F394D71926EED9AB00D96E8BC7F /* SourcepointClientCoordinator.swift in Sources */,
-				40F7F486B3CE88CF189172177C198F3C /* SPAction.swift in Sources */,
-				4AE3B08FC074AA60A4507B0AB4A45B47 /* SPCampaignEnv.swift in Sources */,
-				6217155C5A605D397280CE5B9DC0D01B /* SPCampaigns.swift in Sources */,
-				0266BD3A3F06AC7599F48CDE46A97479 /* SPCampaignType.swift in Sources */,
-				8F85AB8F972DF0D6694D9CF035A063CB /* SPCCPAConsent.swift in Sources */,
-				E280E382FA8CCBFA7C6874D11F0FED05 /* SPConsentManager.swift in Sources */,
-				331E5066AE76FCE90662CCBEF7181D88 /* SPDate.swift in Sources */,
-				07C2A05D4B726006EE5D1E3A877C8096 /* SPDelegate.swift in Sources */,
-				FCEAE9A7D86C0E939EF783A36816511A /* SPDeviceManager.swift in Sources */,
-				0A5CD2C51093BCCD820052572677ABC2 /* SPError.swift in Sources */,
-				D8D01A415641F8D4D7E57267A4EDB0A5 /* SPGDPRConsent.swift in Sources */,
-				1EBE2D97BC331948096A4644A2398EE1 /* SPIDFAStatus.swift in Sources */,
-				104634580142CFDE7F0F7FC20D9669EF /* SPJson.swift in Sources */,
-				ADDAFFE0640B80CFF4F4C81845DDD9BD /* SPLocalStorage.swift in Sources */,
-				FAD5280B8B8D43F440EA73E6E7E546D4 /* SPMessageLanguage.swift in Sources */,
-				C118C9AC089D5730EA3B42F8B939F7F8 /* SPMessageUIDelegate.swift in Sources */,
-				CD0E429547094F9FE50023394FD66417 /* SPMessageViewController.swift in Sources */,
-				7DE9B69135B46AE042CB7A607BA70243 /* SPNativeMessage.swift in Sources */,
-				67EBB57EF74768C9EF00EA3607448A80 /* SPNativeUI.swift in Sources */,
-				DF79562E24A857FA5A6EE71925B81A7D /* SPPrivacyManagerRequestResponse.swift in Sources */,
-				2C5B1C337BC1477ED5C321B394E30900 /* SPPrivacyManagerTab.swift in Sources */,
-				475C865F110F37C7C4F3ED4256E5CF1E /* SPPropertyName.swift in Sources */,
-				B6FE19F9F52705600639607CD2069277 /* SPPublisherData.swift in Sources */,
-				DD5B74BE316833CED3D2194B3CECA967 /* SPSDK.swift in Sources */,
-				F655B5F0DADC94B7960635FF6D2D05B8 /* SPString.swift in Sources */,
-				63071412245CF56B5CE56A3E2C638D2D /* SPStringifiedJSON.swift in Sources */,
-				3CC7DCFF763A7EE70193887DD9C15E81 /* SPUIColor.swift in Sources */,
-				9B6143547566F8822F4BB9869AE649E6 /* SPURLExtensions.swift in Sources */,
-				39FFD4E6BDB35DB077E124AF519A4CCC /* SPUserData.swift in Sources */,
-				2EE484BA6D443A36480400E51A432C7C /* SPUserDefaults.swift in Sources */,
-				86FB16502A47B9D02069F0A82FAF84F6 /* SPWebMessageViewController.swift in Sources */,
-				4C6101B7E73BFAAA9F71C7BE0FE8F36B /* SPWebViewExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4049,6 +4082,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		31319BCFC5345D9CA28392C1501839E1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		332727A5393C8A001AA7B35FA5D4C20E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -4088,13 +4128,6 @@
 				4BA4814575EB8ACAEB44F16D0F3CBB00 /* Wormholy-dummy.m in Sources */,
 				329D1E331CFDE43F39F2F27277A2AF55 /* WormholyConstructor.m in Sources */,
 				DEAAF1DB35FB3F9FDAB6CACC90B882E3 /* WormholyMethodSwizzling.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3CC70D19090D510B193E0C237AA8CD62 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4221,112 +4254,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4BA2C9A007E243225111B74A1AEE6BF2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F13E2E3A6C6D6A7D4238F7BB006D235B /* AddOrDeleteCustomConsentResponse.swift in Sources */,
-				86499B6FCED84C2FA58BE2E66F66B2A6 /* Bundle+Framework.swift in Sources */,
-				E44201B57DCEA6180C7E82DA23317840 /* CCPAPMConsentSnapshot.swift in Sources */,
-				F249F186E29D6A40E5E3485AE1C68D3A /* ChoiceAllResponse.swift in Sources */,
-				05944220BB1C9B120A79643BDEDAAC4D /* ChoiceRequests.swift in Sources */,
-				3F1671B1DB317554BB57EA7FD02CDA37 /* ChoiceResponses.swift in Sources */,
-				7D2E38129B017AF996FC5248BBDACF16 /* Collection.swift in Sources */,
-				294C85F84E5A95020A88CB438371FBCE /* ConnectivityManager.swift in Sources */,
-				9518BAACDC444D786764F90A8B251678 /* ConsentStatus.swift in Sources */,
-				2D31916F48142A95810C372542ABC102 /* ConsentStatusMetadata.swift in Sources */,
-				E37FDD1AC10710E7D25B224CBF62727D /* ConsentStatusResponse.swift in Sources */,
-				1F01BD7C7F30AD01BC98793E51581672 /* ConsentViewController-tvOS-dummy.m in Sources */,
-				0C50C39A1ED303ABE7D73429DBB72698 /* Constants.swift in Sources */,
-				BFB9198E41960C3F9F1FE3D4C4271F43 /* CustomConsentRequest.swift in Sources */,
-				D79E0021F121850662D4F1F8C530A3EA /* Date.swift in Sources */,
-				5B12B0D9D7B1DF75F853A1CE0CE97A5C /* DeleteCustomConsentRequest.swift in Sources */,
-				19154EB3823C5EAD2CEF78D7F81B2E45 /* ErrorMetricsRequest.swift in Sources */,
-				2E3C41BFD60716B25E41688EA2EA83D2 /* GDPRPMConsentSnapshot.swift in Sources */,
-				90A2005F795598B6A27C01839D728F06 /* GDPRPMPayload.swift in Sources */,
-				CB1DD602F26D11ABB3B6D13F42D279A6 /* GDPRPrivacyManagerViewResponse.swift in Sources */,
-				250B702BA60FB06FBF93E50CD518CAF4 /* IDFAStatusReportRequest.swift in Sources */,
-				666C27518DBB4159C3231FC64FE9A775 /* IncludeData.swift in Sources */,
-				9A781B27DCBB7CD11039F7328F8A77C9 /* LongButtonViewCell.swift in Sources */,
-				3AFBE35E03C4CF0F8F962EBD9CA94DCF /* LongButtonViewCell.xib in Sources */,
-				4A58FE28C0FF13DC8325F189A709C1EE /* MessageRequest.swift in Sources */,
-				B1A9A84E7EAB0ACAE20A023BC7AFEFDA /* MessagesRequest.swift in Sources */,
-				6E7082F3BB1398254C7FFC89CA3FFB84 /* MessagesResponse.swift in Sources */,
-				5B4F7258D2856FBAE9189EB74B8CBA25 /* MetaDataRequestResponse.swift in Sources */,
-				553AA0BEA4D073BE1F117CBABFFC68D0 /* NSObjectExtensions.swift in Sources */,
-				16476B64A67EA76BB4582B73F1CBE98A /* OSLogger.swift in Sources */,
-				FA5EF53CA48DE99EE8304DE06540E4EA /* PMCategoryManager.swift in Sources */,
-				F531C25CA962CF3430D3D202951561C1 /* PMVendorManager.swift in Sources */,
-				6A7362A684F7BE2C6C8FCA63B86D3A5D /* PrivacyManagerViewData.swift in Sources */,
-				7E357ADB2FDC66157C93F6984ECE9419 /* PvDataRequestResponse.swift in Sources */,
-				7420768A5792D40A5122083D0D58E2C2 /* QueryParamEncodableProtocol.swift in Sources */,
-				CE1C52E4B6568E30BAF4C21DCD09B59E /* SimpleClient.swift in Sources */,
-				B5CE746A2078B0E7CC783A7705D3AB5B /* SourcePointClient.swift in Sources */,
-				867116FDB336D20E8EBF9DB9395350BF /* SourcepointClientCoordinator.swift in Sources */,
-				022B1141357B4396AD2B271E32957C79 /* SPAction.swift in Sources */,
-				0F39A4E863F3AE8A2B48EFC6D0F381AC /* SPAppleTVButton.swift in Sources */,
-				6E108CC76E2DD1A2D93D368EE0E463A9 /* SPCampaignEnv.swift in Sources */,
-				916B094B72533396023C75425753E6BD /* SPCampaigns.swift in Sources */,
-				A340E0D7878F6653B071D12A01665673 /* SPCampaignType.swift in Sources */,
-				D37A8B154CA9A574EDDE845933D55ACD /* SPCCPACategoryDetailsViewController.swift in Sources */,
-				090DD00A7A9385D8B9181D17A381EBB9 /* SPCCPACategoryDetailsViewController.xib in Sources */,
-				A6F29B7818C52B9B212B4ACFF122C20C /* SPCCPAConsent.swift in Sources */,
-				52D1F2E2CC97F10ADDDD59D9CFECF641 /* SPCCPAManagePreferenceViewController.swift in Sources */,
-				F4FBB4968531BE984382F9A851FEDED5 /* SPCCPAManagePreferenceViewController.xib in Sources */,
-				75F5F7EFC8EE3DF5B8F9B96C6BEEA965 /* SPCCPANativePrivacyManagerViewController.swift in Sources */,
-				5371212E33F88DD66308C6316874B0FA /* SPCCPANativePrivacyManagerViewController.xib in Sources */,
-				E80310BC93907F55D72E360DCD75AD49 /* SPCCPAPartnersViewController.swift in Sources */,
-				34C8AB7A4BBB8FBEB85696DC7C98AAB1 /* SPCCPAPartnersViewController.xib in Sources */,
-				E310AEF625A50C9ABF605F7DD4AE4290 /* SPCCPAVendorDetailsViewController.swift in Sources */,
-				8AB2FF6177D3AA81CF0BFA955E23E2CC /* SPCCPAVendorDetailsViewController.xib in Sources */,
-				AADAC7E56A73377EEEA94C3E3BF7BB51 /* SPConsentManager.swift in Sources */,
-				BF31B4C2C120F9CC18C7AA93A18046F7 /* SPCustomViewController.swift in Sources */,
-				8E5764C4EDA1880EF50F24941B52963A /* SPCustomViewController.xib in Sources */,
-				7DF5F5CEF81E55F0916AAF4294C74310 /* SPDate.swift in Sources */,
-				50BB76696D2116DD435912E89F5145EB /* SPDelegate.swift in Sources */,
-				6AF47148A20E6CB979968091A9C0161D /* SPDeviceManager.swift in Sources */,
-				B4299CF17A30E51B3E2E3317D9C97895 /* SPError.swift in Sources */,
-				80A7E6B00A37846EB3181DA74EC61EF4 /* SPFocusableTextView.swift in Sources */,
-				9A894773ACFD99AA2B0FDDBAD579E51F /* SPGDPRCategoryDetailsViewController.swift in Sources */,
-				156FD4665CEB6CD15865CA2040CF0195 /* SPGDPRCategoryDetailsViewController.xib in Sources */,
-				BF2A8CD1F872B325917CA2331698F10F /* SPGDPRConsent.swift in Sources */,
-				D92907AB3D55185C170A983A2FFA7C90 /* SPGDPRManagePreferenceViewController.swift in Sources */,
-				97BF6421BC7C5EE4DD8B70FBCEB3F7A5 /* SPGDPRManagePreferenceViewController.xib in Sources */,
-				C357449D18157BA3C305EB5CC921EB92 /* SPGDPRNativePrivacyManagerViewController.swift in Sources */,
-				69FB27E97F03C973280695C70789DE02 /* SPGDPRNativePrivacyManagerViewController.xib in Sources */,
-				90C6CB8159AD28A3CC83B65246147390 /* SPGDPRPartnersViewController.swift in Sources */,
-				2E2E46176FB303F284C50259597D2A1F /* SPGDPRPartnersViewController.xib in Sources */,
-				7D0FFFC1862CC36177BF8E255B98BE55 /* SPGDPRVendorDetailsViewController.swift in Sources */,
-				80FD9BD89B2866DDACA4C3C74302D1AF /* SPGDPRVendorDetailsViewController.xib in Sources */,
-				804C860FFE4A6F77660003F2D54F2996 /* SPIDFAStatus.swift in Sources */,
-				620A537A8204B357A2992C13EB6F9C52 /* SPJson.swift in Sources */,
-				976EA059E6F511587739516514C36A27 /* SPLocalStorage.swift in Sources */,
-				78D6B123DA01816CFCD9F79F514EE624 /* SPMessageLanguage.swift in Sources */,
-				1C58692BE8698CA15A01733076A095FD /* SPMessageUIDelegate.swift in Sources */,
-				B8C3927244EB12B8512F2D8721EA0996 /* SPMessageViewController.swift in Sources */,
-				BF9FFDCBDEC2419464E26F13EF7C4E0C /* SPNativeMessage.swift in Sources */,
-				68005740F28FFAB7BE6F8654FE278491 /* SPNativeScreenViewController.swift in Sources */,
-				1A3D29F1D945826397052BEBC9A153FC /* SPNativeUI.swift in Sources */,
-				5C50C3C28DD5C282DA692C6E6C450ABF /* SPPMHeader.swift in Sources */,
-				1EB786BD76C5CAAEB8DF4BAD32D31DB2 /* SPPMHeader.xib in Sources */,
-				8ACA380FF967DE43952AF57B4B61002C /* SPPrivacyManagerRequestResponse.swift in Sources */,
-				98CEBB2DF52F87B152F7ED154C0239FA /* SPPrivacyManagerTab.swift in Sources */,
-				62BC72E6C069F7BD1C7254D7122AC4A5 /* SPPrivacyPolicyViewController.swift in Sources */,
-				B5C625AC4C8CE0EC448E55AC5AFBF387 /* SPPrivacyPolicyViewController.xib in Sources */,
-				3B6B3C0C41A99EC63454B43521F4A4EA /* SPPropertyName.swift in Sources */,
-				F08A4E01FBD0757A33CC516335F7DE4E /* SPPublisherData.swift in Sources */,
-				C302ABE9EBF0D07C9749847A03F2A49D /* SPQRCode.swift in Sources */,
-				6BCCFE746DB02792CCC5F450A9BB8F9B /* SPSDK.swift in Sources */,
-				72C1FC4DADA10FF2BDFE32FBD41DAE1A /* SPString.swift in Sources */,
-				DE0A0E0B1FA6A17ACBDA377879CE53CF /* SPStringifiedJSON.swift in Sources */,
-				4FDBEEF1C6A4540DD71717BB0E58FBCD /* SPUIColor.swift in Sources */,
-				9E835293723B9CAD4F0D75B3415B1A06 /* SPURLExtensions.swift in Sources */,
-				9CF4C91C6DC02CF7DDC33C24E6697720 /* SPUserData.swift in Sources */,
-				D35F05294F99BCAF81088909895D6F3A /* SPUserDefaults.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		78D9590198926D1A055E444A4A06668D /* Sources */ = {
+		65C66BE0ACD7B1F2E09BBDAEC07CAAEE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4338,6 +4266,103 @@
 			buildActionMask = 2147483647;
 			files = (
 				792EF21DE18F4303DB1C58006809F125 /* Pods-ObjC-ExampleApp-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7BA93C1E91F5855516A4F3F52395B17F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				374E83DFB990DFCDCC68285A04120EA2 /* AttributedStringVisitor.swift in Sources */,
+				EEC45B0314FE2938D7FB0E005C43B9EB /* BaseNode.swift in Sources */,
+				33F7F677CB51838EC7294E8150C92114 /* BlockBackgroundColorAttribute.swift in Sources */,
+				7A3A4BC49DA83964A1F6A19E36E59909 /* BlockQuote.swift in Sources */,
+				D3B7A7A30A5124A60D39E6FFBCAAF77F /* blocks.c in Sources */,
+				C1BFBFFE18828308C1B9B894ECAF2DB7 /* buffer.c in Sources */,
+				22442745BD844B200A41DC4DA920052F /* CGPoint+Translate.swift in Sources */,
+				B3AD072C342B6E0035E3ED822A556DF9 /* CGRect+Helpers.swift in Sources */,
+				1424C808FC74FAA793098544D52BE410 /* ChildSequence.swift in Sources */,
+				502D2B240BAFE04257C1AE312CBC035B /* cmark.c in Sources */,
+				845BCF73C4721034FE3DD25CC7D1A93A /* cmark_ctype.c in Sources */,
+				99928BCF42A6CE2741DD6D38425381B2 /* Code.swift in Sources */,
+				762C4E617CD7E6CA375224992F74AEC1 /* CodeBlock.swift in Sources */,
+				BBD2FBF5B86B651224C79E6755F6823B /* CodeBlockOptions.swift in Sources */,
+				2D943B287E36674D25AD106E04B424E5 /* ColorCollection.swift in Sources */,
+				C3A03D6AC955DDE630F61F2162B41093 /* commonmark.c in Sources */,
+				1ABB2CD31D8E70CB777ECB1304577E7D /* CustomBlock.swift in Sources */,
+				BB482FE6C806F364A01CF0BC29F6FF44 /* CustomInline.swift in Sources */,
+				24DC0F49BF32ECCF761EEDDD22BE2BED /* DebugVisitor.swift in Sources */,
+				2A80D07BE978DB7541BFE0D3916D54E4 /* Document.swift in Sources */,
+				4435EF38448930954E398C7A32207707 /* Down.swift in Sources */,
+				F9DB0B757AB75ED7948C8679C48BC8C0 /* Down-dummy.m in Sources */,
+				E5EBBFC642D110FCDDF73912CA25C71A /* DownASTRenderable.swift in Sources */,
+				4036A9966FECAB42F09A8922475DB5CC /* DownAttributedStringRenderable.swift in Sources */,
+				23B10358111EC6D5FE9F2A5E0F696477 /* DownCommonMarkRenderable.swift in Sources */,
+				F7487ADCC00375F9AA16BC2D363BD026 /* DownDebugLayoutManager.swift in Sources */,
+				669936F75787126F76507A08427C4935 /* DownDebugTextView.swift in Sources */,
+				9AA8871DBE7C5BE0F2DF1108978DB971 /* DownErrors.swift in Sources */,
+				6E38FACA38CCF85418A91EDEF28708DB /* DownGroffRenderable.swift in Sources */,
+				A6DC7F64713840FA60274AE9613B5233 /* DownHTMLRenderable.swift in Sources */,
+				5E4404282CFB99E1F359BE2578EAB7FF /* DownLaTeXRenderable.swift in Sources */,
+				C87CC6D043D906ACB7938D2DDE7F1F7F /* DownLayoutManager.swift in Sources */,
+				BAC8F3C3EE7585CF12BFEE5A5266F4DA /* DownOptions.swift in Sources */,
+				214AF75426F6BA735F2BBB8CDC12F9A6 /* DownRenderable.swift in Sources */,
+				3BF4911AE5CE7678F12948A79905E60A /* DownStyler.swift in Sources */,
+				B54165E4F839BD6F802366F75434B0BD /* DownStylerConfiguration.swift in Sources */,
+				9B71663F4E03E95AC94FB72F202C83F0 /* DownTextView.swift in Sources */,
+				BCFF0F00C56D14AE70D7E702477A3B32 /* DownXMLRenderable.swift in Sources */,
+				E994D96E0FB49B4BEAE991E2B3817794 /* Emphasis.swift in Sources */,
+				C1F89F1DC075564975055B271662A222 /* FontCollection.swift in Sources */,
+				BAB2F872ACA3F3B23E208391120201E4 /* Heading.swift in Sources */,
+				D4B3AB1E5772B04FF2A30042FAC84DB7 /* houdini_href_e.c in Sources */,
+				BFE2859DE4107099DAE512C447F21ED0 /* houdini_html_e.c in Sources */,
+				E5E835680A5684F466C41556A0999D16 /* houdini_html_u.c in Sources */,
+				763F87624BAF3474A58F999C478347C6 /* html.c in Sources */,
+				50598D15AC2CB1F0B60B45DF97EBA407 /* HtmlBlock.swift in Sources */,
+				ED2080DA867F4027D45F1D63CF95668F /* HtmlInline.swift in Sources */,
+				BA7FE50DC34F53E27740658FEF006A58 /* Image.swift in Sources */,
+				9089E53D806C98C50756CBACEFACBD43 /* inlines.c in Sources */,
+				E532FE64532159F6B60F3753A2AE99AA /* Item.swift in Sources */,
+				94B37DE5E5628A32F37F019C44DF07CA /* iterator.c in Sources */,
+				DE531ADD98163CD8CCBA59C475E5000C /* latex.c in Sources */,
+				CC19C766CD197D8487E0F7A08A2A4EAE /* LineBreak.swift in Sources */,
+				A4C6E5A326A59304CCCC6D310B0A368A /* Link.swift in Sources */,
+				BCF6D09EC7068DD8338B9A997F86D718 /* List.swift in Sources */,
+				189EFDB22897339D2D3AECCC226AD990 /* ListItemOptions.swift in Sources */,
+				0D7D8F8D3DD745B2AB32EBEDD0055251 /* ListItemParagraphStyler.swift in Sources */,
+				14748721F3EABA6304877E4CC01E2D6D /* ListItemPrefixGenerator.swift in Sources */,
+				ACC02B294165533FCB1B4E27FBC3F457 /* man.c in Sources */,
+				A58CDCAAB593C24FCB3F22F67BE1E512 /* node.c in Sources */,
+				2CBF339DBF53B3597A88BAB1F18CA7DA /* Node.swift in Sources */,
+				EA006FB2601136BBE759E8E63E1C40DE /* NSAttributedString+Helpers.swift in Sources */,
+				D807FE52D528E567A8AC0A101EF02118 /* NSAttributedString+HTML.swift in Sources */,
+				25CAC1A49C16BE629312D4FFFDB4BBDD /* NSMutableAttributedString+Attributes.swift in Sources */,
+				716053D6A4A6671EAC2CECFF1387BE3E /* Paragraph.swift in Sources */,
+				1EB3880702ADF3AB76FD14549329028B /* ParagraphStyleCollection.swift in Sources */,
+				D4C92BA48B345DBAEF28ED196BF6A6ED /* QuoteStripeAttribute.swift in Sources */,
+				BB95436609A369652D77141F398E5AC3 /* QuoteStripeOptions.swift in Sources */,
+				9C3419F7D6EBEEA3FE766862BC874FBC /* references.c in Sources */,
+				18B9E29BA05D7E016600DBF59DA4CA98 /* render.c in Sources */,
+				81DD0F4D82B89C06EAF09944B8BE8526 /* scanners.c in Sources */,
+				53BF06C3D448557F92ADC12BDD149A38 /* SoftBreak.swift in Sources */,
+				55676308D153806856AA8DD5BCD89F82 /* String+ToHTML.swift in Sources */,
+				BF9DFD7DA496B721F2BB68607FCBF02F /* Strong.swift in Sources */,
+				FCA904EE37B68ECFB34E73B5BE23E9C8 /* Styler.swift in Sources */,
+				460D0B15CAF9C135CB8DFBE91416D00F /* Text.swift in Sources */,
+				B95C29E1A4087CD21DA8A0B6FC7AF8EB /* ThematicBreak.swift in Sources */,
+				629410D6D03FEA413114278E368C6D29 /* ThematicBreakAttribute.swift in Sources */,
+				44EE3543B07D25F00B68CF01DCE0FD15 /* ThematicBreakOptions.swift in Sources */,
+				E34D689905647B6DF5F13C42B371749E /* UIFont+Traits.swift in Sources */,
+				B09E6225A40EF72B5FF01BF0F6F16EF5 /* utf8.c in Sources */,
+				F36AC8AE97D0EFFD0C107095E92EE13D /* Visitor.swift in Sources */,
+				04E91FC349F89514314BE68387CAAE0C /* xml.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7EE0E30A74A5B36C4FAFEC3C66FBABA5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4412,6 +4437,77 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CB282BA4A33F3E6460D76C45842143E8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25783A7DFCCB81461D52E72DDACB48A1 /* AddOrDeleteCustomConsentResponse.swift in Sources */,
+				2C186CEADD9054019C84DE8230A79746 /* Bundle+Framework.swift in Sources */,
+				4D6E4754AB85CA38A43B5E82124ABF31 /* ChoiceAllResponse.swift in Sources */,
+				9DD145209E8401E578C11B49F5F3D65A /* ChoiceRequests.swift in Sources */,
+				B9AD66EC489D2782D044A71BE1A777F8 /* ChoiceResponses.swift in Sources */,
+				78EA62EAB73961146F2D5E081C2CE072 /* Collection.swift in Sources */,
+				DCF53F364214141BC1C8D6391B4AD82E /* ConnectivityManager.swift in Sources */,
+				FBD9E446D29BCB831E4800D7CF780DE5 /* ConsentStatus.swift in Sources */,
+				9D21A6CECFB4371ED6F7C61BA4880FCE /* ConsentStatusMetadata.swift in Sources */,
+				DD6502A4F5B42F89D8459CDD59C7C2DA /* ConsentStatusResponse.swift in Sources */,
+				F7545F5D5E094AC99F468F923916DD58 /* ConsentViewController-iOS-dummy.m in Sources */,
+				1F5672E7C94135D532FEC111C90DDD28 /* Constants.swift in Sources */,
+				2C8047EE96EA6D25E430FE1D171CA0E8 /* CustomConsentRequest.swift in Sources */,
+				C653C18B722A016A3F6124944ED9CBEE /* Date.swift in Sources */,
+				AE5BCDC323EB202AD39FA6870D0B9506 /* DeleteCustomConsentRequest.swift in Sources */,
+				B43A31F53F1C1F92146F22D1D9D81FDA /* ErrorMetricsRequest.swift in Sources */,
+				630A9ECD902A86C90BB5F50A929EB68E /* GDPRPrivacyManagerViewResponse.swift in Sources */,
+				6F7589302207C3BF844F724C10934253 /* IDFAStatusReportRequest.swift in Sources */,
+				A8B2D6EB18BAF46E9D8FB1D7AB6B9E73 /* IncludeData.swift in Sources */,
+				90798214EE317569F8A7B526D0201747 /* MessageRequest.swift in Sources */,
+				7D20BEDB64C86638BAE3BF993179ED86 /* MessagesRequest.swift in Sources */,
+				3C720D27E298BA2471CFCCEEB841E57F /* MessagesResponse.swift in Sources */,
+				9C904643C59D92581D0C6965C880907E /* MetaDataRequestResponse.swift in Sources */,
+				6B6291FE4807E5AC8F430C56CFC67F7D /* NSObjectExtensions.swift in Sources */,
+				69CBA346A2E47632591DF9ACCE1FF22C /* OSLogger.swift in Sources */,
+				54AEFDE26531E02177BC55BCC95C7B03 /* PrivacyManagerViewData.swift in Sources */,
+				B09C6D88BEF9C62007DC43A74194FCCB /* PvDataRequestResponse.swift in Sources */,
+				A977EFBD9CE3B017F34846445977CBB3 /* QueryParamEncodableProtocol.swift in Sources */,
+				3A19003F71EE68C99B916DB62D58C5D4 /* SimpleClient.swift in Sources */,
+				FB451EB68912EEE4C258221B2C4C5189 /* SourcePointClient.swift in Sources */,
+				9B4D5E6F4798A9C650889A60F2A46057 /* SourcepointClientCoordinator.swift in Sources */,
+				3DD5056A375E1C6851CD8CCCB31F87E8 /* SPAction.swift in Sources */,
+				75889DA49EEEA94B39802361F494E86B /* SPCampaignEnv.swift in Sources */,
+				189466984306DFA00CF131DCEC21E2CD /* SPCampaigns.swift in Sources */,
+				94D0C783B1CF1327931668352744024E /* SPCampaignType.swift in Sources */,
+				A8E84039664DB68EE8348F5E4AA6EB13 /* SPCCPAConsent.swift in Sources */,
+				217F217989EC5B14A2AC4F4C56835817 /* SPConsentManager.swift in Sources */,
+				D3FCF53C796DDB5A5526325A7CD5F37D /* SPDate.swift in Sources */,
+				4C17480C7A8F330241EB05D345091F65 /* SPDelegate.swift in Sources */,
+				FBA399357D1AD1DD8369B3740472D2FC /* SPDeviceManager.swift in Sources */,
+				AF0D01E35D8991A658FFE2D29EE5A2DD /* SPError.swift in Sources */,
+				EDA108C1B69DBF67A663C703D0BD2853 /* SPGDPRConsent.swift in Sources */,
+				5231ECCEFE0AF39E275B1CD76A7A2B9C /* SPIDFAStatus.swift in Sources */,
+				7781CA98B88D4A50BD3F53074BC3E3D3 /* SPJson.swift in Sources */,
+				1D2497AED2C9953CFEB7E73AB32E3372 /* SPLocalStorage.swift in Sources */,
+				C964BE80ABCD10341DFFA654893FE068 /* SPMessageLanguage.swift in Sources */,
+				904FF4FC9BC800F4C72FBC66144C4188 /* SPMessageUIDelegate.swift in Sources */,
+				ADDC2150CAEC49C690D21243C5327A67 /* SPMessageViewController.swift in Sources */,
+				C039A397C057FEB20C5E09312123E21C /* SPNativeMessage.swift in Sources */,
+				4593A9CB2D295781A44F23A3DC40C3D7 /* SPNativeUI.swift in Sources */,
+				F2D59B5653BDBF8B9D8BE35F976082C3 /* SPPrivacyManagerRequestResponse.swift in Sources */,
+				3E7EC75E6ABD43F08C68163C2248F634 /* SPPrivacyManagerTab.swift in Sources */,
+				1873BFF189953A5AD740D2AEAC0D42CD /* SPPropertyName.swift in Sources */,
+				464683B2F95000AA0ABA9801A4155A14 /* SPPublisherData.swift in Sources */,
+				A7DD3307F3623C072E3F3335076DEDCB /* SPSDK.swift in Sources */,
+				98AE8F228AF19CBBA11E48F190C3E83D /* SPString.swift in Sources */,
+				357BB00E097D83F924FBA7FB6167C78F /* SPStringifiedJSON.swift in Sources */,
+				9F24C8046C399338FCBFD4A5B0F46F0D /* SPUIColor.swift in Sources */,
+				2501B029AF5C193D5B5931EBAE475399 /* SPURLExtensions.swift in Sources */,
+				5D12D6B14023E37E8382331FDB5256F2 /* SPUserData.swift in Sources */,
+				6F4EB6A5C1174E1F2E271B4DFE91DBF3 /* SPUserDefaults.swift in Sources */,
+				BB48D5C6D386BAAEFEFC45D26C075595 /* SPUSNatConsent.swift in Sources */,
+				608230CE3076E22421A182FFF5D215AF /* SPWebMessageViewController.swift in Sources */,
+				7BD92510C39AF145700E112D3536A5E2 /* SPWebViewExtensions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CE9B77B66F0E3FE58C8A6D1BB89B7BF8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -4463,96 +4559,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F412B30E309AD99864724F5F859415E4 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				74BCC3CF3DD4DD4845FB5DE9A37ED3A8 /* AttributedStringVisitor.swift in Sources */,
-				73181F85B5C9FE5A94E1BC461FA020D9 /* BaseNode.swift in Sources */,
-				E4D5475F434519D9B3813F103C29BD4C /* BlockBackgroundColorAttribute.swift in Sources */,
-				8AE7C717B6908A2D296F9B92EA3CDA84 /* BlockQuote.swift in Sources */,
-				9F5648C1C017255F2FD736726A11E230 /* blocks.c in Sources */,
-				78788187454EFD5ED97487765BE0F639 /* buffer.c in Sources */,
-				6DE206C1B7F851D6C588599EBDDCBB0D /* CGPoint+Translate.swift in Sources */,
-				490DAA441F268480896F4FD662E92BAC /* CGRect+Helpers.swift in Sources */,
-				9AF321AEE67E178172712CA532AFA464 /* ChildSequence.swift in Sources */,
-				79A4FF16EEDEEAFE8681125984DD5C75 /* cmark.c in Sources */,
-				6E28509635573545BEB20E69E6103F2E /* cmark_ctype.c in Sources */,
-				928DFD8734B81911B0089FEE3EF9DE6E /* Code.swift in Sources */,
-				735519602608DC4235E44F314F35EBFF /* CodeBlock.swift in Sources */,
-				3DC98E541E81E5357EAE204E4599AEDD /* CodeBlockOptions.swift in Sources */,
-				BBE7465AC7E7B7C3E0C081508A483712 /* ColorCollection.swift in Sources */,
-				8B743D0B6631FD228CE634D33513613F /* commonmark.c in Sources */,
-				E16364CCCC2EC3A2C88B551399A3C067 /* CustomBlock.swift in Sources */,
-				009AB2408CA2894D8A7BA08746194FA5 /* CustomInline.swift in Sources */,
-				28FD58F41CD639AFC86219D80CF06BC5 /* DebugVisitor.swift in Sources */,
-				87302388AFE5A784F26AA2A1334875EA /* Document.swift in Sources */,
-				E82DF2A876881A12235BDD18181C53B9 /* Down.swift in Sources */,
-				3F4887A4ED72D03CA05C90CE19016B61 /* Down-dummy.m in Sources */,
-				C3F91227A537AA9079F4AC7DA5FE342F /* DownASTRenderable.swift in Sources */,
-				9302E300C0C1C23664687B27ABE5751D /* DownAttributedStringRenderable.swift in Sources */,
-				B160A0817E30FC9E70F2EF074B1154A0 /* DownCommonMarkRenderable.swift in Sources */,
-				2199682BD06BE237B4176002356C9E94 /* DownDebugLayoutManager.swift in Sources */,
-				5A9F467AE7A955AD13D98CCE15184229 /* DownDebugTextView.swift in Sources */,
-				BE6DB1C1B054E914D27FD31F314B1C31 /* DownErrors.swift in Sources */,
-				71FCD6EF16284AE8802D8752A07045D7 /* DownGroffRenderable.swift in Sources */,
-				E0769788C6C3A712A151D917A2D7A569 /* DownHTMLRenderable.swift in Sources */,
-				80813FC563F4055FC16DBA87936BF74F /* DownLaTeXRenderable.swift in Sources */,
-				07987665D33F063D56F38605B3294C35 /* DownLayoutManager.swift in Sources */,
-				075465E922CB9ED59B364962D6502A14 /* DownOptions.swift in Sources */,
-				A0D4186E891AE76EA0525F9B91757851 /* DownRenderable.swift in Sources */,
-				9A549E583981974B03714BB2141D7110 /* DownStyler.swift in Sources */,
-				8E24C3D0089C812F269AF79ADE7AC921 /* DownStylerConfiguration.swift in Sources */,
-				C48C46E7121011EF6E81B22C817BBC79 /* DownTextView.swift in Sources */,
-				11B9E8A96ACA07172EDC904B523176D1 /* DownXMLRenderable.swift in Sources */,
-				20E36053EBA9373855545B90AF3D7E8A /* Emphasis.swift in Sources */,
-				C257A3DA14300EEAFADD46655CBB5211 /* FontCollection.swift in Sources */,
-				7A749D37729C4AEF34CAF7B1149C4F4F /* Heading.swift in Sources */,
-				EB008DD97C1D847691A11641B33BE064 /* houdini_href_e.c in Sources */,
-				CFD2B8954682EF0D7B595FECE9ED38C2 /* houdini_html_e.c in Sources */,
-				A7A3781A754F0948602AC660113594A8 /* houdini_html_u.c in Sources */,
-				723EDA59DDE39E557925C0632B9EFFE7 /* html.c in Sources */,
-				DE3F2F06DF59924DE4221370E9335C36 /* HtmlBlock.swift in Sources */,
-				C27ADD338FBDDD52230D69EA2FAFFCF1 /* HtmlInline.swift in Sources */,
-				011B815709A47B8B6C76BD4FB3F1B99F /* Image.swift in Sources */,
-				DF12FFE3D048FC3B0A3BB02BE3EF9815 /* inlines.c in Sources */,
-				6532738946D9652862953EB33E0AA551 /* Item.swift in Sources */,
-				9554144B844C867CADE860A5473F120C /* iterator.c in Sources */,
-				F60312A3EEF16A1F171D651461229C5B /* latex.c in Sources */,
-				4F4ECBFF3F7F80C5721F0FF85BD6F87C /* LineBreak.swift in Sources */,
-				61174EA572FE86EB7B00F68C5DFEC09B /* Link.swift in Sources */,
-				DC6C984069F0A3CDC8A5556F07A7B449 /* List.swift in Sources */,
-				551B7FA521CC47FA121B5F593EDF8B12 /* ListItemOptions.swift in Sources */,
-				EB846114F6A4C80FEF6ECBBA928BD872 /* ListItemParagraphStyler.swift in Sources */,
-				60B6EADD129B1B8C8391FA0449D7D8D7 /* ListItemPrefixGenerator.swift in Sources */,
-				540EFD0374C18608750A36CBC3D7919E /* man.c in Sources */,
-				C0678987BD8FEDA131A9F5C49E6D9A47 /* node.c in Sources */,
-				F7DEEC0F902DF9325D2F32E22F2B7F78 /* Node.swift in Sources */,
-				F924967BE18FCCF7C6AE4B4AE17B4F1D /* NSAttributedString+Helpers.swift in Sources */,
-				4600EE97D03EA80B64934FF6C53F09B3 /* NSAttributedString+HTML.swift in Sources */,
-				A9F77D665A03B2E7C46E6C60CA440FFF /* NSMutableAttributedString+Attributes.swift in Sources */,
-				0424A7BCA93D1423F1F13C0CC78C0ADB /* Paragraph.swift in Sources */,
-				30820BF2A62C49555E4911838D972E0C /* ParagraphStyleCollection.swift in Sources */,
-				AAB454A021CE70A3CD26D3B37AB03F7F /* QuoteStripeAttribute.swift in Sources */,
-				09EA6271886FA501E86A1166A39E1FAD /* QuoteStripeOptions.swift in Sources */,
-				59E8717947DC925959565344B7D69CB0 /* references.c in Sources */,
-				5735E3C808A76B68719E149CD381834D /* render.c in Sources */,
-				B475266C0902180E7292ED319A7835CC /* scanners.c in Sources */,
-				D6F12DA3A1B9775C902A2315E95DB90A /* SoftBreak.swift in Sources */,
-				1A08615492ABE417D55C41C1C250E0A6 /* String+ToHTML.swift in Sources */,
-				7A1E2FF2A212CB72E0F46FB68737DFEC /* Strong.swift in Sources */,
-				7B7BCC772B2DE38DFB7C66B651E9B406 /* Styler.swift in Sources */,
-				7D5B9413C851E75B68D60D434F291050 /* Text.swift in Sources */,
-				CAAF8A9D1168E908BB109846664E441D /* ThematicBreak.swift in Sources */,
-				F10D3CB8B1AC2B271EDE12A75091D79B /* ThematicBreakAttribute.swift in Sources */,
-				7A576C0C9A569B0D2138F5D484E44B2E /* ThematicBreakOptions.swift in Sources */,
-				2431F09F8A90D48F9B3A930199CA78E6 /* UIFont+Traits.swift in Sources */,
-				8BAE42566E46970C56FB4A23F9FC44AE /* utf8.c in Sources */,
-				1D77C403F6D6009A8C80C71CFFC75683 /* Visitor.swift in Sources */,
-				814DAA1C5F02924F9AAB2FEE3CD52528 /* xml.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		FD1731ED48D44B9499ED4C8052854651 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -4572,289 +4578,289 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		075B88CA3D16BE1D079CFB8B2CED2D93 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = E66548A20731577D8A2083227C16C235 /* PBXContainerItemProxy */;
-		};
-		0EDAD8D01C099B1FF23D4C9B1AD8BE4F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Nimble-iOS";
-			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
-			targetProxy = DB09F8DB9B987E2BFA2F0BC8CF7ECF04 /* PBXContainerItemProxy */;
-		};
-		18A90A23BB7A826BD8A20B4209DC5BF2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Quick-iOS";
-			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
-			targetProxy = B0B102E5BEC1506B21469EC79383B8DD /* PBXContainerItemProxy */;
-		};
-		1B19D6FC02449776F00FCA4E7874AC28 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Quick-iOS";
-			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
-			targetProxy = BAAB2BA6E798603AFF76C312C6545A69 /* PBXContainerItemProxy */;
-		};
-		1D817EEB323678729645004FA4B3A856 /* PBXTargetDependency */ = {
+		00C2CB860908C3EA5C13990EF701A472 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Wormholy;
 			target = 3E73ED39761329414C06DD4486C5058E /* Wormholy */;
-			targetProxy = 7FC1E7F40EBB1ED2DAD826E9C3F480F5 /* PBXContainerItemProxy */;
+			targetProxy = F779F5BC881B23107D19A4D140B73FD0 /* PBXContainerItemProxy */;
 		};
-		1E8A2DB665A5184352A92F0F83F0F1D0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Nimble-iOS";
-			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
-			targetProxy = 2EDAAF5E7485CD89B2E1E52E6C4C94CE /* PBXContainerItemProxy */;
-		};
-		2B416DF13E98D18DFC80DB68F8498D7C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "SwiftLint-iOS";
-			target = 2B03D5FD26A26B7D62142EA4492AEB83 /* SwiftLint-iOS */;
-			targetProxy = 8D8FDFDEC91C6BD6F531796521D63437 /* PBXContainerItemProxy */;
-		};
-		2F0E7818127100F77F31CF8207B4BD63 /* PBXTargetDependency */ = {
+		05269D079B7D902026190F96099BE8CB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Wormholy;
 			target = 3E73ED39761329414C06DD4486C5058E /* Wormholy */;
-			targetProxy = 74DB6E2F7A9669C10C100A14575F23CF /* PBXContainerItemProxy */;
+			targetProxy = 0EB16C9D93A0950B058513E5BE395A35 /* PBXContainerItemProxy */;
 		};
-		2F74B75149D368122283CFAC9CAECCD3 /* PBXTargetDependency */ = {
+		10A537EA4B9333C339D98470550E9B5D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "SwiftLint-tvOS";
-			target = 07B93100044EF37C3FEE234DF77D3C11 /* SwiftLint-tvOS */;
-			targetProxy = 160DA45EB7E3B5AFE7FEAE476FCAC691 /* PBXContainerItemProxy */;
+			name = "Nimble-iOS";
+			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
+			targetProxy = 5B9075E549AC7D9F7E2DB6E432E08F90 /* PBXContainerItemProxy */;
 		};
-		3363DC0678ADB85A40A256FA239B4A63 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = 3981021BAE6DDB2CED3031CD875B1C97 /* PBXContainerItemProxy */;
-		};
-		35877D1287C2F4EECE315A7D7EB99B56 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "SwiftLint-iOS";
-			target = 2B03D5FD26A26B7D62142EA4492AEB83 /* SwiftLint-iOS */;
-			targetProxy = A3C758576C043E615550FDDCB27C6C9C /* PBXContainerItemProxy */;
-		};
-		39A04234650125EF45634E25236141F5 /* PBXTargetDependency */ = {
+		12C63C8F542029F4964E1768AF58C24F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = JSONView;
 			target = 2450D89327C2F3947256DE8768B4B9B9 /* JSONView */;
-			targetProxy = 851BF360487D67C059F1289AC3BA4655 /* PBXContainerItemProxy */;
+			targetProxy = 9FBBB4AD5E8BDA2CBFDFCCBF3D786162 /* PBXContainerItemProxy */;
 		};
-		3DC312B44FDDA696FE608DFD4723DCCF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = IQKeyboardManagerSwift;
-			target = B490E7485944099E16C9CBD79119D1D4 /* IQKeyboardManagerSwift */;
-			targetProxy = 68F16B978DBB330A624A46882F55ECF6 /* PBXContainerItemProxy */;
-		};
-		42886AB822FDC8BF3197127020545BF1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = E854AD53877B879B12DD7690F85CD7CB /* PBXContainerItemProxy */;
-		};
-		44DC54C6F646DEFD3F8AF51915989AAD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Down;
-			target = B4575FF01775E963E58050542C9A4E7A /* Down */;
-			targetProxy = 4068E76DA8866A0A00CA3EF6A870C455 /* PBXContainerItemProxy */;
-		};
-		4E170EAF4163585151684FDDB79F5B85 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Nimble-iOS";
-			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
-			targetProxy = 849E8755F5041D971F3A43E03A368BA0 /* PBXContainerItemProxy */;
-		};
-		5A98820D808532CC408A300A19B0A752 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = 7319D8A605BF362249B260F728C6A27B /* PBXContainerItemProxy */;
-		};
-		5B3C724543EE36576BF48FF1E09C9DA6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Wormholy-Wormholy";
-			target = 93CEC7FFB57A497DE49471C5D9517C13 /* Wormholy-Wormholy */;
-			targetProxy = A7DE4E6A2521C0665905019E6805BB72 /* PBXContainerItemProxy */;
-		};
-		5CCF4C706A1D1458C9C46AEA1EB56278 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = A6902F039426B910CB3E424649ADA3B0 /* PBXContainerItemProxy */;
-		};
-		5FC130EC539F3691217DE2317DCE7C6B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = 77332E9B14AC24397A1F5EB54495A2D3 /* PBXContainerItemProxy */;
-		};
-		7042EF2FBCE9A3249414AE81B20F34C7 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Quick-iOS";
-			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
-			targetProxy = DDC91AC0937E58E1AF50AE9EAB476DB5 /* PBXContainerItemProxy */;
-		};
-		7136B7A3AAA1039B79F83ACCCB60A0E4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = D0A6F9A00BE76C59625B593065F562E6 /* PBXContainerItemProxy */;
-		};
-		78DEFD6750A5735F10E0AF81F722B116 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Nimble-iOS";
-			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
-			targetProxy = 1F3C231D6B13D5DE5E0A9EC365069B65 /* PBXContainerItemProxy */;
-		};
-		7D5E31321E2A99C00CADD9777567F7A0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Down;
-			target = B4575FF01775E963E58050542C9A4E7A /* Down */;
-			targetProxy = 17ADF9B50F46F144DF3792C6B8BE1C6F /* PBXContainerItemProxy */;
-		};
-		7F0196C32D06A0C139CAD340817DD685 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS-ConsentViewController";
-			target = F9B2C41D8F3FCEB2256091CF2667D600 /* ConsentViewController-iOS-ConsentViewController */;
-			targetProxy = DA69B6B9170DB3C1CE40EB4F81112C14 /* PBXContainerItemProxy */;
-		};
-		80E3EDED6E1062FE5A4BE025717B3C29 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-tvOS";
-			target = 94DAD332BFFC672BBE92726504A716F8 /* ConsentViewController-tvOS */;
-			targetProxy = 5C1694DC4AF56225D6C8435D8A4FDA3D /* PBXContainerItemProxy */;
-		};
-		8A1ACC1190D55E45387BD7F5F98F572C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Quick-iOS";
-			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
-			targetProxy = 2F5D352CA1E241788AC7956372ACC713 /* PBXContainerItemProxy */;
-		};
-		8A4BCAC7BA434BCE548A6025E547972D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = 2D19851531AA66A331D25160F0854368 /* PBXContainerItemProxy */;
-		};
-		92EDECA4DA5B5959ABA5D934FB0C7628 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Nimble-iOS";
-			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
-			targetProxy = F336E1CABE76013355A971615C0FB7CD /* PBXContainerItemProxy */;
-		};
-		9800DC88D5370195F85B179B5619555B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Wormholy;
-			target = 3E73ED39761329414C06DD4486C5058E /* Wormholy */;
-			targetProxy = 665D4055195737200E37AB1FDDC6E530 /* PBXContainerItemProxy */;
-		};
-		9D9FD4A63888EE6BF12E76B158872B23 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-tvOS";
-			target = 94DAD332BFFC672BBE92726504A716F8 /* ConsentViewController-tvOS */;
-			targetProxy = 964C2703089A64E332846FE9BAA4CE8C /* PBXContainerItemProxy */;
-		};
-		ADF0996DB9CCE99D066ED3470CFA4F46 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Nimble-tvOS";
-			target = A897D2D55F6D87795224F846F8ED3A36 /* Nimble-tvOS */;
-			targetProxy = E9CD623118892B6A1DF2DC05E5FAD7A2 /* PBXContainerItemProxy */;
-		};
-		B63688CBF35F174CBED68F23ED53CBF9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Wormholy;
-			target = 3E73ED39761329414C06DD4486C5058E /* Wormholy */;
-			targetProxy = D84E7950FD5950F95424229E03FB50B9 /* PBXContainerItemProxy */;
-		};
-		B8469307BAC3AB2165E261F7D86E7BE2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Quick-iOS";
-			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
-			targetProxy = 9F3C60976E05B34067101C6905388FA2 /* PBXContainerItemProxy */;
-		};
-		C3E7EDCA29B83C63E30A40089C71AC2D /* PBXTargetDependency */ = {
+		21152E2139178304A85BB77BF9C32862 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "SwiftLint-iOS";
 			target = 2B03D5FD26A26B7D62142EA4492AEB83 /* SwiftLint-iOS */;
-			targetProxy = D6F0CECEDF1BD87AEA0D8EBFEA41916F /* PBXContainerItemProxy */;
+			targetProxy = 46704566BA8FE276ED864B18CEAA2292 /* PBXContainerItemProxy */;
 		};
-		C5ADAFD7D106B2ED8AD9D8351067B913 /* PBXTargetDependency */ = {
+		21842F441F9F640D02252DBAE1BE9CDB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = 6500B4468F2188530EC7A44FE7116AC4 /* PBXContainerItemProxy */;
+			name = Wormholy;
+			target = 3E73ED39761329414C06DD4486C5058E /* Wormholy */;
+			targetProxy = A16C4725D26014A305F0FF849BF43E82 /* PBXContainerItemProxy */;
 		};
-		CCBA251BD08EF87D77EF9B0A64BFDF6A /* PBXTargetDependency */ = {
+		2E424ED6963BF170ED94D045CFB00DE2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "ConsentViewController-tvOS-ConsentViewController";
-			target = 5D0718052BFEE502C9D9BEC44BDCFA76 /* ConsentViewController-tvOS-ConsentViewController */;
-			targetProxy = E30890D50B629A51F163C20FB9561E5A /* PBXContainerItemProxy */;
+			name = "Nimble-iOS";
+			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
+			targetProxy = 229D5C703D169B3366C093324420CF54 /* PBXContainerItemProxy */;
 		};
-		D04F94F7505A91A31643AB458CEC8C6C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Quick-iOS";
-			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
-			targetProxy = 7142DE2902FF3476C02A8A5944E03F03 /* PBXContainerItemProxy */;
-		};
-		D0657478CA67403C33E2351BCC8E1F61 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = 7608F9B295C7813537752A00FF08D602 /* PBXContainerItemProxy */;
-		};
-		E223A9349FA2A956831D70D9CE0B1946 /* PBXTargetDependency */ = {
+		421CD1A69D0D1DD7EF173998D1FB0156 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Quick-tvOS";
 			target = 28BE3303E3F4ECC2BDF79B1D886D2E74 /* Quick-tvOS */;
-			targetProxy = 716504E32A837C4DDB3D19C0D7FA8C0C /* PBXContainerItemProxy */;
+			targetProxy = B806FB04FCD51974D1F8C6B58B201417 /* PBXContainerItemProxy */;
 		};
-		E5D343636409627A97789EF74AEA1B54 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ConsentViewController-iOS";
-			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
-			targetProxy = D07EF2D8482B9AE84165AF445223CCC6 /* PBXContainerItemProxy */;
-		};
-		F533353FF0CCE7F8B901A1C8BACEF6D6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "SwiftLint-iOS";
-			target = 2B03D5FD26A26B7D62142EA4492AEB83 /* SwiftLint-iOS */;
-			targetProxy = 41C44B10C37CAD3B796060AC4982F7A9 /* PBXContainerItemProxy */;
-		};
-		F7871A369EF73AA466B6B033E11CA4E4 /* PBXTargetDependency */ = {
+		44D6DC5773EADB1C99A61400BBE793E5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Nimble-iOS";
 			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
-			targetProxy = FE22FFBBBCE76E91A82574D671FB4068 /* PBXContainerItemProxy */;
+			targetProxy = F87A63B38C5CDDF85AA817B102700E1D /* PBXContainerItemProxy */;
 		};
-		FF4DA7E4FD840A4E86416448BC649851 /* PBXTargetDependency */ = {
+		450E1AA5592C4855A3D47198E68C9E78 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Quick-iOS";
+			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
+			targetProxy = 8B00ABAF7623D3023E779479836CE01A /* PBXContainerItemProxy */;
+		};
+		4BD5749091913957710214DE471EF4B4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = F92EC957ED3B918DECA4CA74CF133E97 /* PBXContainerItemProxy */;
+		};
+		4C0E7EC20AF5D42E2999700D5D73965A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "SwiftLint-iOS";
+			target = 2B03D5FD26A26B7D62142EA4492AEB83 /* SwiftLint-iOS */;
+			targetProxy = 1E6DB739C36D41A4F1483E8B1D2F3CAA /* PBXContainerItemProxy */;
+		};
+		597920466A1435C84267C52F2C8D31BC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = 2FD7695B7399015B1EAE65CD7FC87CDD /* PBXContainerItemProxy */;
+		};
+		5B1F06AAAF8C183FCFCD6AFE91D7861B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Down;
 			target = B4575FF01775E963E58050542C9A4E7A /* Down */;
-			targetProxy = A5926497343F913E5972E50D9AA79AD0 /* PBXContainerItemProxy */;
+			targetProxy = 86B3F5254DDDF14F38C28DF828FF01CD /* PBXContainerItemProxy */;
+		};
+		6B8A78046B7D8A023E79998EA91FA50C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IQKeyboardManagerSwift;
+			target = B490E7485944099E16C9CBD79119D1D4 /* IQKeyboardManagerSwift */;
+			targetProxy = EC1DEF749FDAC7AE58073DD1198B55F8 /* PBXContainerItemProxy */;
+		};
+		6D4A18368B1AB8248957C149A15CA6A5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Nimble-iOS";
+			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
+			targetProxy = 502CB354C59C7F8FE0032A29DC071D20 /* PBXContainerItemProxy */;
+		};
+		72152A6048D9F3E501C45685B2B01B2D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = 3EFD0DA2D60C5E8962D5214512D41CC0 /* PBXContainerItemProxy */;
+		};
+		7A3E34046FEEBB4CB032090E5E743540 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Quick-iOS";
+			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
+			targetProxy = C382818C5B0380876C791CAB0046244F /* PBXContainerItemProxy */;
+		};
+		7E11C12519E54B0A1596B20575F4626B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "SwiftLint-iOS";
+			target = 2B03D5FD26A26B7D62142EA4492AEB83 /* SwiftLint-iOS */;
+			targetProxy = CABA4DF7BC11EEDBC646ED0663B75337 /* PBXContainerItemProxy */;
+		};
+		7E5252E28A8880C286C6E3515EDDADC2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = 821BEF280C2F14783681D05F2BA439AB /* PBXContainerItemProxy */;
+		};
+		7EAE540829CCFAE20A28002E38476954 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = 98983E4558C9437DF6E83AA6D3825A83 /* PBXContainerItemProxy */;
+		};
+		86C04C0AFD21277A4029F80E07EEC054 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Wormholy-Wormholy";
+			target = 93CEC7FFB57A497DE49471C5D9517C13 /* Wormholy-Wormholy */;
+			targetProxy = 5616F39BEAFDE287E670B9E628749E64 /* PBXContainerItemProxy */;
+		};
+		88ACD56619ECD6477866C1A4ED548C2D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = 901AFDAAE712CA40A3B61387EB2EA645 /* PBXContainerItemProxy */;
+		};
+		88C5045F2E4D752793D29181889DCF9C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Nimble-tvOS";
+			target = A897D2D55F6D87795224F846F8ED3A36 /* Nimble-tvOS */;
+			targetProxy = 90A13DB2B3DD2D1C29091EF2B566CCF5 /* PBXContainerItemProxy */;
+		};
+		8F6C468D6785F8DD08B2242DE2B88E20 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = 25342608FE1929AA4B56E7AE30A09E66 /* PBXContainerItemProxy */;
+		};
+		91D51B0983DE1B53648D6870289CBCEF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "SwiftLint-iOS";
+			target = 2B03D5FD26A26B7D62142EA4492AEB83 /* SwiftLint-iOS */;
+			targetProxy = 33C6F846C372CD1410735885705FF51C /* PBXContainerItemProxy */;
+		};
+		96F4FD01D743A4566EA1A053A5971B84 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = B8DD3AB4756D360B5A592180D30433FC /* PBXContainerItemProxy */;
+		};
+		98A4438EE7F40B40F0D7A8BFD849B392 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Nimble-iOS";
+			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
+			targetProxy = D910B25BA337221BF00A503BA7512B1E /* PBXContainerItemProxy */;
+		};
+		A79AE7A6A7EA626209C5BDC01E8AC5CF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Down;
+			target = B4575FF01775E963E58050542C9A4E7A /* Down */;
+			targetProxy = D1A57FD56DC1BA996073B927D990D016 /* PBXContainerItemProxy */;
+		};
+		ACE42A67D806A29DEE2F049D94E738B6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Quick-iOS";
+			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
+			targetProxy = DC8530C67103BB9859BA58346A2238E4 /* PBXContainerItemProxy */;
+		};
+		AE81D426D55C1309E850FCD8247141C3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Down;
+			target = B4575FF01775E963E58050542C9A4E7A /* Down */;
+			targetProxy = 58F80337938A5DCE37BD1E57AAA210C3 /* PBXContainerItemProxy */;
+		};
+		B4EC0F8508D741B2B9AE8DFAF7A2BD58 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-tvOS-ConsentViewController";
+			target = 5D0718052BFEE502C9D9BEC44BDCFA76 /* ConsentViewController-tvOS-ConsentViewController */;
+			targetProxy = BD749A9F459A72C355F483A0217FA836 /* PBXContainerItemProxy */;
+		};
+		BBE328FD7BAFE453EED509B56AF1BEAA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Quick-iOS";
+			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
+			targetProxy = DAD44AC88A8FD4AF7A7C66B9823898E6 /* PBXContainerItemProxy */;
+		};
+		C0F0E25BDB702888D19EF370C140EE5F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Quick-iOS";
+			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
+			targetProxy = C51F702BEAC827482CFE4B7B2A9D3751 /* PBXContainerItemProxy */;
+		};
+		C40855A43EE5843E4B5036EDEA4D3D89 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = C1A46E0188AB1346A1B7114FB6B87674 /* PBXContainerItemProxy */;
+		};
+		C679F612E8CEB34497D5FC82AE3C2D34 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Wormholy;
+			target = 3E73ED39761329414C06DD4486C5058E /* Wormholy */;
+			targetProxy = 9F7615A0C882490334863C77A7071E0E /* PBXContainerItemProxy */;
+		};
+		CB501D5E7C66012C2115C590D6FE1EF0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-tvOS";
+			target = 94DAD332BFFC672BBE92726504A716F8 /* ConsentViewController-tvOS */;
+			targetProxy = A1923F91BD1183F3A724B4D0B25A3136 /* PBXContainerItemProxy */;
+		};
+		D54449243D110E5DCBA3C6F1E201C6B3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS-ConsentViewController";
+			target = F9B2C41D8F3FCEB2256091CF2667D600 /* ConsentViewController-iOS-ConsentViewController */;
+			targetProxy = 2BE2349261F6DCFC6ABF8B1629ADDB0C /* PBXContainerItemProxy */;
+		};
+		DBEC714D2F90ABC5F77733F53E0FC210 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "SwiftLint-tvOS";
+			target = 07B93100044EF37C3FEE234DF77D3C11 /* SwiftLint-tvOS */;
+			targetProxy = B51E6CE363832D3922F3ECBFE5B61E49 /* PBXContainerItemProxy */;
+		};
+		E54E773DA433A0BC289339D9F1E0EE47 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Quick-iOS";
+			target = 89B29D1C701EFC639B36BC482FE72F13 /* Quick-iOS */;
+			targetProxy = B34E818879775E5CA86BC97DE3AD1D4A /* PBXContainerItemProxy */;
+		};
+		E715548AFDD927BA2332CF0E9E243B6B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-tvOS";
+			target = 94DAD332BFFC672BBE92726504A716F8 /* ConsentViewController-tvOS */;
+			targetProxy = B5E6FB98604B14402B21577689ACAF40 /* PBXContainerItemProxy */;
+		};
+		E8006DA537E8B1B1A35D3C8B502C725D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = CEDB05DD946DD30B08CEE06608262538 /* PBXContainerItemProxy */;
+		};
+		ECE52E1A7420444F3491AD9C740EDA86 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Nimble-iOS";
+			target = 3AAFED87F58BAA2AC3177A35C2CF5B23 /* Nimble-iOS */;
+			targetProxy = 0651035C2449812536FB714428B5F2E1 /* PBXContainerItemProxy */;
+		};
+		F6CEAD9133997D5F3C386BCACE4BCC1E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ConsentViewController-iOS";
+			target = 84E1147DCA59477E2E390B109585DCAF /* ConsentViewController-iOS */;
+			targetProxy = 0EEF8927DE90936A9CCDDB7C4E0FA23B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		034060E3299C26CF05C8466E94C0CFAA /* Release */ = {
+		038C8BF2061ABB86B49E1C7E14AF435A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BB99BA06CBE242DB60211532AF6D3446 /* Wormholy.release.xcconfig */;
+			baseConfigurationReference = 64112AD2026682A3DE57EEDB1D2865BA /* ConsentViewController-iOS.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGNING_ALLOWED = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/Wormholy";
-				IBSC_MODULE = Wormholy;
-				INFOPLIST_FILE = "Target Support Files/Wormholy/ResourceBundle-Wormholy-Wormholy-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				PRODUCT_NAME = Wormholy;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/ConsentViewController-iOS";
+				IBSC_MODULE = ConsentViewController;
+				INFOPLIST_FILE = "Target Support Files/ConsentViewController-iOS/ResourceBundle-ConsentViewController-ConsentViewController-iOS-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				PRODUCT_NAME = ConsentViewController;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = bundle;
 			};
-			name = Release;
+			name = Debug;
 		};
 		0713164992F5E521347FC482D5A47111 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -4890,6 +4896,23 @@
 			};
 			name = Debug;
 		};
+		0AA4CA4692F1D22D2886CAF90EE73F4D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 86BA2F35C05C02BCABF8F3D30603A915 /* ConsentViewController-tvOS.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/ConsentViewController-tvOS";
+				IBSC_MODULE = ConsentViewController;
+				INFOPLIST_FILE = "Target Support Files/ConsentViewController-tvOS/ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist";
+				PRODUCT_NAME = ConsentViewController;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		0D2ED34DCB28393F6C51CDEB599E08AD /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BB99BA06CBE242DB60211532AF6D3446 /* Wormholy.release.xcconfig */;
@@ -4924,23 +4947,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
-		};
-		190D5C7758FF1D54F71C8F342B3667C8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 42A51D82D7093FF4E1BF5B76F611BD58 /* Wormholy.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGNING_ALLOWED = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/Wormholy";
-				IBSC_MODULE = Wormholy;
-				INFOPLIST_FILE = "Target Support Files/Wormholy/ResourceBundle-Wormholy-Wormholy-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				PRODUCT_NAME = Wormholy;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Debug;
 		};
 		1DC3F2797085B0CA43FDFB9E557063FA /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -5028,6 +5034,40 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		256E7B95EC0D0069BF860F45CE3735AB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1836C79E905BFED1185217A961DE5924 /* Down.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Down/Down-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Down/Down-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/Down/Down.modulemap";
+				PRODUCT_MODULE_NAME = Down;
+				PRODUCT_NAME = Down;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.1;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -5157,23 +5197,6 @@
 			};
 			name = Release;
 		};
-		384C8422CBAEAEB8CC830775CF0C17AE /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB6F0B2251A6458ABB109B0A14981E5F /* ConsentViewController-iOS.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGNING_ALLOWED = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/ConsentViewController-iOS";
-				IBSC_MODULE = ConsentViewController;
-				INFOPLIST_FILE = "Target Support Files/ConsentViewController-iOS/ResourceBundle-ConsentViewController-ConsentViewController-iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = ConsentViewController;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Debug;
-		};
 		39560CD8986628B3DE0D6DA585AE79C3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D1725DC51D44B4115DEE79C60D671DC /* Quick-tvOS.release.xcconfig */;
@@ -5296,6 +5319,58 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		492830E9156B2401DFA3D14E7591662A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 14CC9F07ACC4CAD18A2A4F5AFF7D3D44 /* Down.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Down/Down-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Down/Down-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/Down/Down.modulemap";
+				PRODUCT_MODULE_NAME = Down;
+				PRODUCT_NAME = Down;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.1;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		4A95C1AFAD72FC01D53B728D5F357EBE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6A67307522A739D21C03BC55C7799A3F /* ConsentViewController-tvOS.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/ConsentViewController-tvOS";
+				IBSC_MODULE = ConsentViewController;
+				INFOPLIST_FILE = "Target Support Files/ConsentViewController-tvOS/ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist";
+				PRODUCT_NAME = ConsentViewController;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
 		};
@@ -5513,6 +5588,41 @@
 			};
 			name = Release;
 		};
+		60C15527DF340DF26B621214FB030CAF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 64112AD2026682A3DE57EEDB1D2865BA /* ConsentViewController-iOS.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS.modulemap";
+				PRODUCT_MODULE_NAME = ConsentViewController;
+				PRODUCT_NAME = ConsentViewController;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		65205A188656B883537EA60B1529DD25 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FE3E5ADA5583AAAD42F4FE34CFB5CC81 /* JSONView.release.xcconfig */;
@@ -5541,6 +5651,42 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		67DD053751815F753B300B061856558C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8E2C263BAF9DFE562CB999D63FBED33A /* ConsentViewController-iOS.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS.modulemap";
+				PRODUCT_MODULE_NAME = ConsentViewController;
+				PRODUCT_NAME = ConsentViewController;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -5697,41 +5843,6 @@
 			};
 			name = Debug;
 		};
-		8A655DB17ACDBBD2F05B8C34632D782C /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 14CC9F07ACC4CAD18A2A4F5AFF7D3D44 /* Down.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Down/Down-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Down/Down-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/Down/Down.modulemap";
-				PRODUCT_MODULE_NAME = Down;
-				PRODUCT_NAME = Down;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.1;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		8A9FC18B08922168093C8CC63C276987 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 53C3E3B8AC4E7FFCA4CC1428AD662243 /* Pods-ConsentViewController_Example.debug.xcconfig */;
@@ -5798,6 +5909,40 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		8D4B060DDF39812315CFFE45645C5ACA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6A67307522A739D21C03BC55C7799A3F /* ConsentViewController-tvOS.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS.modulemap";
+				PRODUCT_MODULE_NAME = ConsentViewController;
+				PRODUCT_NAME = ConsentViewController;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -5873,6 +6018,23 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
+		};
+		9738997B48739CF90A3A4CB01DD26748 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BB99BA06CBE242DB60211532AF6D3446 /* Wormholy.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/Wormholy";
+				IBSC_MODULE = Wormholy;
+				INFOPLIST_FILE = "Target Support Files/Wormholy/ResourceBundle-Wormholy-Wormholy-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				PRODUCT_NAME = Wormholy;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
 		};
 		9BD94977283C2AD5CDD617F193F901D3 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -6173,163 +6335,6 @@
 			};
 			name = Release;
 		};
-		BC8E3FDB83C91D81304CB62A42693ABB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB6F0B2251A6458ABB109B0A14981E5F /* ConsentViewController-iOS.debug.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS.modulemap";
-				PRODUCT_MODULE_NAME = ConsentViewController;
-				PRODUCT_NAME = ConsentViewController;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		BCED61788E7B27C9982A2FFF116B5137 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1836C79E905BFED1185217A961DE5924 /* Down.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Down/Down-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Down/Down-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/Down/Down.modulemap";
-				PRODUCT_MODULE_NAME = Down;
-				PRODUCT_NAME = Down;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.1;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		BDDE7E55793E7BE20A6BAD5F39B291EA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7F964AB7CFB89116902A252500ADD788 /* ConsentViewController-tvOS.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGNING_ALLOWED = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/ConsentViewController-tvOS";
-				IBSC_MODULE = ConsentViewController;
-				INFOPLIST_FILE = "Target Support Files/ConsentViewController-tvOS/ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist";
-				PRODUCT_NAME = ConsentViewController;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Debug;
-		};
-		C8B0F5FA56D6CFFEBFB9D5FF4235CAC2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = ABC0C636E983A146EF76F6E672AA40B3 /* ConsentViewController-iOS.release.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/ConsentViewController-iOS/ConsentViewController-iOS.modulemap";
-				PRODUCT_MODULE_NAME = ConsentViewController;
-				PRODUCT_NAME = ConsentViewController;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		D28FD60D4CAB0A43D841755EA342D905 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F0594D4B29BF1FFCBEBE609EBC5B50EB /* ConsentViewController-tvOS.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS.modulemap";
-				PRODUCT_MODULE_NAME = ConsentViewController;
-				PRODUCT_NAME = ConsentViewController;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		D3A67E8404FC38559FF4E0D88769BB47 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CA3196906642F926213FD7D7BE1EEEE3 /* Pods-SPGDPRExampleAppUITests.debug.xcconfig */;
@@ -6477,6 +6482,23 @@
 			};
 			name = Debug;
 		};
+		DB102AB77D640D3D408A3A2CA016EA9D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 42A51D82D7093FF4E1BF5B76F611BD58 /* Wormholy.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/Wormholy";
+				IBSC_MODULE = Wormholy;
+				INFOPLIST_FILE = "Target Support Files/Wormholy/ResourceBundle-Wormholy-Wormholy-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				PRODUCT_NAME = Wormholy;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
 		E424F35D4AF69317585EE0726154027A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 24E349AFF4609C8B48DE335DAEC14E7C /* Pods-ConsentViewController_ExampleTests.debug.xcconfig */;
@@ -6581,40 +6603,6 @@
 			};
 			name = Debug;
 		};
-		EE5514A15376A94A2870ABFD60720691 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7F964AB7CFB89116902A252500ADD788 /* ConsentViewController-tvOS.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS.modulemap";
-				PRODUCT_MODULE_NAME = ConsentViewController;
-				PRODUCT_NAME = ConsentViewController;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		F0377F003E77F0F91AC8FEE0F297E927 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 03E6DD0FCA9C5A4862739B575FA5EC61 /* IQKeyboardManagerSwift.debug.xcconfig */;
@@ -6649,9 +6637,44 @@
 			};
 			name = Debug;
 		};
-		F423F7D383C4F6C2E598C7A73371E069 /* Release */ = {
+		F4112934C0261A5BF752EA218C18E346 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = ABC0C636E983A146EF76F6E672AA40B3 /* ConsentViewController-iOS.release.xcconfig */;
+			baseConfigurationReference = 86BA2F35C05C02BCABF8F3D30603A915 /* ConsentViewController-tvOS.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/ConsentViewController-tvOS/ConsentViewController-tvOS.modulemap";
+				PRODUCT_MODULE_NAME = ConsentViewController;
+				PRODUCT_NAME = ConsentViewController;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		F64791998D32BE4FD8B7F6D56E3DADC4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8E2C263BAF9DFE562CB999D63FBED33A /* ConsentViewController-iOS.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGNING_ALLOWED = NO;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/ConsentViewController-iOS";
@@ -6662,23 +6685,6 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Release;
-		};
-		F5D505D6C0D90CDE120C38D804693021 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F0594D4B29BF1FFCBEBE609EBC5B50EB /* ConsentViewController-tvOS.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGNING_ALLOWED = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/ConsentViewController-tvOS";
-				IBSC_MODULE = ConsentViewController;
-				INFOPLIST_FILE = "Target Support Files/ConsentViewController-tvOS/ResourceBundle-ConsentViewController-ConsentViewController-tvOS-Info.plist";
-				PRODUCT_NAME = ConsentViewController;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;
@@ -6804,15 +6810,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		23AF51B058580EC2BD55E9CF139988DA /* Build configuration list for PBXNativeTarget "Wormholy-Wormholy" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				190D5C7758FF1D54F71C8F342B3667C8 /* Debug */,
-				034060E3299C26CF05C8466E94C0CFAA /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		24E146ADDCFB70F3E2B4511712897E8E /* Build configuration list for PBXNativeTarget "Nimble-tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6885,6 +6882,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		6CBC2C9167F540881A213AEA58A6BD1C /* Build configuration list for PBXNativeTarget "Down" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				256E7B95EC0D0069BF860F45CE3735AB /* Debug */,
+				492830E9156B2401DFA3D14E7591662A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		6F4036EF217B05C74462DC446343FB74 /* Build configuration list for PBXNativeTarget "Nimble-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6894,29 +6900,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6FD6729A41A3247C1240607A2D9235AD /* Build configuration list for PBXNativeTarget "ConsentViewController-tvOS-ConsentViewController" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BDDE7E55793E7BE20A6BAD5F39B291EA /* Debug */,
-				F5D505D6C0D90CDE120C38D804693021 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		7A71D33AF5AD7FE987D9D4E2CC7353B9 /* Build configuration list for PBXAggregateTarget "SwiftLint-tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				3D9543BCB95FA49B643F0FA3F7C9BB6D /* Debug */,
 				35B7B676B4DC30A8EEACF85A9FBC275C /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		7B5DAC41EF3F896427FC9C30DC6C9AD2 /* Build configuration list for PBXNativeTarget "ConsentViewController-iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC8E3FDB83C91D81304CB62A42693ABB /* Debug */,
-				C8B0F5FA56D6CFFEBFB9D5FF4235CAC2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -6939,6 +6927,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		9200B5FD285E083A51425DB30064EEE8 /* Build configuration list for PBXNativeTarget "Wormholy-Wormholy" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DB102AB77D640D3D408A3A2CA016EA9D /* Debug */,
+				9738997B48739CF90A3A4CB01DD26748 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		9C26F84AD7B70FC8CA5F1DE77EE99396 /* Build configuration list for PBXNativeTarget "Pods-NativeMessageExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6953,15 +6950,6 @@
 			buildConfigurations = (
 				A25B2EC18B365A1C2769B116B852AA2B /* Debug */,
 				5290D27DE18DA1A25833597C7E89EDA6 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		A3C54A93F9720A7819E98D4EDFA3FDB4 /* Build configuration list for PBXNativeTarget "Down" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BCED61788E7B27C9982A2FFF116B5137 /* Debug */,
-				8A655DB17ACDBBD2F05B8C34632D782C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -6984,6 +6972,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		AD80BBB004316DCCE3319230516202AE /* Build configuration list for PBXNativeTarget "ConsentViewController-iOS-ConsentViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				038C8BF2061ABB86B49E1C7E14AF435A /* Debug */,
+				F64791998D32BE4FD8B7F6D56E3DADC4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		AE033C46EF682BFB21E405F544FAB7E9 /* Build configuration list for PBXNativeTarget "Quick-tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -7002,29 +6999,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B35C8DCE4E723B8050C8AF02047EB695 /* Build configuration list for PBXNativeTarget "ConsentViewController-tvOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				EE5514A15376A94A2870ABFD60720691 /* Debug */,
-				D28FD60D4CAB0A43D841755EA342D905 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		BB0F236B65CF2CEE01DEB816389B234C /* Build configuration list for PBXNativeTarget "ConsentViewController-iOS-ConsentViewController" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				384C8422CBAEAEB8CC830775CF0C17AE /* Debug */,
-				F423F7D383C4F6C2E598C7A73371E069 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		BC76FF67FC62C9C3FDEB937EA8CF06E5 /* Build configuration list for PBXNativeTarget "Pods-NativePMExampleAppUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D690A4AA6F8BB8504920A15CCFBD215C /* Debug */,
 				B63BFD9DAB26AA5ACD8A5C08795E9B9E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BEFA0297B3D240216851578D96A31668 /* Build configuration list for PBXNativeTarget "ConsentViewController-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8D4B060DDF39812315CFFE45645C5ACA /* Debug */,
+				F4112934C0261A5BF752EA218C18E346 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -7047,11 +7035,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		F9EE0728868978B4E665129E8E0CB554 /* Build configuration list for PBXNativeTarget "ConsentViewController-tvOS-ConsentViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A95C1AFAD72FC01D53B728D5F357EBE /* Debug */,
+				0AA4CA4692F1D22D2886CAF90EE73F4D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FA6BC2B1351F5C60DBAE0C17E7946A9D /* Build configuration list for PBXNativeTarget "Pods-ConsentViewController_Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				8A9FC18B08922168093C8CC63C276987 /* Debug */,
 				5A685529DB0C8311577744B645532955 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FD12896596E31CF67041D230A855E993 /* Build configuration list for PBXNativeTarget "ConsentViewController-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				60C15527DF340DF26B621214FB030CAF /* Debug */,
+				67DD053751815F753B300B061856558C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
* Implement new campaign type `USNatCampaign`
* Implement new consent type `SPUSNatConsent`
* Expand `SPUserData` to contain `SPUSNatConsent`
* Expand `/meta-data` request/response to contain `usnat` 
  * handle `/meta-data` when calling response `.loadMessages`
* Add tests for `SPCoordinator` regarding USNat `/meta-data`

Since usnat is only available on stage and many tests rely on ids present only on prod, several tests were skipped. Only the ones related to the feature will run. We'll revert that back when usnat is in preprod and we're close to merge to develop.