### PR TITLE
use flag to control if `MuessageUIDelegate.loaded()` was called

### DIFF
--- a/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
+++ b/ConsentViewController/Classes/Views/iOS/SPWebMessageViewController.swift
@@ -178,6 +178,7 @@ import WebKit
     }
 
     var isFirstLayerMessage = true
+    private var wasLoadedCalled = false
 
     lazy var timeoutWorkItem: DispatchWorkItem = {
         DispatchWorkItem { [weak self] in
@@ -193,6 +194,7 @@ import WebKit
             contentController.removeScriptMessageHandler(forName: Self.MESSAGE_HANDLER_NAME)
             contentController.removeAllUserScripts()
         }
+        wasLoadedCalled = false
         super.viewWillDisappear(animated)
     }
 
@@ -289,14 +291,16 @@ import WebKit
     func onMessageReady() {
         timeoutWorkItem.cancel()
         webview?.evaluateJavaScript("window.spLegislation=\"\(self.campaignType.rawValue)\"")
-        if !isBeingPresented, view.window == nil { // make sure current ViewController is not being presented
+        if wasLoadedCalled == false {
+            wasLoadedCalled = true
             messageUIDelegate?.loaded(self)
         }
     }
 
     func onPmReady() {
         timeoutWorkItem.cancel()
-        if isFirstLayerMessage {
+        if isFirstLayerMessage, wasLoadedCalled == false {
+            wasLoadedCalled = true
             messageUIDelegate?.loaded(self)
         }
     }

--- a/Example/ConsentViewController_ExampleTests/GenericWebMessageViewControllerSpec.swift
+++ b/Example/ConsentViewController_ExampleTests/GenericWebMessageViewControllerSpec.swift
@@ -163,7 +163,7 @@ class GenericWebMessageViewControllerSpec: QuickSpec {
         describe("when rendering app dispatches sp.showMessage multiple times") {
             it("calls onMessageReady only once") {
                 loadMessage(with: DuplicatedShowMessageRenderingAppMock.self, delegate: delegate)
-                expect(delegate.loadedCallCount).toEventually(equal(1), timeout: .seconds(10))
+                expect(delegate.loadedCallCount).toNever(beGreaterThan(1), until: .seconds(5))
             }
         }
     }

--- a/Example/ConsentViewController_ExampleTests/MessageUIDelegateMock.swift
+++ b/Example/ConsentViewController_ExampleTests/MessageUIDelegateMock.swift
@@ -9,11 +9,6 @@
 import Foundation
 @testable import ConsentViewController
 
-class MockedGenericWebMessageViewController: GenericWebMessageViewController {
-    var mockIsBeingPresented = false
-    override var isBeingPresented: Bool { mockIsBeingPresented }
-}
-
 class MessageUIDelegateSpy: SPMessageUIDelegate {
     var loadedCallCount: Int = 0
     var loadedWasCalled = false
@@ -22,7 +17,6 @@ class MessageUIDelegateSpy: SPMessageUIDelegate {
     var onLoaded: ((UIViewController?) -> Void)?
 
     func loaded(_ controller: UIViewController) {
-        (controller as? MockedGenericWebMessageViewController)?.mockIsBeingPresented = true
         loadedWasCalled = true
         loadedCallCount += 1
         onLoaded?(controller)


### PR DESCRIPTION
Guard against calling `MuessageUIDelegate.loaded()` multiple times if the `sp.showMessage` event is dispatched repeatedly. 

Reference #650 #649 