### PR TITLE
DIA-3283 expire consent if propertyId or accountId change

### DIFF
--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -115,6 +115,8 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             var partitionUUID: String?
         }
 
+        var accountId, propertyId: Int?
+
         var gdpr: SPGDPRConsent?
         var ccpa: SPCCPAConsent?
         var usnat: SPUSNatConsent?
@@ -336,12 +338,27 @@ class SourcepointClientCoordinator: SPClientCoordinator {
         )
         self.deviceManager = deviceManager
 
-        self.state = Self.setupState(from: storage, campaigns: campaigns)
+        self.state = Self.setupState(
+            from: storage,
+            accountId: accountId,
+            propertyId: propertyId,
+            campaigns: campaigns
+        )
         self.storage.spState = self.state
     }
 
-    static func setupState(from localStorage: SPLocalStorage, campaigns localCampaigns: SPCampaigns) -> State {
+    static func setupState(
+        from localStorage: SPLocalStorage,
+        accountId: Int,
+        propertyId: Int,
+        campaigns localCampaigns: SPCampaigns
+    ) -> State {
         var spState = localStorage.spState ?? .init()
+        if spState.accountId == nil || spState.propertyId == nil {
+            spState.accountId = accountId
+            spState.propertyId = propertyId
+        }
+
         if localCampaigns.gdpr != nil, spState.gdpr == nil {
             spState.gdpr = localStorage.userData.gdpr?.consents ?? .empty()
             spState.gdpr?.applies = localStorage.userData.gdpr?.applies ?? false
@@ -485,7 +502,12 @@ class SourcepointClientCoordinator: SPClientCoordinator {
     }
 
     func loadMessages(forAuthId authId: String?, pubData: SPPublisherData?, _ handler: @escaping MessagesAndConsentsHandler) {
-        state = Self.setupState(from: storage, campaigns: campaigns)
+        state = Self.setupState(
+            from: storage,
+            accountId: accountId,
+            propertyId: propertyId,
+            campaigns: campaigns
+        )
         storage.spState = state
 
         self.authId = authId

--- a/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
+++ b/ConsentViewController/Classes/SourcePointClient/SourcepointClientCoordinator.swift
@@ -359,6 +359,12 @@ class SourcepointClientCoordinator: SPClientCoordinator {
             spState.propertyId = propertyId
         }
 
+        if spState.accountId != accountId || spState.propertyId != propertyId {
+            spState = .init()
+            spState.accountId = accountId
+            spState.propertyId = propertyId
+        }
+
         if localCampaigns.gdpr != nil, spState.gdpr == nil {
             spState.gdpr = localStorage.userData.gdpr?.consents ?? .empty()
             spState.gdpr?.applies = localStorage.userData.gdpr?.applies ?? false

--- a/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/SPClientCoordinator/SPClientCoordinatorSpec.swift
@@ -934,6 +934,26 @@ class SPClientCoordinatorSpec: QuickSpec {
                     }
                 }
             }
+
+            it("when propertyId changes") {
+                let sameStorage = LocalStorageMock()
+                coordinator = coordinatorFor(propertyId: 999, campaigns: gdprCcpaCampaigns, storage: sameStorage)
+                coordinator.state.gdpr?.uuid = "foo"
+                expect(coordinator.state.gdpr?.uuid).to(equal("foo"))
+
+                coordinator = coordinatorFor(propertyId: 123, campaigns: gdprCcpaCampaigns, storage: sameStorage)
+                expect(coordinator.state.gdpr?.uuid).to(beNil())
+            }
+
+            it("when accountId changes") {
+                let sameStorage = LocalStorageMock()
+                coordinator = coordinatorFor(accountId: 999, campaigns: gdprCcpaCampaigns, storage: sameStorage)
+                coordinator.state.gdpr?.uuid = "foo"
+                expect(coordinator.state.gdpr?.uuid).to(equal("foo"))
+
+                coordinator = coordinatorFor(accountId: 123, campaigns: gdprCcpaCampaigns, storage: sameStorage)
+                expect(coordinator.state.gdpr?.uuid).to(beNil())
+            }
         }
     }
 }


### PR DESCRIPTION
This PR addresses an edge case in which the developer might change the property or account id provided to the SDK and the SDK would keep consent data regardless.

Since some endpoints might not be called once the user has accepted all, we need to "manually" check if property id or account id changed and reset state if so.