### PR TITLE
DIA-3950 add idfaStatus query param to GET choice requests

### DIFF
--- a/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcePointClient.swift
@@ -155,6 +155,7 @@ protocol SourcePointProtocol {
         actionType: SPActionType,
         accountId: Int,
         propertyId: Int,
+        idfaStatus: SPIDFAStatus,
         metadata: ChoiceAllMetaDataParam,
         includeData: IncludeData,
         handler: @escaping ChoiceHandler
@@ -492,6 +493,7 @@ extension SourcePointClient {
         withSiteActions: Bool,
         includeCustomVendorsRes: Bool,
         includeData: IncludeData,
+        idfaStatus: String,
         metadata: ChoiceAllMetaDataParam
     ) -> URL? {
         var baseUrl: URL
@@ -508,6 +510,7 @@ extension SourcePointClient {
             "propertyId": String(propertyId),
             "withSiteActions": String(withSiteActions),
             "includeCustomVendorsRes": String(includeCustomVendorsRes),
+            "idfaStatus": idfaStatus,
             "metadata": metadata.stringified(),
             "includeData": includeData.string
         ])
@@ -517,6 +520,7 @@ extension SourcePointClient {
         actionType: SPActionType,
         accountId: Int,
         propertyId: Int,
+        idfaStatus: SPIDFAStatus,
         metadata: ChoiceAllMetaDataParam,
         includeData: IncludeData,
         handler: @escaping ChoiceHandler
@@ -529,6 +533,7 @@ extension SourcePointClient {
             withSiteActions: false,
             includeCustomVendorsRes: false,
             includeData: includeData,
+            idfaStatus: idfaStatus.description,
             metadata: metadata
         ) else {
             handler(Result.failure(InvalidChoiceAllParamsError()))

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -780,6 +780,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
                 actionType: action.type,
                 accountId: accountId,
                 propertyId: propertyId,
+                idfaStatus: .accepted,
                 metadata: .init(
                     gdpr: campaigns.gdpr != nil ? .init(applies: state.gdpr?.applies ?? false) : nil,
                     ccpa: campaigns.ccpa != nil ? .init(applies: state.ccpa?.applies ?? false) : nil

--- a/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/CustomMatchers.swift
@@ -143,6 +143,26 @@ public func containQueryParam(_ name: String, withValue value: String) -> Predic
     }
 }
 
+/// expect(url).to(containQueryParam(["name": "value"]))
+public func containQueryParams(_ expectedParams: [String: String?]) -> Predicate<URL> {
+    Predicate { actual in
+        guard let actual = try actual.evaluate(),
+              let params = actual.queryParams
+        else {
+            return PredicateResult(bool: false, message: .fail("could not get query params from URL(\((try? actual.evaluate()?.absoluteString) as Any))"))
+        }
+        var pass = true
+        var message = ""
+        expectedParams.forEach { (key, value) in
+            if params[key] != value {
+                pass = false
+                message += "Expected to contain param \(key) equal to \(String(describing: value)), but found \(params[key] ?? "")\n"
+            }
+        }
+        return PredicateResult(bool: pass, message: .fail(message))
+    }
+}
+
 /// expect(spDate).to(equal(year: 123, month: 123, day: 123))
 public func equal(year: Int? = nil, month: Int? = nil, day: Int? = nil) -> Predicate<SPDate> {
     Predicate { actual in

--- a/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
+++ b/Example/ConsentViewController_ExampleTests/Helpers/SourcePointClientMock.swift
@@ -252,6 +252,7 @@ class SourcePointClientMock: SourcePointProtocol {
         actionType: SPActionType,
         accountId: Int,
         propertyId: Int,
+        idfaStatus: SPIDFAStatus,
         metadata: ChoiceAllMetaDataParam,
         includeData: IncludeData,
         handler: @escaping ChoiceHandler

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/SourcePointClientSpec.swift
@@ -165,6 +165,33 @@ class SourcePointClientSpec: QuickSpec {
                 }
             }
 
+            describe("choiceAll") {
+                it("should contain the correct query params") {
+                    let includeData = IncludeData.standard
+                    client.choiceAll(
+                        actionType: .AcceptAll, 
+                        accountId: 123,
+                        propertyId: 321,
+                        idfaStatus: .accepted,
+                        metadata: .init(gdpr: .init(applies: true), ccpa: .init(applies: false)),
+                        includeData: includeData
+                    ) { _ in }
+                    let choiceAllUrl = URL(string: httpClient.getWasCalledWithUrl!)
+                    expect(choiceAllUrl).to(
+                        containQueryParams([
+                            "accountId": "123",
+                            "hasCsp": "true",
+                            "propertyId": "321",
+                            "withSiteActions": "false",
+                            "includeCustomVendorsRes": "false",
+                            "idfaStatus": "accepted",
+                            "metadata": #"{"ccpa":{"applies":false},"gdpr":{"applies":true}}"#
+                        ])
+                    )
+                    expect(choiceAllUrl).to(containQueryParam("includeData"))
+                }
+            }
+
             describe("postAction") {
                 describe("gdpr") {
                     it("calls post on the http client with the right url") {

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SourcePointClient/UnmockedSourcepointClientSpec.swift
@@ -270,6 +270,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                         actionType: .RejectAll,
                         accountId: accountId,
                         propertyId: propertyId,
+                        idfaStatus: .accepted,
                         metadata: .init(
                             gdpr: .init(applies: true),
                             ccpa: .init(applies: true)
@@ -299,6 +300,7 @@ class UnmockedSourcepointClientSpec: QuickSpec {
                         actionType: .AcceptAll,
                         accountId: accountId,
                         propertyId: propertyId,
+                        idfaStatus: .accepted,
                         metadata: .init(
                             gdpr: .init(applies: true),
                             ccpa: .init(applies: true)


### PR DESCRIPTION
This change will allow wrapper (our backend) to take the idfa status into consideration when returning consent data.