### PR TITLE
DIA-3811 preload consents not working

### DIFF
--- a/ConsentViewController/Classes/Extensions/SPURLExtensions.swift
+++ b/ConsentViewController/Classes/Extensions/SPURLExtensions.swift
@@ -10,7 +10,7 @@ import Foundation
 extension URL {
     /// - Parameter parameters: parameters dictionary.
     /// - Returns: URL with appending given query parameters.
-    func appendQueryItems(_ parameters: [String: String?]) -> URL? {
+    public func appendQueryItems(_ parameters: [String: String?]) -> URL? {
         let filteredParams = parameters.filter { _, value in value != nil }
 
         if var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: true) {

--- a/Example/AuthExample/HomeViewController.swift
+++ b/Example/AuthExample/HomeViewController.swift
@@ -11,17 +11,28 @@ import WebKit
 import ConsentViewController
 
 class HomeViewController: UIViewController {
-    static let webviewUrl = URL(string: "https://sourcepointusa.github.io/sdks-auth-consent-test-page/?_sp_version=4.9.0&_sp_pass_consent=true")!
+    var webviewUrl: URL { (URL(string: "https://sourcepointusa.github.io/sdks-auth-consent-test-page")?
+        .appendQueryItems([
+            "_sp_pass_consent": "true",
+            "accountId": accountId,
+            "propertyId": propertyId,
+            "propertyName": propertyName
+        ]))!
+    }
     static let notFoundHtml = Bundle.main.path(forResource: "webserver/404", ofType: "html")!
 
     @IBOutlet weak var webview: WKWebView!
 
     var userData: SPUserData!
+    var accountId, propertyId, propertyName: String!
 
     override func viewDidLoad() {
+        if #available(iOS 16.4, *) {
+            webview.isInspectable = true
+        }
         webview.cleanCache()
         webview.navigationDelegate = self
-        webview.load(URLRequest(url: HomeViewController.webviewUrl))
+        webview.load(URLRequest(url: webviewUrl))
         webview.preloadConsent(from: userData)
     }
 }

--- a/Example/AuthExample/LoginViewController.swift
+++ b/Example/AuthExample/LoginViewController.swift
@@ -31,10 +31,16 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         ccpa: SPCampaign()
     )}
 
+    let accountId = 22
+    let propertyName = "mobile.multicampaign.demo"
+    let propertyId = 16893
+    let loginPagePropertyName = "sdks-auth-consent-test-page"
+    let loginPagePropertyId = 31007
+
     lazy var consentManager: SPSDK = { SPConsentManager(
-        accountId: 22,
-        propertyId: 16893,
-        propertyName: try! SPPropertyName("mobile.multicampaign.demo"),
+        accountId: accountId,
+        propertyId: propertyId,
+        propertyName: try! SPPropertyName(propertyName),
         campaigns: campaigns,
         delegate: self
     )}()
@@ -85,6 +91,9 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let homeController = segue.destination as? HomeViewController
         homeController?.userData = consentManager.userData
+        homeController?.accountId = String(accountId)
+        homeController?.propertyId = String(loginPagePropertyId)
+        homeController?.propertyName = loginPagePropertyName
     }
 
     func sdkLoading() {

--- a/Example/AuthExample/LoginViewController.swift
+++ b/Example/AuthExample/LoginViewController.swift
@@ -17,11 +17,6 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var authIdTextField: UITextField!
     @IBOutlet var consentTableView: UITableView!
 
-    @IBAction func onAuthIdChanged(_ sender: Any) {
-        authId = authIdTextField.text
-        authId = authId == "" ? nil : authId
-    }
-
     @IBAction func onDonePress(_ sender: Any) {
         self.messageFlow()
     }
@@ -44,15 +39,6 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         delegate: self
     )}()
 
-    /// Use a random generated `UUID` if you don't intend to share consent among different apps
-    /// Otherwise use the `UIDevice().identifierForVendor` if you intend to share consent among
-    /// different apps you control but don't have an id tha uniquely identifies a user such as email, username, etc.
-    /// Make sure to persist the authId as it needs to be re-used everytime the `.loadMessage(forAuthId:` is called.
-    var authId: String! {
-        didSet {
-            UserDefaults.standard.set(authId, forKey: "MyAppsAuthId")
-        }
-    }
     
     let tableSections = ["SDK Data"]
     var sdkData: [String: String?] = [:]
@@ -85,7 +71,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     func messageFlow() {
         initData()
         sdkLoading()
-        consentManager.loadMessage(forAuthId: authId)
+        consentManager.loadMessage()
     }
 
     override func viewDidLoad() {
@@ -93,7 +79,6 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         sdkStatusLabel.accessibilityIdentifier = "sdkStatusLabel"
         // dismiss keyboard when tapping outside the authId text field
         view.addGestureRecognizer(UITapGestureRecognizer(target: view, action: #selector(UIView.endEditing)))
-        authId = UserDefaults.standard.string(forKey: "MyAppsAuthId")
         messageFlow()
     }
 


### PR DESCRIPTION
In certain cases, when serialising `consents.webConsents` to string, the resulting string would be invalid when interpolating inside a javascript context.

This PR fixes this issue by introducing the struct `PreloadConsentsPayload` and using that when injecting javascript instead of string interpolating `.webConsents` directly.