### PR TITLE
Make webConsents public

### DIFF
--- a/ConsentViewController/Classes/Consents/SPUserData.swift
+++ b/ConsentViewController/Classes/Consents/SPUserData.swift
@@ -70,7 +70,7 @@ public class SPConsent<ConsentType: Codable & Equatable & NSCopying>: NSObject, 
     /// - SeeAlso: `SPUSNatConsent`
     public let usnat: SPConsent<SPUSNatConsent>?
 
-    var webConsents: SPWebConsents { SPWebConsents(
+    public var webConsents: SPWebConsents { SPWebConsents(
         gdpr: .init(uuid: gdpr?.consents?.uuid, webConsentPayload: gdpr?.consents?.webConsentPayload),
         ccpa: .init(uuid: ccpa?.consents?.uuid, webConsentPayload: ccpa?.consents?.webConsentPayload),
         usnat: .init(uuid: usnat?.consents?.uuid, webConsentPayload: usnat?.consents?.webConsentPayload)


### PR DESCRIPTION
Hey,

in our React Native app we would like to read out the webConsents ourselves, so we can inject them manually instead of relying on `WKWebView.loadConsent`.

For this we need to access the webConsents

Does this make sense?

Best,
Finn