### PR TITLE
make fields on `SPPreferencesConsent` public and objc compatible

### DIFF
--- a/ConsentViewController/Classes/Consents/SPPreferencesConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPPreferencesConsent.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @objcMembers public class SPPreferencesConsent: NSObject, Codable, CampaignConsent, NSCopying {
     var applies: Bool = true
-    var dateCreated: SPDate
+    public var dateCreated: SPDate
     var messageId: String?
     public var uuid: String?
     public var status: [PreferencesStatus] = []
@@ -59,20 +59,56 @@ extension SPPreferencesConsent {
 }
 
 extension SPPreferencesConsent {
-    public struct PreferencesStatus: Codable {
-        var categoryId: Int
-        var channels: [PreferencesChannels] = []
-        var changed: Bool?
-        var dateConsented: SPDate?
-        var subType: PreferencesSubType? = PreferencesSubType.Unknown
+    @objcMembers public class PreferencesStatus: NSObject, Codable {
+        public let categoryId: Int
+        public let channels: [PreferencesChannels]
+        public let changed: Bool?
+        public let dateConsented: SPDate?
+        public let subType: PreferencesSubType?
+
+        init(categoryId: Int, channels: [PreferencesChannels] = [], changed: Bool? = nil, dateConsented: SPDate? = nil, subType: PreferencesSubType? = nil) {
+            self.categoryId = categoryId
+            self.channels = channels
+            self.changed = changed
+            self.dateConsented = dateConsented
+            self.subType = subType
+        }
     }
 
-    struct PreferencesChannels: Codable {
-        var channelId: Int
-        var status: Bool
+    @objcMembers public class PreferencesChannels: NSObject, Codable {
+        public let channelId: Int
+        public let status: Bool
+
+        init(channelId: Int, status: Bool) {
+            self.channelId = channelId
+            self.status = status
+        }
     }
 
-    public enum PreferencesSubType: Codable {
+    @objc public enum PreferencesSubType: Int, Codable, CustomStringConvertible {
         case AIPolicy, TermsAndConditions, PrivacyPolicy, LegalPolicy, TermsOfSale, Unknown
+
+        public var description: String {
+            return switch self {
+            case .AIPolicy: "AIPolicy"
+            case .TermsAndConditions: "TermsAndConditions"
+            case .PrivacyPolicy: "PrivacyPolicy"
+            case .LegalPolicy: "LegalPolicy"
+            case .TermsOfSale: "TermsOfSale"
+            case .Unknown: "Unknown"
+            }
+        }
+
+        init(rawString: String) {
+            switch rawString.lowercased() {
+            case "aipolicy": self = .AIPolicy
+            case "termsandconditions": self = .TermsAndConditions
+            case "privacypolicy": self = .PrivacyPolicy
+            case "legalpolicy": self = .LegalPolicy
+            case "termsofsale": self = .TermsOfSale
+            case "unknown": self = .Unknown
+            default: self = .Unknown
+            }
+        }
     }
 }

--- a/ConsentViewController/Classes/Consents/SPPreferencesConsent.swift
+++ b/ConsentViewController/Classes/Consents/SPPreferencesConsent.swift
@@ -8,29 +8,18 @@
 import Foundation
 
 @objcMembers public class SPPreferencesConsent: NSObject, Codable, CampaignConsent, NSCopying {
+
+    public static func empty() -> SPPreferencesConsent {
+        SPPreferencesConsent(dateCreated: .now())
+    }
+
     var applies: Bool = true
     public var dateCreated: SPDate
     var messageId: String?
     public var uuid: String?
-    public var status: [PreferencesStatus] = []
-    public var rejectedStatus: [PreferencesStatus] = []
+    public var status: [Status] = []
+    public var rejectedStatus: [Status] = []
 
-    init(
-        dateCreated: SPDate,
-        messageId: String? = nil,
-        uuid: String? = nil,
-        status: [PreferencesStatus] = [],
-        rejectedStatus: [PreferencesStatus] = []
-    ) {
-        self.uuid = uuid
-        self.status = status
-        self.messageId = messageId
-        self.dateCreated = dateCreated
-        self.rejectedStatus = rejectedStatus
-    }
-}
-
-extension SPPreferencesConsent {
     override open var description: String {
         """
         SPPreferencesConsent(
@@ -43,9 +32,19 @@ extension SPPreferencesConsent {
         """
     }
 
-    public static func empty() -> SPPreferencesConsent { SPPreferencesConsent(
-        dateCreated: .now()
-    )}
+    init(
+        dateCreated: SPDate,
+        messageId: String? = nil,
+        uuid: String? = nil,
+        status: [Status] = [],
+        rejectedStatus: [Status] = []
+    ) {
+        self.uuid = uuid
+        self.status = status
+        self.messageId = messageId
+        self.dateCreated = dateCreated
+        self.rejectedStatus = rejectedStatus
+    }
 
     public func copy(with zone: NSZone? = nil) -> Any {
         SPPreferencesConsent(
@@ -59,14 +58,25 @@ extension SPPreferencesConsent {
 }
 
 extension SPPreferencesConsent {
-    @objcMembers public class PreferencesStatus: NSObject, Codable {
+    @objcMembers public class Status: NSObject, Codable {
         public let categoryId: Int
-        public let channels: [PreferencesChannels]
+        public let channels: [Channel]
         public let changed: Bool?
         public let dateConsented: SPDate?
-        public let subType: PreferencesSubType?
+        public let subType: SubType?
 
-        init(categoryId: Int, channels: [PreferencesChannels] = [], changed: Bool? = nil, dateConsented: SPDate? = nil, subType: PreferencesSubType? = nil) {
+        public override var description: String {
+            """
+            SPPreferencesConsent.Status(
+                - categoryId: \(categoryId)
+                - channels: \(channels)
+                - changed: \(changed as Any)
+                - dateConsented: \(dateConsented as Any)
+                - subType: \(subType as Any)
+            """
+        }
+
+        init(categoryId: Int, channels: [Channel] = [], changed: Bool? = nil, dateConsented: SPDate? = nil, subType: SubType? = nil) {
             self.categoryId = categoryId
             self.channels = channels
             self.changed = changed
@@ -75,27 +85,35 @@ extension SPPreferencesConsent {
         }
     }
 
-    @objcMembers public class PreferencesChannels: NSObject, Codable {
-        public let channelId: Int
+    @objcMembers public class Channel: NSObject, Codable {
+        public let id: Int
         public let status: Bool
 
-        init(channelId: Int, status: Bool) {
-            self.channelId = channelId
+        public override var description: String {
+            """
+            SPPreferencesConsent.Channel(
+                - id: \(id)
+                - status: \(status)
+            """
+        }
+
+        init(id: Int, status: Bool) {
+            self.id = id
             self.status = status
         }
     }
 
-    @objc public enum PreferencesSubType: Int, Codable, CustomStringConvertible {
+    @objc public enum SubType: Int, Codable, CustomStringConvertible {
         case AIPolicy, TermsAndConditions, PrivacyPolicy, LegalPolicy, TermsOfSale, Unknown
 
         public var description: String {
             return switch self {
-            case .AIPolicy: "AIPolicy"
-            case .TermsAndConditions: "TermsAndConditions"
-            case .PrivacyPolicy: "PrivacyPolicy"
-            case .LegalPolicy: "LegalPolicy"
-            case .TermsOfSale: "TermsOfSale"
-            case .Unknown: "Unknown"
+            case .AIPolicy: "SPPreferencesConsent.SubType.AIPolicy"
+            case .TermsAndConditions: "SPPreferencesConsent.SubType.TermsAndConditions"
+            case .PrivacyPolicy: "SPPreferencesConsent.SubType.PrivacyPolicy"
+            case .LegalPolicy: "SPPreferencesConsent.SubType.LegalPolicy"
+            case .TermsOfSale: "SPPreferencesConsent.SubType.TermsOfSale"
+            case .Unknown: "SPPreferencesConsent.SubType.Unknown"
             }
         }
 

--- a/ConsentViewController/Classes/SourcePointClient/Adapters.swift
+++ b/ConsentViewController/Classes/SourcePointClient/Adapters.swift
@@ -272,29 +272,31 @@ extension SPMobileCore.PreferencesConsent.PreferencesSubType? {
 }
 
 extension SPMobileCore.PreferencesConsent.PreferencesStatusPreferencesChannels {
-    func toNative() -> SPPreferencesConsent.PreferencesChannels { return .init(channelId: Int(self.channelId), status: self.status) }
+    func toNative() -> SPPreferencesConsent.PreferencesChannels {
+        .init(channelId: Int(self.channelId), status: self.status)
+    }
 }
 
 extension SPMobileCore.PreferencesConsent.PreferencesStatus {
     func toNative() -> SPPreferencesConsent.PreferencesStatus {
-        return .init(
-            categoryId: Int(self.categoryId),
-            channels: self.channels?.map { $0.toNative() } ?? [],
-            changed: self.changed?.boolValue,
-            dateConsented: SPDate(string: self.dateConsented?.instantToString() ?? SPDate.now().originalDateString),
-            subType: self.subType.toNative()
+        .init(
+            categoryId: Int(categoryId),
+            channels: channels?.map { $0.toNative() } ?? [],
+            changed: changed?.boolValue,
+            dateConsented: SPDate(string: dateConsented?.instantToString() ?? SPDate.now().originalDateString),
+            subType: subType.toNative()
         )
     }
 }
 
 extension SPMobileCore.PreferencesConsent {
     func toNative() -> SPPreferencesConsent {
-        return .init(
-            dateCreated: SPDate(string: self.dateCreated?.instantToString() ?? SPDate.now().originalDateString),
-            messageId: self.messageId != nil ? String(Int(truncating: self.messageId ?? 0)) : nil,
-            uuid: self.uuid,
-            status: self.status?.map { $0.toNative() } ?? [],
-            rejectedStatus: self.rejectedStatus?.map { $0.toNative() } ?? []
+        .init(
+            dateCreated: SPDate(string: dateCreated?.instantToString() ?? SPDate.now().originalDateString),
+            messageId: messageId != nil ? String(Int(truncating: messageId ?? 0)) : nil,
+            uuid: uuid,
+            status: status?.map { $0.toNative() } ?? [],
+            rejectedStatus: rejectedStatus?.map { $0.toNative() } ?? []
         )
     }
 }

--- a/ConsentViewController/Classes/SourcePointClient/Adapters.swift
+++ b/ConsentViewController/Classes/SourcePointClient/Adapters.swift
@@ -258,7 +258,7 @@ extension SPMobileCore.USNatConsent {
 }
 
 extension SPMobileCore.PreferencesConsent.PreferencesSubType? {
-    func toNative() -> SPPreferencesConsent.PreferencesSubType {
+    func toNative() -> SPPreferencesConsent.SubType {
         switch self {
         case .aipolicy: return .AIPolicy
         case .legalpolicy: return .LegalPolicy
@@ -272,13 +272,13 @@ extension SPMobileCore.PreferencesConsent.PreferencesSubType? {
 }
 
 extension SPMobileCore.PreferencesConsent.PreferencesStatusPreferencesChannels {
-    func toNative() -> SPPreferencesConsent.PreferencesChannels {
-        .init(channelId: Int(self.channelId), status: self.status)
+    func toNative() -> SPPreferencesConsent.Channel {
+        .init(id: Int(channelId), status: status)
     }
 }
 
 extension SPMobileCore.PreferencesConsent.PreferencesStatus {
-    func toNative() -> SPPreferencesConsent.PreferencesStatus {
+    func toNative() -> SPPreferencesConsent.Status {
         .init(
             categoryId: Int(categoryId),
             channels: channels?.map { $0.toNative() } ?? [],

--- a/Example/ObjC-ExampleApp/ViewController.m
+++ b/Example/ObjC-ExampleApp/ViewController.m
@@ -38,7 +38,7 @@
                               ccpa: NULL
                               usnat: campaign
                               ios14: campaign
-                              preferences: NULL
+                              preferences: campaign
                               environment: SPCampaignEnvPublic];
 
     consentManager = [[SPConsentManager alloc]
@@ -105,5 +105,6 @@
     NSLog(@"GDPR: %@", userData.objcGDPRConsents);
     NSLog(@"USNAT Applies: %d", userData.objcUSNatApplies);
     NSLog(@"USNAT: %@", userData.objcUSNatConsents);
+    NSLog(@"PREFERENCES: %@", userData.objcPreferencesConsents);
 }
 @end

--- a/Example/ObjC-ExampleAppUITests/ExampleApp.swift
+++ b/Example/ObjC-ExampleAppUITests/ExampleApp.swift
@@ -74,6 +74,10 @@ class ExampleApp: XCUIApplication {
         webViews.first(withLabel: "USNat Message")
     }
 
+    var preferencesMessage: XCUIElement {
+        webViews.first(withLabel: "updated our terms")
+    }
+
     var acceptAllButton: XCUIElement {
         buttons.first(withLabel: "Accept")
     }

--- a/Example/ObjC-ExampleAppUITests/ObjC_ExampleAppUITests.swift
+++ b/Example/ObjC-ExampleAppUITests/ObjC_ExampleAppUITests.swift
@@ -60,6 +60,10 @@ class ObjCExampleAppUITests: QuickSpec {
             self.app.acceptAllButton.tap()
             expect(self.app.usnatMessage).to(disappear())
 
+            expect(self.app.preferencesMessage).toEventually(showUp())
+            self.app.acceptAllButton.tap()
+            expect(self.app.preferencesMessage).to(disappear())
+
             expect(self.app.sdkStatus).toEventually(containText("Finished"))
 
             self.app.relaunch()


### PR DESCRIPTION
* make fields inside `SPPreferencesConsent` (and its subclasses) `public`
* make `SPPreferencesConsent` subclasses `objc` compatible