### PR TITLE
use `loadLabelText` on tvOS UITableViews

### DIFF
--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPACategoryDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPACategoryDetailsViewController.swift
@@ -83,10 +83,10 @@ extension SPCCPACategoryDetailsViewController: UITableViewDataSource, UITableVie
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let sectionComponent = sections[section] else { return nil }
+
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
-        label.text = "\(sections[section]?.settings.text ?? "Partners") (\(partners.count))"
-        label.font = UIFont(from: sections[section]?.settings.style.font)
-        label.textColor = UIColor(hexString: sections[section]?.settings.style.font.color)
+        loadLabelText(forComponent: sectionComponent, label: label)
         return label
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAManagePreferenceViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAManagePreferenceViewController.swift
@@ -109,14 +109,14 @@ extension SPCCPAManagePreferenceViewController: UITableViewDataSource, UITableVi
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let sectionComponent = sections[section].header else { return nil }
+
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
-        label.text = sections[section].header?.settings.text
-        label.font = UIFont(from: sections[section].header?.settings.style.font)
-        label.textColor = UIColor(hexString: sections[section].header?.settings.style.font.color)
+        loadLabelText(forComponent: sectionComponent, label: label)
         return label
     }
 
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         UITableView.automaticDimension
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAPartnersViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAPartnersViewController.swift
@@ -87,10 +87,10 @@ extension SPCCPAPartnersViewController: UITableViewDataSource, UITableViewDelega
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let sectionComponent = sections[section] else { return nil }
+
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
-        label.text = "\(sections[section]?.settings.text ?? "Partners")"
-        label.font = UIFont(from: sections[section]?.settings.style.font)
-        label.textColor = UIColor(hexString: sections[section]?.settings.style.font.color)
+        loadLabelText(forComponent: sectionComponent, label: label)
         return label
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAVendorDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/CCPA/SPCCPAVendorDetailsViewController.swift
@@ -85,10 +85,10 @@ extension SPCCPAVendorDetailsViewController: UITableViewDataSource, UITableViewD
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let sectionComponent = sections[section].header else { return nil }
+
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
-        label.text = sections[section].header?.settings.text
-        label.font = UIFont(from: sections[section].header?.settings.style.font)
-        label.textColor = UIColor(hexString: sections[section].header?.settings.style.font.color)
+        loadLabelText(forComponent: sectionComponent, label: label)
         return label
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
@@ -204,19 +204,25 @@ class FocusGuideDebugView: UIView {
         }
         return button
     }
+    
+    @discardableResult
+    func loadLabelText(forComponent component: SPNativeText, labelText text: String? = nil, label: UILabel) -> UILabel {
+        let style = component.settings.style
+        label.text = ""
+        if let text = text {
+            label.attributedText = text.htmlToAttributedString
+        } else {
+            label.attributedText = component.settings.text.htmlToAttributedString
+        }
+        label.textColor = UIColor(hexString: style.font.color)
+        label.font = UIFont(from: style.font)
+        return label
+    }
 
     @discardableResult
     func loadLabelText(forComponentId id: String, labelText text: String? = nil, label: UILabel) -> UILabel {
         if let textDetails = components.first(where: { $0.id == id }) as? SPNativeText {
-            let style = textDetails.settings.style
-            label.text = ""
-            if let text = text {
-                label.attributedText = text.htmlToAttributedString
-            } else {
-                label.attributedText = textDetails.settings.text.htmlToAttributedString
-            }
-            label.textColor = UIColor(hexString: style.font.color)
-            label.font = UIFont(from: style.font)
+            loadLabelText(forComponent: textDetails, labelText: text, label: label)
         }
         return label
     }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRCategoryDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRCategoryDetailsViewController.swift
@@ -97,10 +97,10 @@ extension SPGDPRCategoryDetailsViewController: UITableViewDataSource, UITableVie
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let sectionComponent = sections[section] else { return nil }
+
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
-        label.text = "\(sections[section]?.settings.text ?? "Partners") (\(partners.count))"
-        label.font = UIFont(from: sections[section]?.settings.style.font)
-        label.textColor = UIColor(hexString: sections[section]?.settings.style.font.color)
+        loadLabelText(forComponent: sectionComponent, label: label)
         return label
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRManagePreferenceViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRManagePreferenceViewController.swift
@@ -33,7 +33,7 @@ class SPGDPRManagePreferenceViewController: SPNativeScreenViewController {
     var nativeLongButton: SPNativeLongButton?
 
     var consentsSnapshot = GDPRPMConsentSnaptshot()
-    var displayingLegIntCategories: Bool { categorySlider.selectedSegmentIndex == 1 || emptyConsentSection}
+    var displayingLegIntCategories: Bool { categorySlider.selectedSegmentIndex == 1 || emptyConsentSection }
 
     var categories: [GDPRCategory] = []
     var legIntCategories: [GDPRCategory] { categories.filter { $0.legIntVendors?.isNotEmpty() ?? false } }
@@ -180,10 +180,10 @@ extension SPGDPRManagePreferenceViewController: UITableViewDataSource, UITableVi
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let sectionComponent = sections[section].header else { return nil }
+
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
-        label.text = sections[section].header?.settings.text
-        label.font = UIFont(from: sections[section].header?.settings.style.font)
-        label.textColor = UIColor(hexString: sections[section].header?.settings.style.font.color)
+        loadLabelText(forComponent: sectionComponent, label: label)
         label.isHidden = displayingLegIntCategories ?
             sections[section].contentLegIntCategory.isEmpty : sections[section].contentConsent.isEmpty
         return label

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRPartnersViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRPartnersViewController.swift
@@ -105,10 +105,10 @@ extension SPGDPRPartnersViewController: UITableViewDataSource, UITableViewDelega
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let sectionComponent = sections[section] else { return nil }
+
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
-        label.text = "\(sections[section]?.settings.text.stripOutCss(stripHtml: true) ?? "Partners")"
-        label.font = UIFont(from: sections[section]?.settings.style.font)
-        label.textColor = UIColor(hexString: sections[section]?.settings.style.font.color)
+        loadLabelText(forComponent: sectionComponent, label: label)
         return label
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
@@ -188,10 +188,10 @@ extension SPGDPRVendorDetailsViewController: UITableViewDataSource, UITableViewD
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 50))
+        guard let sectionComponent = sections[section].header else { return nil }
+
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 50))
-        label.text = sections[section].header?.settings.text
-        label.font = UIFont(from: sections[section].header?.settings.style.font)
-        label.textColor = UIColor(hexString: sections[section].header?.settings.style.font.color)
+        loadLabelText(forComponent: sectionComponent, label: label)
         headerView.addSubview(label)
         if sections[section].hasAdditionalContent {
             let retentionlabel = UILabel()


### PR DESCRIPTION
tvOS' views that contained sectioned UITableView, rendered raw html tags on their section headers. 

This PR refactor those cases to use the `loadLabelText` function (which takes into account `htmlToAttributedString` when rendering labels).