### PR TITLE
DIA-2956 expire consent based on vendorListId change

### DIFF
--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -86,6 +86,7 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         static let version = 4
 
         struct GDPRMetaData: Codable, SPSampleable, Equatable {
+            var vendorListId: String?
             var additionsChangeDate = SPDate.now()
             var legalBasisChangeDate: SPDate?
             var sampleRate = Float(1)
@@ -104,13 +105,8 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             var sampleRate = Float(1)
             var wasSampled: Bool?
             var wasSampledAt: Float?
-            var vendorListId: String = ""
+            var vendorListId: String?
             var applicableSections: [Int] = []
-
-            enum CodingKeys: String, CodingKey {
-                case additionsChangeDate, sampleRate, wasSampled, wasSampledAt, applicableSections
-                case vendorListId = "_id"
-            }
         }
 
         struct AttCampaign: Codable {
@@ -515,10 +511,14 @@ class SourcepointClientCoordinator: SPClientCoordinator {
 
     func handleMetaDataResponse(_ response: SPMobileCore.MetaDataResponse) {
         if let gdprMetaData = response.gdpr {
+            if state.gdprMetaData?.vendorListId != nil && state.gdprMetaData?.vendorListId != gdprMetaData.vendorListId {
+                state.gdpr = .empty()
+            }
             state.gdpr?.applies = gdprMetaData.applies
             state.gdprMetaData?.additionsChangeDate = SPDate(string: gdprMetaData.additionsChangeDate)
             state.gdprMetaData?.legalBasisChangeDate = SPDate(string: gdprMetaData.legalBasisChangeDate)
             state.gdprMetaData?.updateSampleFields(gdprMetaData.sampleRate)
+            state.gdprMetaData?.vendorListId = gdprMetaData.vendorListId
             if campaigns.gdpr?.groupPmId != gdprMetaData.childPmId {
                 storage.gdprChildPmId = gdprMetaData.childPmId
             }
@@ -529,6 +529,9 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         }
         if let usnatMetaData = response.usnat {
             let previousApplicableSections = state.usNatMetaData?.applicableSections ?? []
+            if state.usNatMetaData?.vendorListId != nil && state.usNatMetaData?.vendorListId != usnatMetaData.vendorListId {
+                state.usnat = .empty()
+            }
             state.usnat?.applies = usnatMetaData.applies
             state.usNatMetaData?.vendorListId = usnatMetaData.vendorListId
             state.usNatMetaData?.additionsChangeDate = SPDate(string: usnatMetaData.additionsChangeDate)

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -892,5 +892,48 @@ class SPClientCoordinatorSpec: QuickSpec {
                 }
             }
         }
+
+        fdescribe("flushing consent") {
+            it("when gdpr vendorListId changes") {
+                waitUntil { done in
+                    coordinator.loadMessages(forAuthId: nil, pubData: nil) { firstLoadMessages in
+                        let (firstMessages, _) = try! firstLoadMessages.get()
+                        expect(firstMessages.filter { $0.type == .gdpr }).notTo(beEmpty())
+
+                        coordinator.reportAction(SPAction(type: .AcceptAll, campaignType: .gdpr)) { _ in
+                            coordinator.state.gdprMetaData?.vendorListId = "foo"
+                            coordinator.storage.spState = coordinator.state
+
+                            coordinator.loadMessages(forAuthId: nil, pubData: nil) { secondLoadMessages in
+                                let (secondMessages, _) = try! secondLoadMessages.get()
+                                expect(secondMessages.filter { $0.type == .gdpr }).notTo(beEmpty())
+                                done()
+                            }
+                        }
+                    }
+                }
+            }
+
+            it("when usnat vendorListId changes") {
+                waitUntil { done in
+                    coordinator = coordinatorFor(campaigns: SPCampaigns(usnat: SPCampaign()))
+                    coordinator.loadMessages(forAuthId: nil, pubData: nil) { firstLoadMessages in
+                        let (firstMessages, _) = try! firstLoadMessages.get()
+                        expect(firstMessages.filter { $0.type == .usnat }).notTo(beEmpty())
+
+                        coordinator.reportAction(SPAction(type: .AcceptAll, campaignType: .usnat)) { _ in
+                            coordinator.state.usNatMetaData?.vendorListId = "foo"
+                            coordinator.storage.spState = coordinator.state
+
+                            coordinator.loadMessages(forAuthId: nil, pubData: nil) { secondLoadMessages in
+                                let (secondMessages, _) = try! secondLoadMessages.get()
+                                expect(secondMessages.filter { $0.type == .usnat }).notTo(beEmpty())
+                                done()
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -893,7 +893,7 @@ class SPClientCoordinatorSpec: QuickSpec {
             }
         }
 
-        fdescribe("flushing consent") {
+        describe("flushing consent") {
             it("when gdpr vendorListId changes") {
                 waitUntil { done in
                     coordinator.loadMessages(forAuthId: nil, pubData: nil) { firstLoadMessages in


### PR DESCRIPTION
The SDK won't call `/messages` if the user has accepted all. As a result, if the property changes vendor list, the user won't be remessaged. 

This PR fixes this issue by checking the vendorListId present in the response of `/meta-data` and, if different than the current one, purging that legislation's consent from local storage.