### PR TITLE
Fix Visual Effects on tvOS

### DIFF
--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPAppleTVButton.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPAppleTVButton.swift
@@ -7,34 +7,30 @@
 
 import UIKit
 
-extension UIView {
-    var allSubviews: [UIView] {
-        subviews.reduce(into: [self]) { array, subview in
-            array += subview.allSubviews
-        }
+/// A button that enforces clear background colors.
+/// To style the background, use ``UIButton.setBackgroundImage(_ image:for:)``.
+/// This suppresses unwanted background and border effects automatically added when using
+/// the system button type while keeping the default appearance, drop shadow, and scaling effect.
+final class SPAppleTVButton: UIButton {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        clearBackgroundColors()
     }
 }
 
-class SPAppleTVButton: UIButton {
-    var viewBeforeUITitleView: UIView? { allSubviews.dropFirst(allSubviews.count - 2).first }
+extension UIView {
 
-    var onFocusBackgroundColor: UIColor?
-    var onUnfocusBackgroundColor: UIColor? {
-        didSet {
-            viewBeforeUITitleView?.backgroundColor = onUnfocusBackgroundColor
-        }
-    }
+    /// Sets the background colors of all the view's subviews to ``UIColor.clear``.
+    /// - Parameter ignoredColor: Exception that is not overridden.
+    func clearBackgroundColors(ignoring ignoredColor: UIColor? = nil) {
+        for subview in subviews {
+            subview.clearBackgroundColors(ignoring: ignoredColor)
 
-    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-        super.didUpdateFocus(in: context, with: coordinator)
-        if isFocused {
-            backgroundColor = onFocusBackgroundColor
-            coordinator.addCoordinatedAnimations({ [weak self] in
-                self?.viewBeforeUITitleView?.backgroundColor = self?.onFocusBackgroundColor
-            })
-        } else {
-            backgroundColor = onUnfocusBackgroundColor
-            viewBeforeUITitleView?.backgroundColor = onUnfocusBackgroundColor
+            if let ignoredColor, subview.backgroundColor == ignoredColor {
+                continue
+            }
+
+            subview.backgroundColor = .clear
         }
     }
 }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
@@ -194,11 +194,13 @@ class FocusGuideDebugView: UIView {
             button.setTitle(action.settings.text, for: .normal)
             button.setTitleColor(UIColor(hexString: style.onUnfocusTextColor), for: .normal)
             button.setTitleColor(UIColor(hexString: style.onFocusTextColor), for: .focused)
-            button.backgroundColor = UIColor(hexString: style.onUnfocusBackgroundColor)
-            button.onUnfocusBackgroundColor = button.backgroundColor
-            button.onFocusBackgroundColor = UIColor(hexString: style.onFocusBackgroundColor)
             button.titleLabel?.font = UIFont(from: style.font)
-            button.layer.cornerRadius = 12
+            UIColor(hexString: style.onUnfocusBackgroundColor)
+                .map { getImageWithColor(color: $0) }
+                .map { button.setBackgroundImage($0, for: .normal) }
+            UIColor(hexString: style.onFocusBackgroundColor)
+                .map { getImageWithColor(color: $0) }
+                .map { button.setBackgroundImage($0, for: .focused) }
         } else {
             button.isHidden = true
         }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
@@ -339,7 +339,7 @@ class CategoryCellView: UITableViewCell {
     
     private func setupBackground() {
         var backgroundConfiguration = UIBackgroundConfiguration.listPlainCell()
-        backgroundConfiguration.backgroundColor = nil
+        backgroundConfiguration.backgroundColor = .darkGray
         self.backgroundConfiguration = backgroundConfiguration
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
@@ -300,6 +300,7 @@ extension SPGDPRNativePrivacyManagerViewController: UITableViewDataSource {
         let cell = categoryTableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier, for: indexPath)
         cell.textLabel?.text = categories[indexPath.row].name.trimmingCharacters(in: .whitespacesAndNewlines)
         cell.textLabel?.setDefaultTextColorForDarkMode()
+        cell.textLabel?.font = .preferredFont(forTextStyle: .footnote)
         return cell
     }
 }

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRNativePrivacyManagerViewController.swift
@@ -58,7 +58,11 @@ protocol SPNativePrivacyManagerHome {
         setFocusGuidesForButtons()
         categoryTableView.accessibilityIdentifier = "Categories List"
         categoryTableView.allowsSelection = false
-        categoryTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
+        if #available(tvOS 14.0, *) {
+            categoryTableView.register(CategoryCellView.self, forCellReuseIdentifier: cellReuseIdentifier)
+        } else {
+            categoryTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
+        }
         categoryTableView.delegate = self
         categoryTableView.dataSource = self
         disableMenuButton()
@@ -314,6 +318,34 @@ extension SPGDPRNativePrivacyManagerViewController: UITableViewDelegate {
 class FocusableScrollView: UIScrollView {
     override var canBecomeFocused: Bool {
         true
+    }
+}
+
+/// A table view cell with a custom background configuration.
+/// It suppresses unwanted background and border effects that are automatically added by the system
+/// while while keeping the drop shadow and scaling effect when being focused.
+@available(tvOS 14.0, *)
+class CategoryCellView: UITableViewCell {
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupBackground()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupBackground() {
+        var backgroundConfiguration = UIBackgroundConfiguration.listPlainCell()
+        backgroundConfiguration.backgroundColor = nil
+        self.backgroundConfiguration = backgroundConfiguration
+    }
+
+    override func updateConfiguration(using state: UICellConfigurationState) {
+        super.updateConfiguration(using: state)
+        textLabel?.textColor = .white
+        clearBackgroundColors(ignoring: backgroundConfiguration?.backgroundColor)
     }
 }
 


### PR DESCRIPTION
Hello 👋

We now show the GDPR Privacy Manager in our tvOS app 👍🏻 

There are two minor UI imperfections that we want to improve with this MR: 

- Unsharp border of `SPAppleTVButton`
- Readability and background color of GDPR category cells

I hope the commit messages and the following screenshots provide enough information for you.

<img width="800" alt="Before" src="https://github.com/SourcePointUSA/ios-cmp-app/assets/141837531/8040f4b8-5e96-4280-8896-3b2ddf8202aa">

<img width="800" alt="After" src="https://github.com/SourcePointUSA/ios-cmp-app/assets/141837531/04431a31-b0bb-49ff-b749-daac4b97f1af">