### PR TITLE
Fix UUID query param for PM URL

### DIFF
--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -168,6 +168,12 @@ import UIKit
         #if os(iOS)
 
         case .web:
+            var uuid: String?
+            switch type {
+                case .gdpr: uuid = spCoordinator.userData.gdpr?.consents?.uuid
+                case .ccpa: uuid = spCoordinator.userData.ccpa?.consents?.uuid
+                default: break
+            }
             return GenericWebMessageViewController(
                 url: url,
                 messageId: messageId,
@@ -175,7 +181,7 @@ import UIKit
                 campaignType: type,
                 timeout: messageTimeoutInSeconds,
                 delegate: self,
-                consentUUID: spCoordinator.userData.gdpr?.consents?.uuid
+                consentUUID: uuid
             )
         #endif
 

--- a/ConsentViewController/Classes/SPMessageUIDelegate.swift
+++ b/ConsentViewController/Classes/SPMessageUIDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  MessageUIDelegate.swift
+//  MessageUIDelegateSpy.swift
 //  ConsentViewController
 //
 //  Created by Andre Herculano on 10.02.21.

--- a/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
@@ -120,7 +120,7 @@ public func containQueryParam(_ expected: String) -> Predicate<URL> {
 }
 
 /// expect(url).to(containQueryParam(("name", "value")))
-public func containQueryParam(_ expected: (name: String, value: String)) -> Predicate<URL> {
+public func containQueryParam(_ name: String, withValue value: String) -> Predicate<URL> {
     Predicate { actual in
         guard let actual = try actual.evaluate(),
               let params = actual.queryParams
@@ -129,14 +129,14 @@ public func containQueryParam(_ expected: (name: String, value: String)) -> Pred
         }
         var pass = false
         var message = ""
-        if params.keys.contains(expected.name) {
-            if params.values.contains(expected.value) {
+        if params.keys.contains(name) {
+            if params.values.contains(value) {
                 pass = true
             } else {
-                message = "Expected param \(expected.name) to equal \(expected.value), but found \(params[expected.name] ?? "")"
+                message = "Expected param \(name) to equal \(value), but found \(params[name] ?? "")"
             }
         } else {
-            message = "Could not find query param with name \(expected.name) in \(actual.absoluteString)"
+            message = "Could not find query param with name \(name) in \(actual.absoluteString)"
         }
         return PredicateResult(bool: pass, message: .fail(message))
     }

--- a/Example/ConsentViewController_ExampleTests/MessageUIDelegateMock.swift
+++ b/Example/ConsentViewController_ExampleTests/MessageUIDelegateMock.swift
@@ -9,15 +9,20 @@
 import Foundation
 @testable import ConsentViewController
 
-class MessageUIDelegate: SPMessageUIDelegate {
+class MessageUIDelegateSpy: SPMessageUIDelegate {
     var loadedWasCalled = false
     var onErrorWasCalled = false
+    var actionCalledWith: SPAction?
+    var onLoaded: ((UIViewController?) -> Void)?
 
     func loaded(_ controller: UIViewController) {
         loadedWasCalled = true
+        onLoaded?(controller)
     }
 
-    func action(_ action: ConsentViewController.SPAction, from controller: UIViewController) {}
+    func action(_ action: ConsentViewController.SPAction, from controller: UIViewController) {
+        actionCalledWith = action
+    }
 
     func onError(_ error: ConsentViewController.SPError) {
         onErrorWasCalled = true

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -148,7 +148,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                                 expect(response).to(beAnInstanceOf(MessagesResponse.self))
                                 expect(response.campaigns.count) == 2
                                 response.campaigns.forEach { campaign in
-                                    expect(campaign.url).to(containQueryParam(("consentLanguage", "ES")))
+                                    expect(campaign.url).to(containQueryParam("consentLanguage", withValue: "ES"))
                                 }
 
                             case .failure(let error):


### PR DESCRIPTION
Fix a regression introduced by #499 in which the gdpr consent uuid value and query param would be used also for ccpa campaigns when loading the PM from the 1st layer message.