### PR TITLE
[DIA-5445] Fix vendor details view on tvOS

### DIFF
--- a/ConsentViewController/Classes/Constants.swift
+++ b/ConsentViewController/Classes/Constants.swift
@@ -36,7 +36,7 @@ struct Constants {
         }
         struct StandartStyle {
             public var backgroundColor: String = "#575757"
-            public var activeBackgroundColor: String = "#ffffff"
+            public var activeBackgroundColor: String = "#707070"
             public var onFocusTextColor: String = "#000000"
             public var onUnfocusTextColor: String = "#ffffff"
             public var onFocusBackgroundColor: String = "#ffffff"

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/Common/SPNativeScreenViewController.swift
@@ -257,6 +257,22 @@ class FocusGuideDebugView: UIView {
     }
 
     @discardableResult
+    func loadSliderButtonFromNativeTexts(firstSegmentForComponentId firstId: String, secondSegmentForComponentId secondId: String, slider: UISegmentedControl) -> UISegmentedControl {
+        if let sliderDetails = components.first(where: { $0.id == firstId }) as? SPNativeText {
+            slider.setTitle(sliderDetails.settings.text, forSegmentAt: 0)
+            let style = sliderDetails.settings.style
+            if #available(tvOS 14.0, *) {
+                backgroundForV14(slider: slider, backgroundHex: style.backgroundColor, activeBackground: style.activeBackgroundColor)
+            }
+            loadSliderSegmentFont(style: style, slider: slider)
+        }
+        if let sliderDetails = components.first(where: { $0.id == secondId }) as? SPNativeText {
+            slider.setTitle(sliderDetails.settings.text, forSegmentAt: 1)
+        }
+        return slider
+    }
+
+    @discardableResult
     func loadSliderButton(forComponentId id: String, slider: UISegmentedControl) -> UISegmentedControl {
         if let sliderDetails = components.first(where: { $0.id == id }) as? SPNativeSlider {
             slider.setTitle(sliderDetails.settings.leftText, forSegmentAt: 0)
@@ -267,7 +283,6 @@ class FocusGuideDebugView: UIView {
             }
             loadSliderSegmentFont(style: style, slider: slider)
         }
-
         return slider
     }
 

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
@@ -122,7 +122,8 @@ class SPGDPRVendorDetailsViewController: SPNativeScreenViewController {
 
     func loadVendorDataText() {
         if vendor?.iabDataCategories?.isEmpty ?? true {
-            removeSliderButtonSegment(slider: categorySlider, removeSegmentNum: 1)
+            categorySlider.isHidden = true
+            addFocusGuide(from: headerView.backButton, to: vendorDetailsTableView, direction: .right)
             return
         }
         var labels = [String()]

--- a/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
+++ b/ConsentViewController/Classes/Views/tvOS/NativePrivacyManager/GDPR/SPGDPRVendorDetailsViewController.swift
@@ -68,7 +68,7 @@ class SPGDPRVendorDetailsViewController: SPNativeScreenViewController {
         setHeader()
         loadTextView(forComponentId: "VendorDescription", textView: descriptionTextView, text: vendor?.description, bounces: false)
         backgroundForV14(slider: categorySlider, backgroundHex: "#d8d9dd", activeBackground: "#777a7e")
-        loadSliderSegmentFont(style: SPNativeStyle(), slider: categorySlider)
+        loadSliderButtonFromNativeTexts(firstSegmentForComponentId: "PurposesHeaderText", secondSegmentForComponentId: "DataCategoriesHeaderText", slider: categorySlider)
         if vendor?.description==nil {
             descriptionTextView.isHidden=true
         }


### PR DESCRIPTION
[DIA-5445](https://sourcepoint.atlassian.net/browse/DIA-5445) Random untranslated text element in vendor details view

- [x] Sets the translated text into slider
- [x] Sets `background` and `activeBackground` colors for the slider
- [x] Disables slider element if no `iabDataCategories ` are present

[DIA-5445]: https://sourcepoint.atlassian.net/browse/DIA-5445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ