### PR TITLE
DIA-2625 add usnat to `/consent-status`

### DIFF
--- a/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
@@ -262,33 +262,3 @@ extension SPUSPString {
         try container.encode(expirationDate, forKey: .expirationDate)
     }
 }
-
-extension SPCCPAConsent {
-    convenience init?(
-        uuid: String?,
-        applies: Bool?,
-        campaignResponse: Campaign
-    ) {
-        switch campaignResponse.userConsent {
-            case .ccpa(let consents):
-                self.init(
-                    uuid: uuid,
-                    status: consents.status,
-                    rejectedVendors: consents.rejectedVendors,
-                    rejectedCategories: consents.rejectedCategories,
-                    signedLspa: consents.signedLspa,
-                    childPmId: consents.childPmId,
-                    applies: applies ?? false,
-                    dateCreated: consents.dateCreated,
-                    expirationDate: consents.expirationDate,
-                    lastMessage: LastMessageData(from: campaignResponse.messageMetaData),
-                    consentStatus: consents.consentStatus,
-                    webConsentPayload: consents.webConsentPayload,
-                    GPPData: consents.GPPData
-                )
-                return
-            default: break
-        }
-        return nil
-    }
-}

--- a/ConsentViewController/Classes/Consents/SPGDPRConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPGDPRConsent.swift
@@ -239,31 +239,3 @@ public typealias SPGDPRPurposeId = String
         )
     }
 }
-
-extension SPGDPRConsent {
-    convenience init?(uuid: String?, applies: Bool?, campaignResponse: Campaign) {
-        switch campaignResponse.userConsent {
-            case .gdpr(let consents):
-                self.init(
-                    uuid: uuid,
-                    vendorGrants: consents.vendorGrants,
-                    euconsent: consents.euconsent,
-                    tcfData: consents.tcfData,
-                    childPmId: consents.childPmId,
-                    dateCreated: consents.dateCreated,
-                    expirationDate: consents.expirationDate,
-                    applies: applies ?? false,
-                    consentStatus: consents.consentStatus,
-                    lastMessage: LastMessageData(from: campaignResponse.messageMetaData),
-                    webConsentPayload: consents.webConsentPayload,
-                    legIntCategories: consents.legIntCategories,
-                    legIntVendors: consents.legIntVendors,
-                    vendors: consents.vendors,
-                    categories: consents.categories
-                )
-                return
-            default: break
-        }
-        return nil
-    }
-}

--- a/ConsentViewController/Classes/Consents/SPUSNatConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPUSNatConsent.swift
@@ -99,28 +99,3 @@ import Foundation
         consentStatus: consentStatus
     )}
 }
-
-extension SPUSNatConsent {
-    convenience init?(
-        uuid: String?,
-        applies: Bool?,
-        campaignResponse: Campaign
-    ) {
-        switch campaignResponse.userConsent {
-            case .usnat(let consents):
-                self.init(
-                    uuid: uuid,
-                    applies: applies ?? false,
-                    dateCreated: consents.dateCreated,
-                    consentString: consents.consentString,
-                    webConsentPayload: consents.webConsentPayload,
-                    lastMessage: LastMessageData(from: campaignResponse.messageMetaData),
-                    categories: consents.categories,
-                    consentStatus: consents.consentStatus
-                )
-                return
-            default: break
-        }
-        return nil
-    }
-}

--- a/ConsentViewController/Classes/SourcePointClient/ConsentStatusMetadata.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ConsentStatusMetadata.swift
@@ -17,5 +17,5 @@ struct ConsentStatusMetaData: QueryParamEncodable {
         let idfaStatus: SPIDFAStatus?
     }
 
-    let gdpr, ccpa: Campaign?
+    let gdpr, ccpa, usnat: Campaign?
 }

--- a/ConsentViewController/Classes/SourcePointClient/ConsentStatusResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ConsentStatusResponse.swift
@@ -32,8 +32,17 @@ struct ConsentStatusResponse: Decodable, Equatable {
             let GPPData: SPJson?
         }
 
+        struct USNAT: Decodable, Equatable {
+            let uuid, consentString: String
+            let dateCreated: SPDate
+            let consentStatus: ConsentStatus
+            let categories: [String]
+            let webConsentPayload: SPWebConsentPayload?
+        }
+
         let gdpr: GDPR?
         let ccpa: CCPA?
+        let usnat: USNAT?
     }
 
     let consentStatusData: Data

--- a/ConsentViewController/Classes/SourcePointClient/MessagesResponse.swift
+++ b/ConsentViewController/Classes/SourcePointClient/MessagesResponse.swift
@@ -151,6 +151,75 @@ extension Consent: Codable {
         default: break
         }
     }
+
+    func toConsent(defaults: SPUSNatConsent?, messageMetaData: MessageMetaData?) -> SPUSNatConsent? {
+        switch self {
+            case .usnat(let consents):
+                return SPUSNatConsent(
+                    uuid: defaults?.uuid,
+                    applies: defaults?.applies ?? false,
+                    dateCreated: consents.dateCreated,
+                    consentString: consents.consentString,
+                    webConsentPayload: consents.webConsentPayload,
+                    lastMessage: LastMessageData(from: messageMetaData),
+                    categories: consents.categories,
+                    consentStatus: consents.consentStatus
+                )
+
+            default:
+                return defaults?.copy() as? SPUSNatConsent
+        }
+    }
+
+    func toConsent(defaults: SPCCPAConsent?, messageMetaData: MessageMetaData?) -> SPCCPAConsent? {
+        switch self {
+            case .ccpa(let consents):
+                return SPCCPAConsent(
+                    uuid: defaults?.uuid,
+                    status: consents.status,
+                    rejectedVendors: consents.rejectedVendors,
+                    rejectedCategories: consents.rejectedCategories,
+                    signedLspa: consents.signedLspa,
+                    childPmId: consents.childPmId,
+                    applies: defaults?.applies ?? false,
+                    dateCreated: consents.dateCreated,
+                    expirationDate: consents.expirationDate,
+                    lastMessage: LastMessageData(from: messageMetaData),
+                    consentStatus: consents.consentStatus,
+                    webConsentPayload: consents.webConsentPayload,
+                    GPPData: consents.GPPData
+                )
+
+            default:
+                return defaults?.copy() as? SPCCPAConsent
+        }
+    }
+
+    func toConsent(defaults: SPGDPRConsent?, messageMetaData: MessageMetaData?) -> SPGDPRConsent? {
+        switch self {
+            case .gdpr(let consents):
+                return SPGDPRConsent(
+                    uuid: defaults?.uuid,
+                    vendorGrants: consents.vendorGrants,
+                    euconsent: consents.euconsent,
+                    tcfData: consents.tcfData,
+                    childPmId: consents.childPmId,
+                    dateCreated: consents.dateCreated,
+                    expirationDate: consents.expirationDate,
+                    applies: defaults?.applies ?? false,
+                    consentStatus: consents.consentStatus,
+                    lastMessage: LastMessageData(from: messageMetaData),
+                    webConsentPayload: consents.webConsentPayload,
+                    legIntCategories: consents.legIntCategories,
+                    legIntVendors: consents.legIntVendors,
+                    vendors: consents.vendors,
+                    categories: consents.categories
+                )
+
+            default:
+                return defaults?.copy() as? SPGDPRConsent
+        }
+    }
 }
 
 struct MessageMetaData: Equatable {

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -185,7 +185,11 @@ class SourcepointClientCoordinator: SPClientCoordinator {
     var needsNewConsentData: Bool {
         migratingUser || (
             state.localVersion != State.version &&
-            (state.gdpr?.uuid != nil || state.ccpa?.uuid != nil)
+            (
+                state.gdpr?.uuid != nil ||
+                state.ccpa?.uuid != nil ||
+                state.usnat?.uuid != nil
+            )
         )
     }
 

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -480,13 +480,13 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         }
     }
 
-    func consentStatusMetadataFromState(_ campaign: CampaignConsent?, _ hasLocalData: Bool) -> ConsentStatusMetaData.Campaign? {
+    func consentStatusMetadataFromState(_ campaign: CampaignConsent?) -> ConsentStatusMetaData.Campaign? {
         guard let campaign = campaign else { return nil }
         return ConsentStatusMetaData.Campaign(
             applies: campaign.applies,
             dateCreated: campaign.dateCreated,
             uuid: campaign.uuid,
-            hasLocalData: hasLocalData,
+            hasLocalData: false,
             idfaStatus: SPIDFAStatus.current()
         )
     }
@@ -533,14 +533,8 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             spClient.consentStatus(
                 propertyId: propertyId,
                 metadata: .init(
-                    gdpr: consentStatusMetadataFromState(
-                        state.gdpr,
-                        false
-                    ),
-                    ccpa: consentStatusMetadataFromState(
-                        state.ccpa,
-                        false
-                    )
+                    gdpr: consentStatusMetadataFromState(state.gdpr),
+                    ccpa: consentStatusMetadataFromState(state.ccpa),
                 ),
                 authId: authId,
                 includeData: includeData

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -86,7 +86,7 @@ class SourcePointClientMock: SourcePointProtocol {
             } else {
                 handler(.success(
                     ConsentStatusResponse(
-                        consentStatusData: .init(gdpr: nil, ccpa: nil),
+                        consentStatusData: .init(gdpr: nil, ccpa: nil, usnat: nil),
                         localState: SPJson())
                 ))
             }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -15,7 +15,7 @@ import Quick
 
 class UnmockedSourcepointClientSpec: QuickSpec {
     override func spec() {
-        let emptyMetaData = ConsentStatusMetaData(gdpr: nil, ccpa: nil)
+        let emptyMetaData = ConsentStatusMetaData(gdpr: nil, ccpa: nil, usnat: nil)
         let propertyName = try! SPPropertyName("tests.unified-script.com")
         let accountId = 22
         let propertyId = 17_801
@@ -91,6 +91,13 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                                 uuid: nil,
                                 hasLocalData: false,
                                 idfaStatus: nil
+                            ),
+                            usnat: .init(
+                                applies: true,
+                                dateCreated: nil,
+                                uuid: nil,
+                                hasLocalData: false,
+                                idfaStatus: nil
                             )
                         ),
                         authId: "user_auth_id",
@@ -138,10 +145,10 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                             idfaStatus: nil,
                             includeData: IncludeData(gppConfig: nil)
                         ),
-                        metadata: MessagesRequest.MetaData(
-                            ccpa: MessagesRequest.MetaData.Campaign(applies: true),
-                            gdpr: MessagesRequest.MetaData.Campaign(applies: true),
-                            usnat: MessagesRequest.MetaData.Campaign(applies: true)
+                        metadata: .init(
+                            ccpa: .init(applies: true),
+                            gdpr: .init(applies: true),
+                            usnat: .init(applies: true)
                         ),
                         nonKeyedLocalState: MessagesRequest.NonKeyedLocalState(nonKeyedLocalState: SPJson())
                     )) {


### PR DESCRIPTION
* refactored a data mapping from `Consent` to `SPCCPAConsent`, `SPGDPRConsent` and `SPUSNatConsent` classes. Those mappings were `convenience init`'s on each of those classes and they are now a method called `.toConsent` on the `Consent` class.
* added `usnat` to `/consent-status` request, response and response handler on SPCoordinator
* added tests for authenticated consent on SPCoordinator (currently failing because `/consent-status` returns an new `uuid` every time it's called with the same `authId`