### PR TITLE
[DIA-6103] Expand extension for native `ConsentStatus.GranularStatus`

### DIFF
--- a/ConsentViewController/Classes/SourcePointClient/Adapters/SharedCoreToNativeAdapters.swift
+++ b/ConsentViewController/Classes/SourcePointClient/Adapters/SharedCoreToNativeAdapters.swift
@@ -135,7 +135,10 @@ extension SPMobileCore.ConsentStatus.ConsentStatusGranularStatus {
             purposeConsent: purposeConsent,
             purposeLegInt: purposeLegInt,
             previousOptInAll: previousOptInAll?.boolValue,
-            defaultConsent: defaultConsent?.boolValue
+            defaultConsent: defaultConsent?.boolValue,
+            sellStatus: sellStatus?.boolValue,
+            shareStatus: shareStatus?.boolValue,
+            sensitiveDataStatus: sensitiveDataStatus?.boolValue
         )
     }
 }


### PR DESCRIPTION
[DIA-6103](https://sourcepoint.atlassian.net/browse/DIA-6103)
The onConsentReady Callback is Returning nil for sellStatus, shareStatus and sensitiveDataStatus

[DIA-6103]: https://sourcepoint.atlassian.net/browse/DIA-6103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ