### PR TITLE
fix: prevent duplicate onSPUIReady delivery from repeated rendering app events

### DIFF
--- a/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
+++ b/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
@@ -178,6 +178,7 @@ import WebKit
     }
 
     var isFirstLayerMessage = true
+    private var hasCalledLoaded = false
 
     lazy var timeoutWorkItem: DispatchWorkItem = {
         DispatchWorkItem { [weak self] in
@@ -288,14 +289,16 @@ import WebKit
 
     func onMessageReady() {
         timeoutWorkItem.cancel()
+        guard !hasCalledLoaded else { return }
+        hasCalledLoaded = true
         webview?.evaluateJavaScript("window.spLegislation=\"\(self.campaignType.rawValue)\"")
         messageUIDelegate?.loaded(self)
     }
 
     func onPmReady() {
         timeoutWorkItem.cancel()
-        if isFirstLayerMessage {
-            messageUIDelegate?.loaded(self)
-        }
+        guard isFirstLayerMessage, !hasCalledLoaded else { return }
+        hasCalledLoaded = true
+        messageUIDelegate?.loaded(self)
     }
 }

--- a/Example/ConsentViewController_ExampleTests/GenericWebMessageViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GenericWebMessageViewControllerSpec.swift
@@ -33,6 +33,28 @@ func renderingAppMock(messageReadyDelayInSeconds: Int) -> String {
     """
 }
 
+// Simulates a rendering app that fires sp.showMessage twice in sequence for the same message,
+// reproducing the crash: "Application tried to present a view controller already being presented."
+class DuplicatingRenderingAppMock: WKWebView {
+    override func load(_ request: URLRequest) -> WKNavigation? {
+        loadHTMLString("""
+            <html>
+            <header>
+            <script>
+                window.addEventListener("load", () => {
+                    setTimeout(() => {
+                        window.postMessage({ name: "sp.showMessage" }, "*");
+                        window.postMessage({ name: "sp.showMessage" }, "*");
+                    }, 500);
+                })
+            </script>
+            </header>
+            <body></body>
+            </html>
+        """, baseURL: URL(string: "https://example.com")!)
+    }
+}
+
 class FaultyRenderingAppMock: WKWebView {
     override func load(_ request: URLRequest) -> WKNavigation? {
         loadHTMLString(
@@ -98,6 +120,13 @@ class GenericWebMessageViewControllerSpec: QuickSpec {
             loadMessage(with: RenderingAppMock.self, delegate: delegate)
             expect(delegate.loadedWasCalled).toEventually(beTrue(), timeout: .seconds(15))
             expect(delegate.onErrorWasCalled).to(beFalse())
+        }
+
+        it("calls loaded exactly once even if the rendering app fires sp.showMessage twice") {
+            loadMessage(with: DuplicatingRenderingAppMock.self, delegate: delegate)
+            // Wait until at least one loaded call arrives, then verify no duplicate was delivered.
+            expect(delegate.loadedCallCount).toEventually(beGreaterThanOrEqualTo(1), timeout: .seconds(15))
+            expect(delegate.loadedCallCount).to(equal(1))
         }
 
         it("calls onError if .loaded() is not called on the delegate before the timeout") {

--- a/Example/ConsentViewController_ExampleTests/MessageUIDelegateMock.swift
+++ b/Example/ConsentViewController_ExampleTests/MessageUIDelegateMock.swift
@@ -11,12 +11,14 @@ import Foundation
 
 class MessageUIDelegateSpy: SPMessageUIDelegate {
     var loadedWasCalled = false
+    var loadedCallCount = 0
     var onErrorWasCalled = false
     var actionCalledWith: SPAction?
     var onLoaded: ((UIViewController?) -> Void)?
 
     func loaded(_ controller: UIViewController) {
         loadedWasCalled = true
+        loadedCallCount += 1
         onLoaded?(controller)
     }
 


### PR DESCRIPTION
## Problem

Crash reported via Firebase Crashlytics:
> Application tried to present modally a view controller `<ConsentViewController.GenericWebMessageViewController: 0x1318ffe00>` that is already being presented by `<HostApp.SomeViewController: 0x131913200>`.

The same `GenericWebMessageViewController` instance was triggering `delegate.onSPUIReady()` more than once. Host apps following the documented pattern (`present(controller, animated: true)` inside `onSPUIReady`) would crash on the second call.

## Root cause

`SPJSReceiver.js` converts a `sp.showMessage` (without `fromPM`) postMessage into an `onMessageReady` native event. If the rendering app fires this event more than once for the same view, the Swift side had no idempotency guard:

```swift
// before — no guard
func onMessageReady() {
    timeoutWorkItem.cancel()
    webview?.evaluateJavaScript(...)
    messageUIDelegate?.loaded(self)  // called N times if event fires N times
}
```

`onPmReady()` had a partial guard via `isFirstLayerMessage`, but that flag guards a state-machine transition (first layer → PM), not duplicate events on the same path.

## Fix

Add a `hasCalledLoaded` boolean flag to `GenericWebMessageViewController` that ensures `loaded()` — and therefore `onSPUIReady()` — is delivered **at most once per controller instance**, regardless of how many JS events arrive.

```swift
private var hasCalledLoaded = false

func onMessageReady() {
    timeoutWorkItem.cancel()
    guard !hasCalledLoaded else { return }
    hasCalledLoaded = true
    webview?.evaluateJavaScript(...)
    messageUIDelegate?.loaded(self)
}

func onPmReady() {
    timeoutWorkItem.cancel()
    guard isFirstLayerMessage, !hasCalledLoaded else { return }
    hasCalledLoaded = true
    messageUIDelegate?.loaded(self)
}
```

The two guards are orthogonal: `isFirstLayerMessage` remains for its original purpose (suppress PM-ready when coming from a first-layer flow); `hasCalledLoaded` adds the missing idempotency invariant across both paths.

## Test

Added `DuplicatingRenderingAppMock` — a `WKWebView` subclass that fires `sp.showMessage` twice in the same tick — and a regression test that asserts `loadedCallCount == 1`.

- Before fix: `loadedCallCount` would be 2 → test fails
- After fix: `loadedCallCount` is 1 → test passes ✅

All 5 tests in `GenericWebMessageViewControllerSpec` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)