### PR TITLE
DIA-3249 handle ccpa opt-outs

### DIFF
--- a/ConsentViewController/Classes/SPCampaigns.swift
+++ b/ConsentViewController/Classes/SPCampaigns.swift
@@ -16,20 +16,29 @@ public typealias SPTargetingParams = [String: String]
 
     let groupPmId: String?
 
+    /**
+     Used by usNat campaigns only. Set this flag only if your app used an SDK older than `7.6.0`, use authenticated consent
+     and has a CCPA campaign.
+     */
+    let transitionCCPAAuth: Bool?
+
     override public var description: String {
         """
         SPCampaign
             - targetingParams: \(targetingParams)
             - groupPmId: \(groupPmId as Any)
+            - transitionCCPAAuth: \(transitionCCPAAuth as Any)
         """
     }
 
     public init(
         targetingParams: SPTargetingParams = [:],
-        groupPmId: String? = nil
+        groupPmId: String? = nil,
+        transitionCCPAAuth: Bool? = nil
     ) {
         self.targetingParams = targetingParams
         self.groupPmId = groupPmId
+        self.transitionCCPAAuth = transitionCCPAAuth
     }
 }
 

--- a/ConsentViewController/Classes/SourcePointClient/ConsentStatusMetadata.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ConsentStatusMetadata.swift
@@ -13,9 +13,41 @@ struct ConsentStatusMetaData: QueryParamEncodable {
         let applies: Bool
         let dateCreated: SPDate?
         let uuid: String?
-        let hasLocalData: Bool
+        let hasLocalData = false
         let idfaStatus: SPIDFAStatus?
     }
 
-    let gdpr, ccpa, usnat: Campaign?
+    struct USNatCampaign: Encodable {
+        let applies: Bool
+        let dateCreated: SPDate?
+        let uuid: String?
+        let hasLocalData = false
+        let idfaStatus: SPIDFAStatus?
+    }
+
+    let gdpr, ccpa: Campaign?
+    let usnat: USNatCampaign?
+}
+
+extension ConsentStatusMetaData.Campaign {
+    init?(_ consent: CampaignConsent?, campaign: SPCampaign?, idfaStatus: SPIDFAStatus?) {
+        guard let consent = consent, campaign != nil else { return nil }
+        applies = consent.applies
+        dateCreated = consent.dateCreated
+        uuid = consent.uuid
+        self.idfaStatus = idfaStatus
+    }
+}
+
+extension ConsentStatusMetaData.USNatCampaign {
+    init?(
+        _ consent: CampaignConsent?,
+        campaign: SPCampaign?,
+        idfaStatus: SPIDFAStatus?,
+    ) {
+        guard let consent = consent, let campaign = campaign else { return nil }
+        applies = consent.applies
+        uuid = consent.uuid
+        self.dateCreated = dateCreated
+    }
 }

--- a/ConsentViewController/Classes/SourcePointClient/ConsentStatusMetadata.swift
+++ b/ConsentViewController/Classes/SourcePointClient/ConsentStatusMetadata.swift
@@ -23,6 +23,8 @@ struct ConsentStatusMetaData: QueryParamEncodable {
         let uuid: String?
         let hasLocalData = false
         let idfaStatus: SPIDFAStatus?
+        let transitionCCPAAuth: Bool?
+        let optedOut: Bool?
     }
 
     let gdpr, ccpa: Campaign?
@@ -44,10 +46,15 @@ extension ConsentStatusMetaData.USNatCampaign {
         _ consent: CampaignConsent?,
         campaign: SPCampaign?,
         idfaStatus: SPIDFAStatus?,
+        dateCreated: SPDate?,
+        optedOut: Bool?
     ) {
         guard let consent = consent, let campaign = campaign else { return nil }
         applies = consent.applies
         uuid = consent.uuid
+        transitionCCPAAuth = campaign.transitionCCPAAuth
         self.dateCreated = dateCreated
+        self.optedOut = optedOut
+        self.idfaStatus = idfaStatus
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -217,6 +217,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
     }
 
     var transitionCCPAUSNat: Bool {
+        campaigns.usnat != nil &&
         ccpaUUID != nil &&
         usnatUUID == nil &&
         (state.ccpa?.status == .RejectedAll || state.ccpa?.status == .RejectedSome)

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -372,6 +372,10 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             localState.usnat = .empty()
         }
 
+        if localState.localVersion == nil {
+            localState.localVersion = State.version
+        }
+
         return localState
     }
 

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -196,7 +196,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
     }
 
     var needsNewConsentData: Bool {
-        migratingUser || needsNewUSNatData || (
+        migratingUser || needsNewUSNatData || transitionCCPAUSNat || (
             state.localVersion != nil && state.localVersion != State.version &&
             (
                 state.gdpr?.uuid != nil ||
@@ -211,6 +211,16 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         Used as part of the decision to call `/consent-status`
      */
     var needsNewUSNatData = false
+
+    var authTransitionCCPAUSNat: Bool {
+        authId != nil && campaigns.usnat?.transitionCCPAAuth == true
+    }
+
+    var transitionCCPAUSNat: Bool {
+        ccpaUUID != nil &&
+        usnatUUID == nil &&
+        (state.ccpa?.status == .RejectedAll || state.ccpa?.status == .RejectedSome)
+    }
 
     var shouldCallConsentStatus: Bool {
         needsNewConsentData || authId != nil

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -711,21 +711,21 @@ class SourcepointClientCoordinator: SPClientCoordinator {
 
     func pvData(pubData: SPPublisherData?, _ handler: @escaping () -> Void) {
         let pvDataGroup = DispatchGroup()
-        if let gdprMetadata = state.gdprMetaData {
+        if let gdprMetadata = state.gdprMetaData, campaigns.gdpr != nil {
             pvDataGroup.enter()
             let sampled = sampleAndPvData(gdprMetadata, body: gdprPvDataBody(from: state, pubData: pubData)) {
                 pvDataGroup.leave()
             }
             state.gdprMetaData?.wasSampled = sampled
         }
-        if let ccpaMetadata = state.ccpaMetaData {
+        if let ccpaMetadata = state.ccpaMetaData, campaigns.ccpa != nil {
             pvDataGroup.enter()
             let sampled = sampleAndPvData(ccpaMetadata, body: ccpaPvDataBody(from: state, pubData: pubData)) {
                 pvDataGroup.leave()
             }
             state.ccpaMetaData?.wasSampled = sampled
         }
-        if let usNatMetadata = state.usNatMetaData {
+        if let usNatMetadata = state.usNatMetaData, campaigns.usnat != nil {
             pvDataGroup.enter()
             let sampled = sampleAndPvData(usNatMetadata, body: usnatPvDataBody(from: state, pubData: pubData)) {
                 pvDataGroup.leave()

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -17,11 +17,7 @@ class SourcePointClientMock: SourcePointProtocol {
     var postGDPRActionCalled = false, postCCPAActionCalled = false,
         customConsentCalled = false, consentStatusCalled = false,
         pvDataCalled = false, getMessagesCalled = false
-    var customConsentWasCalledWith: [String: Any?]!
-    var errorMetricsCalledWith: [String: Any?]!
-    var postGDPRActionCalledWith: [String: Any?]!
-    var postCCPAActionCalledWith: [String: Any?]!
-    var postUSNatActionCalledWith: [String: Any?]?
+    var consentStatusCalledWith, customConsentWasCalledWith, errorMetricsCalledWith, postGDPRActionCalledWith, postCCPAActionCalledWith, postUSNatActionCalledWith: [String: Any?]?
 
     var metadataResponse = MetaDataResponse(ccpa: nil, gdpr: nil, usnat: nil)
 
@@ -65,6 +61,12 @@ class SourcePointClientMock: SourcePointProtocol {
         includeData: IncludeData,
         handler: @escaping ConsentStatusHandler) {
             consentStatusCalled = true
+            consentStatusCalledWith = [
+                "propertyId": propertyId,
+                "metadata": metadata,
+                "authId": authId,
+                "includeData": includeData
+            ]
 
             if let error = error {
                 handler(.failure(error))

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -615,7 +615,7 @@ class SPClientCoordinatorSpec: QuickSpec {
                                         accountId: accountId,
                                         propertyName: try! SPPropertyName("usnat.mobile.demo"),
                                         propertyId: 34152,
-                                        campaigns: SPCampaigns(usnat: SPCampaign()),
+                                        campaigns: SPCampaigns(usnat: SPCampaign(transitionCCPAAuth: true)),
                                         storage: LocalStorageMock()
                                     )
                                     coordinator.loadMessages(forAuthId: ccpaAuthId, pubData: nil) { usnatMessages in

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -123,7 +123,7 @@ class SPClientCoordinatorSpec: QuickSpec {
 
                                 case .success:
                                     expect(spClientMock.postGDPRActionCalled).to(beTrue())
-                                    let body = spClientMock.postGDPRActionCalledWith["body"] as? GDPRChoiceBody
+                                    let body = spClientMock.postGDPRActionCalledWith?["body"] as? GDPRChoiceBody
                                     expect(body?.pubData).to(equal(gdprAction.encodablePubData))
                             }
                             done()
@@ -142,7 +142,7 @@ class SPClientCoordinatorSpec: QuickSpec {
 
                                 case .success:
                                     expect(spClientMock.postCCPAActionCalled).to(beTrue())
-                                    let body = spClientMock.postCCPAActionCalledWith["body"] as? CCPAChoiceBody
+                                    let body = spClientMock.postCCPAActionCalledWith?["body"] as? CCPAChoiceBody
                                     expect(body?.pubData).to(equal(ccpaAction.encodablePubData))
                             }
                             done()
@@ -588,6 +588,104 @@ class SPClientCoordinatorSpec: QuickSpec {
                                     expect(userData.usnat?.consents?.uuid).to(equal(actionUuid))
 
                                     done()
+                                }
+                            }
+                        }
+                    }
+                }
+
+                describe("and the transitionCCPAAuth campaign config is true") {
+                    it("sets the flag transitionCCPAAuth in consent-status' metadata param") {
+                        coordinator = SourcepointClientCoordinator(
+                            accountId: accountId,
+                            propertyName: try! SPPropertyName("usnat.mobile.demo"),
+                            propertyId: 34152,
+                            campaigns: SPCampaigns(ccpa: SPCampaign()),
+                            storage: LocalStorageMock()
+                        )
+                        let ccpaAuthId = UUID().uuidString
+
+                        waitUntil { done in
+                            coordinator.loadMessages(forAuthId: ccpaAuthId, pubData: nil) { _ in
+                                coordinator.reportAction(SPAction(type: .RejectAll, campaignType: .ccpa)) { actionResult in
+                                    let userData = try? actionResult.get()
+                                    expect(userData?.ccpa?.consents?.status).to(equal(.RejectedAll))
+
+                                    coordinator = SourcepointClientCoordinator(
+                                        accountId: accountId,
+                                        propertyName: try! SPPropertyName("usnat.mobile.demo"),
+                                        propertyId: 34152,
+                                        campaigns: SPCampaigns(usnat: SPCampaign()),
+                                        storage: LocalStorageMock()
+                                    )
+                                    coordinator.loadMessages(forAuthId: ccpaAuthId, pubData: nil) { usnatMessages in
+                                        let (messages, usnatUserData) = try! usnatMessages.get()
+                                        expect(messages).to(beEmpty())
+                                        expect(usnatUserData.usnat?.consents?.consentStatus.rejectedAny).to(beTrue())
+                                        expect(usnatUserData.usnat?.consents?.consentStatus.consentedToAll).to(beFalse())
+                                        done()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            describe("handles ccpa opt-outs") {
+                describe("when there's no authId") {
+                    it("transitionCCPAAuth in consent-status' metadata param is nil") {
+                        let client = SourcePointClientMock()
+                        coordinator = SourcepointClientCoordinator(
+                            accountId: accountId,
+                            propertyName: try! SPPropertyName("usnat.mobile.demo"),
+                            propertyId: 34152,
+                            campaigns: SPCampaigns(usnat: SPCampaign(transitionCCPAAuth: true)),
+                            storage: LocalStorageMock(),
+                            spClient: client
+                        )
+
+                        waitUntil { done in
+                            coordinator.loadMessages(forAuthId: nil, pubData: nil) { _ in
+                                let consentStatusMetadata = client.consentStatusCalledWith?["metadata"] as? ConsentStatusMetaData
+                                expect(consentStatusMetadata?.usnat?.transitionCCPAAuth).to(beNil())
+                                done()
+                            }
+                        }
+                    }
+                }
+
+                describe("and there is ccpa consent data") {
+                    it("returns a rejected-all usnat consent") {
+                        let storage = LocalStorageMock()
+                        let campaignsWithCCPA = SPCampaigns(ccpa: SPCampaign())
+                        let campaignsWithUSNat = SPCampaigns(usnat: SPCampaign())
+                        coordinator = SourcepointClientCoordinator(
+                            accountId: accountId,
+                            propertyName: try! SPPropertyName("usnat.mobile.demo"),
+                            propertyId: 34152,
+                            campaigns: campaignsWithCCPA,
+                            storage: storage
+                        )
+
+                        waitUntil { done in
+                            coordinator.loadMessages(forAuthId: nil, pubData: nil) { _ in
+                                coordinator.reportAction(SPAction(type: .RejectAll, campaignType: .ccpa)) { _ in
+                                    expect(coordinator.ccpaUUID).notTo(beNil())
+                                    coordinator = SourcepointClientCoordinator(
+                                        accountId: accountId,
+                                        propertyName: try! SPPropertyName("usnat.mobile.demo"),
+                                        propertyId: 34152,
+                                        campaigns: campaignsWithUSNat,
+                                        storage: storage
+                                    )
+
+                                    coordinator.loadMessages(forAuthId: nil, pubData: nil) { response in
+                                        let (messages, userData) = try! response.get()
+                                        expect(messages).to(beEmpty())
+                                        expect(userData.usnat?.consents?.uuid).notTo(beNil())
+                                        done()
+                                    }
                                 }
                             }
                         }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -82,14 +82,12 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                                 applies: true,
                                 dateCreated: nil,
                                 uuid: nil,
-                                hasLocalData: false,
                                 idfaStatus: nil
                             ),
                             ccpa: .init(
                                 applies: true,
                                 dateCreated: nil,
                                 uuid: nil,
-                                hasLocalData: false,
                                 idfaStatus: nil
                             ),
                             usnat: nil


### PR DESCRIPTION
* fixed an issue with `/pv-data` being called for campaigns that are not in the config ✅ 
* fixed an issue with `/consent-status` being called in fresh installs (when `localVersion` is `nil`) ✅ 
* added `transitionCCPAAuth` flag to `SPConfig` so clients can choose to transfer their CCPA authenticated consent to USNat ✅
* implemented logic to transfer CCPA opted-out consent over to USNat ✅