### PR TITLE
DIA-4868 add messageId to JSReceiver

### DIFF
--- a/ConsentViewController/Assets/javascript/SPJSReceiver.js
+++ b/ConsentViewController/Assets/javascript/SPJSReceiver.js
@@ -111,7 +111,8 @@ var handleMessageOrPMEvent = function (SDK) {
                 payload: data.payload || data.actions || {},
                 consentLanguage: data.consentLanguage,
                 customAction: data.customAction,
-                pmUrl: data.iframe_url
+                pmUrl: data.iframe_url,
+                messageId: data.messageId
             });
         } catch (error) {
             SDK.onError(error);


### PR DESCRIPTION
Fix an issue causing `messageId` to be absent on the call to `POST /choice`, potentially messing up with reporting.