### PR TITLE
DIA-3617 fix gdpr consents disappearing on SDK update

### DIFF
--- a/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPCCPAConsent.swift
@@ -191,14 +191,14 @@ extension SPUSPString {
         status = try container.decode(CCPAConsentStatus.self, forKey: .status)
         rejectedVendors = try container.decode([String].self, forKey: .rejectedVendors)
         rejectedCategories = try container.decode([String].self, forKey: .rejectedCategories)
-        signedLspa = try container.decode(Bool.self, forKey: .signedLspa)
+        signedLspa = try container.decodeIfPresent(Bool.self, forKey: .signedLspa) ?? false
         uuid = try container.decodeIfPresent(String.self, forKey: .uuid)
         childPmId = try container.decodeIfPresent(String.self, forKey: .childPmId)
         consentStatus = try (try? container.decode(ConsentStatus.self, forKey: .consentStatus)) ?? ConsentStatus(from: decoder)
         webConsentPayload = try container.decodeIfPresent(SPWebConsentPayload.self, forKey: .webConsentPayload)
         applies = try container.decodeIfPresent(Bool.self, forKey: .applies) ?? false
         GPPData = try container.decodeIfPresent(SPJson.self, forKey: .GPPData) ?? SPJson()
-        expirationDate = try container.decode(SPDate.self, forKey: .expirationDate)
+        expirationDate = try container.decodeIfPresent(SPDate.self, forKey: .expirationDate) ?? .distantFuture()
         if let date = try container.decodeIfPresent(SPDate.self, forKey: .dateCreated) {
             dateCreated = date
         }

--- a/ConsentViewController/Classes/SPConsentManager.swift
+++ b/ConsentViewController/Classes/SPConsentManager.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 import UIKit
-// swiftlint:disable file_length
+
+// swiftlint:disable file_length function_parameter_count
 @objcMembers public class SPConsentManager: NSObject {
     static let DefaultTimeout = TimeInterval(30)
     public static var shouldCallErrorMetrics = true
@@ -701,3 +702,5 @@ func mainSync<T>(execute work: () throws -> T) rethrows -> T {
 
     return try DispatchQueue.main.sync { try work() }
 }
+
+// swiftlint:enable function_parameter_count

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -464,7 +464,6 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             self.consentStatus {
                 self.state.udpateGDPRStatus()
                 self.state.udpateUSNatStatus()
-                self.state.localVersion = State.version
                 self.messages { messagesResponse in
                     handler(messagesResponse)
                     self.pvData(pubData: pubData) { }
@@ -595,6 +594,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             ) { result in
                 switch result {
                     case .success(let response):
+                        self.state.localVersion = State.version
                         self.handleConsentStatusResponse(response)
 
                     case .failure(let error):
@@ -603,6 +603,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 next()
             }
         } else {
+            self.state.localVersion = State.version
             next()
         }
     }

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -464,6 +464,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             self.consentStatus {
                 self.state.udpateGDPRStatus()
                 self.state.udpateUSNatStatus()
+                self.state.localVersion = State.version
                 self.messages { messagesResponse in
                     handler(messagesResponse)
                     self.pvData(pubData: pubData) { }
@@ -604,7 +605,6 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         } else {
             next()
         }
-        state.localVersion = State.version
     }
 
     func handleMessagesResponse(_ response: MessagesResponse) -> LoadMessagesReturnType {

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -81,7 +81,7 @@ extension SPSampleable {
 
 class SourcepointClientCoordinator: SPClientCoordinator {
     struct State: Codable {
-        static let version = 2
+        static let version = 3
 
         struct GDPRMetaData: Codable, SPSampleable, Equatable {
             var additionsChangeDate = SPDate.now()

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -197,8 +197,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
 
     var needsNewConsentData: Bool {
         migratingUser || needsNewUSNatData || transitionCCPAUSNat || (
-            state.localVersion != nil && state.localVersion != State.version &&
-            (
+            state.localVersion != State.version && (
                 state.gdpr?.uuid != nil ||
                 state.ccpa?.uuid != nil ||
                 state.usnat?.uuid != nil
@@ -371,10 +370,6 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         if let usnatExpirationDate = localState.usnat?.expirationDate.date,
            usnatExpirationDate < Date() {
             localState.usnat = .empty()
-        }
-
-        if localState.localVersion == nil {
-            localState.localVersion = State.version
         }
 
         return localState
@@ -568,7 +563,6 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             )
         }
 
-        state.localVersion = State.version
         storage.spState = state
     }
 
@@ -610,6 +604,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         } else {
             next()
         }
+        state.localVersion = State.version
     }
 
     func handleMessagesResponse(_ response: MessagesResponse) -> LoadMessagesReturnType {

--- a/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
@@ -126,7 +126,7 @@ public func containQueryParam(_ name: String, withValue value: String) -> Predic
         guard let actual = try actual.evaluate(),
               let params = actual.queryParams
         else {
-            return PredicateResult(bool: false, message: .fail("could not get query params from URL(\(try? actual.evaluate()?.absoluteString))"))
+            return PredicateResult(bool: false, message: .fail("could not get query params from URL(\(try? actual.evaluate()?.absoluteString as Any))"))
         }
         var pass = false
         var message = ""

--- a/Example/ConsentViewController_ExampleTests/SPCCPAConsentSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPCCPAConsentSpec.swift
@@ -36,7 +36,6 @@ class SPCCPAConsentsSpec: QuickSpec {
                     "rejectedCategories": [],
                     "consentStatus": {},
                     "signedLspa": false,
-                    "expirationDate": "2023-02-06T16:20:53.707Z",
                     "GPPData": {
                         "foo": "bar"
                     }
@@ -50,7 +49,7 @@ class SPCCPAConsentsSpec: QuickSpec {
             expect(consent.rejectedCategories).to(beEmpty())
             expect(consent.signedLspa).to(beFalse())
             expect(consent.GPPData.dictionaryValue?["foo"] as? String).to(equal("bar"))
-            expect(consent.expirationDate).to(equal(year: 2023, month: 2, day: 6))
+            expect(consent.expirationDate).to(equal(.distantFuture()))
         }
     }
 }


### PR DESCRIPTION
* assign default value to `signedLspa` and `expirationDate` attribute when decoding `SPCCPAConsent` object
* make sure to update consent data when `localVersion != State.version` even when `localVersion` is `nil`