### PR TITLE
[DIA-5446] Add translation for `PolicyQrCodeLabel`

### DIFF
--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
@@ -73,6 +73,7 @@ class SPGDPRVendorDetailsViewController: SPNativeScreenViewController {
             descriptionTextView.isHidden=true
         }
         loadTextView(forComponentId: "VendorDescription", textView: vendorDetailsTextView)
+        loadLabelText(forComponentId: "PrivacyPolicyText", label: PolicyQrCodeLabel)
         loadLabelText(forComponentId: "QrInstructions", label: ToScanLabel)
         descriptionTextView.flashScrollIndicators()
         loadButton(forComponentId: "OnButton", button: onButton)


### PR DESCRIPTION
[DIA-5446](https://sourcepoint.atlassian.net/browse/DIA-5446) QR code translation missing in vendor details view

[DIA-5446]: https://sourcepoint.atlassian.net/browse/DIA-5446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ