### PR TITLE
avoid calling `messageUIDelegate.loaded` repeatedly

### DIFF
--- a/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
+++ b/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
@@ -289,7 +289,9 @@ import WebKit
     func onMessageReady() {
         timeoutWorkItem.cancel()
         webview?.evaluateJavaScript("window.spLegislation=\"\(self.campaignType.rawValue)\"")
-        messageUIDelegate?.loaded(self)
+        if !isBeingPresented, view.window == nil { // make sure current ViewController is not being presented
+            messageUIDelegate?.loaded(self)
+        }
     }
 
     func onPmReady() {

--- a/Example/ConsentViewController_ExampleTests/GenericWebMessageViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GenericWebMessageViewControllerSpec.swift
@@ -66,6 +66,26 @@ class RenderingAppMock: WKWebView {
     }
 }
 
+class DuplicatedShowMessageRenderingAppMock: WKWebView {
+    override func load(_ request: URLRequest) -> WKNavigation? {
+        loadHTMLString("""
+            <html>
+            <header>
+            <script>
+                window.addEventListener("load", () => {
+                    setTimeout(() => {
+                        window.postMessage({ name: "sp.showMessage" }, "*");
+                        window.postMessage({ name: "sp.showMessage" }, "*");
+                    }, 500);
+                })
+            </script>
+            </header>
+            <body></body>
+            </html>
+        """, baseURL: URL(string: "https://example.com")!)
+    }
+}
+
 func loadMessage(
     with RenderingAppClass: WKWebView.Type,
     delegate: SPMessageUIDelegate,
@@ -137,6 +157,13 @@ class GenericWebMessageViewControllerSpec: QuickSpec {
                     expect(delegate.actionCalledWith?.pmURL)
                         .toEventually(containQueryParam("ccpaUUID", withValue: "abc"), timeout: .seconds(15))
                 }
+            }
+        }
+
+        describe("when rendering app dispatches sp.showMessage multiple times") {
+            it("calls onMessageReady only once") {
+                loadMessage(with: DuplicatedShowMessageRenderingAppMock.self, delegate: delegate)
+                expect(delegate.loadedCallCount).toEventually(equal(1), timeout: .seconds(10))
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/MessageUIDelegateMock.swift
+++ b/Example/ConsentViewController_ExampleTests/MessageUIDelegateMock.swift
@@ -9,14 +9,22 @@
 import Foundation
 @testable import ConsentViewController
 
+class MockedGenericWebMessageViewController: GenericWebMessageViewController {
+    var mockIsBeingPresented = false
+    override var isBeingPresented: Bool { mockIsBeingPresented }
+}
+
 class MessageUIDelegateSpy: SPMessageUIDelegate {
+    var loadedCallCount: Int = 0
     var loadedWasCalled = false
     var onErrorWasCalled = false
     var actionCalledWith: SPAction?
     var onLoaded: ((UIViewController?) -> Void)?
 
     func loaded(_ controller: UIViewController) {
+        (controller as? MockedGenericWebMessageViewController)?.mockIsBeingPresented = true
         loadedWasCalled = true
+        loadedCallCount += 1
         onLoaded?(controller)
     }
 


### PR DESCRIPTION
If the rendering app dispatches the event `sp.showMessage` multiple times and the consentUI is being presented, clients' app can crash if their code is not guarding against re-presenting the consent ViewController.

Almost entirely inspired on #649 